### PR TITLE
Task/fp 1801 guides […] - getting started via tam

### DIFF
--- a/apcd-cms/Dockerfile
+++ b/apcd-cms/Dockerfile
@@ -1,4 +1,4 @@
-FROM taccwma/core-cms:e6e4a7b
+FROM taccwma/core-cms:e51eb0d
 
 WORKDIR /code
 

--- a/apcd-cms/Dockerfile
+++ b/apcd-cms/Dockerfile
@@ -1,4 +1,4 @@
-FROM taccwma/core-cms:912467c
+FROM taccwma/core-cms:f2203de
 
 WORKDIR /code
 

--- a/apcd-cms/Dockerfile
+++ b/apcd-cms/Dockerfile
@@ -1,4 +1,4 @@
-FROM taccwma/core-cms:e51eb0d
+FROM taccwma/core-cms:912467c
 
 WORKDIR /code
 

--- a/apcd-cms/Dockerfile
+++ b/apcd-cms/Dockerfile
@@ -1,4 +1,4 @@
-FROM taccwma/core-cms:f2203de
+FROM taccwma/core-cms:739a219
 
 WORKDIR /code
 

--- a/apcd-cms/src/taccsite_cms/settings_custom.py
+++ b/apcd-cms/src/taccsite_cms/settings_custom.py
@@ -11,7 +11,7 @@ CMS_TEMPLATES = (
     ('standard.html', 'Standard'),
     ('fullwidth.html', 'Full Width'),
     ('guide.html', 'Guide'),
-    ('guides/getting_started.html', 'Guide: Getting Started'),
+    ('guides/getting_started.tam.html', 'Guide: Getting Started'),
     ('guides/data_transfer.html', 'Guide: Data Transfer'),
     ('guides/data_transfer.globus.html', 'Guide: Globus Data Transfer'),
     ('guides/portal_technology.html', 'Guide: Portal Technology Stack')


### PR DESCRIPTION
## Overview

Updates from Core-CMS: new variable, new template.

## Related

- [FP-1801]
- requires https://github.com/TACC/Core-CMS/pull/549
- mirrors APCD change in https://github.com/TACC/Core-CMS-Resources/pull/164

## Changes

- feat(apcd): FP-1802 use tam getting started guide

## Testing & UI

### Setup

0. Log in to CMS https://txapcd.org/admin.
1. (if not already present) Add a redirect from `/tam/register` to https://accounts-dev.tacc.utexas.edu/apcd/register .[^1]

[^1]: To avoid this requirement per Portal that uses TAM, we could instead add redirects in `urls.py` in CMS [or in Portal](https://github.com/TACC/Core-Portal/pull/688#discussion_r956488404).

### Steps

0. Log in to CMS https://txapcd.org/admin.
1. Open https://txapcd.org/help/getting-started/.
2. Confirm that the content beneath header matches this screenshot:
    ![Getting Started APCD Prod - Link Updated](https://user-images.githubusercontent.com/62723358/187095795-1cd5f0f9-b4ff-48cf-a81f-10a4c9732c36.png)
3. Verify it uses template "Getting Started" *not* "Standard".
4. Verify the template "Portal Technology Stack" is not available.

[FP-1801]: https://jira.tacc.utexas.edu/browse/FP-1801