### PR TITLE
Use taccsite_custom dir for static files.

### DIFF
--- a/apcd-cms/src/taccsite_cms/custom_app_settings.py
+++ b/apcd-cms/src/taccsite_cms/custom_app_settings.py
@@ -1,3 +1,3 @@
 CUSTOM_APPS = []
 CUSTOM_MIDDLEWARE = []
-STATICFILES_DIRS = ('apcd-cms',)
+STATICFILES_DIRS = ('taccsite_custom/apcd-cms',)


### PR DESCRIPTION
When the image is built, static files live under `/code/taccsite_custom`.