### PR TITLE
docs: migrate readme to root

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,6 @@ cd custom-project-dir
 make start
 ```
 
-The `Makefile` commands assume shared CMS databases. To use a unique database:
-
-```bash
-cd custom-project-dir
-docker-compose -f docker-compose.dev.unique.yml build
-docker-compose -f docker-compose.dev.unique.yml up
-```
-
 ### Running Custom App on a Custom CMS
 
 - Update `custom_app_settings.py` with relevant content from [TACC/Core-CMS:`/taccsite_cms/custom_app_settings.example.py`](https://github.com/TACC/Core-CMS/blob/1d88c35/taccsite_cms/custom_app_settings.example.py).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,71 @@
+# Core-CMS-Custom
+
+Extensions of the [Core CMS] project
+
+## Related Repositories
+
+- [Camino], a Docker container-based deployment scheme
+- [Core Portal], the base Portal code for TACC WMA CMS Websites
+- [Core CMS Resources], the original solution for extensions of the [Core CMS] project
+- [Core Portal Deployments], private repository that facilitates deployments of [Core Portal] images via [Camino] and Jenkins
+
+## Architecture
+
+- [`./src/apps`](./src/apps/): Contains any additional Django applications
+- [`./src/taccsite_cms`](./src/taccsite_cms/): Contains settings files which specify additional apps, static files and middleware to load on top of Core CMS, along with standard Core CMS settings files
+- [`./src/taccsite_custom`](./src/taccsite_custom/): Contains static assets and templates, organized in the way that Django CMS expects them before imported via `python manage.py collectstatic`.
+
+## Local Development Setup
+
+### Prequisites for Running the CMS
+
+See [Core-CMS](https://github.com/TACC/Core-CMS#prequisites-for-running-the-cms).
+
+### Code Configuration
+
+#### Settings
+
+See [Core-CMS](https://github.com/TACC/Core-CMS#settings).
+
+## Running the CMS
+
+### Running in Development Mode
+
+A `Makefile` has been included for convenience in each CMS project. You may use:
+
+```bash
+cd custom-project-dir
+make start
+```
+
+The `Makefile` commands assume shared CMS databases. To use a unique database:
+
+```bash
+cd custom-project-dir
+docker-compose -f docker-compose.dev.unique.yml build
+docker-compose -f docker-compose.dev.unique.yml up
+```
+
+### Running Custom App on a Custom CMS
+
+- Update `custom_app_settings.py` with relevant content from [TACC/Core-CMS:`/taccsite_cms/custom_app_settings.example.py`](https://github.com/TACC/Core-CMS/blob/1d88c35/taccsite_cms/custom_app_settings.example.py).
+- Update `urls_custom.py` with relevant content from [TACC/Core-CMS:`/taccsite_cms/urls_custom.example.py`](https://github.com/TACC/Core-CMS/blob/1d88c35/taccsite_cms/urls_custom.example.py).
+
+## Porting from [Core CMS Resources]
+
+When porting a downstream CMS project from [Core CMS Resources], the contents of a specific project's custom assets should be copied to [`./custom-project-dir/src/taccsite_custom`](./src/taccsite_custom/). The `settings_custom.py` from the CMS project directory should be moved to [`./custom-project-dir/src/taccsite_cms`](./src/taccsite_cms/) since that is where the file would be placed during a CMS build process from Jenkins.
+
+
+## Automatic Builds
+
+Automatic builds should occur on pushes to each CMS directory e.g. `apcd-cms`.
+
+
+<!-- Link Aliases -->
+
+[Core Portal Deployments]: https://github.com/TACC/Core-Portal-Deployments
+[Camino]: https://github.com/TACC/Camino
+[Core CMS]: https://github.com/TACC/Core-CMS
+[Core Styles]: https://github.com/TACC/tup-ui/tree/main/libs/core-styles
+[Core CMS Resources]: https://github.com/TACC/Core-CMS-Resources
+[Core Portal]: https://github.com/TACC/Core-Portal

--- a/apcd-cms/README.md
+++ b/apcd-cms/README.md
@@ -2,25 +2,6 @@
 
 An extension of the [Core CMS](https://github.com/TACC/Core-CMS) project
 
-## Architecture
+## Basic Set Up
 
-- [`./src/apps`](./src/apps/): Contains any additional Django applications
-- [`./src/taccsite_cms`](./src/taccsite_cms/): Contains settings files which specify additional apps, static files and middleware to load on top of Core CMS, along with standard Core CMS settings files
-- [`./src/taccsite_custom`](./src/taccsite_custom/): Contains static assets and templates, organized in the way that Django CMS expects them before imported via `python manage.py collectstatic`.
-
-## Running in Development Mode
-
-A `Makefile` has been included for convenience. You may use
-
-```bash
-make start
-```
-
-## Porting from Core CMS Resources
-
-When porting a downstream CMS project from [Core CMS Resources](https://github.com/tacc/core-cms-resources), the contents of a specific project's custom assets should be copied to [`./src/taccsite_custom`](./src/taccsite_custom/). The `settings_custom.py` from this directory should be moved to [`./src/taccsite_cms`](./src/taccsite_cms/) since that is where the file would be placed during a CMS build process from Jenkins.
-
-
-## Automatic Builds
-
-Automatic builds should occur on pushes to the `apcd-cms` directory
+See [Core-CMS-Custom](https://github.com/TACC/Core-CMS-Custom).


### PR DESCRIPTION
## Overview

Migrate apcd-cms `Readme.md` to root, because most of its content is applicable to any custom CMS.

## Related

- none

## Changes

- migrate `apcd-cms/README.md` to root
- add minimal `apcd-cms/README.md`

## Testing & UI

1. Read root readme via https://github.com/TACC/Core-CMS-Custom/tree/task/move-readme-to-root.
2. Read apcd-cms readme via https://github.com/TACC/Core-CMS-Custom/tree/task/move-readme-to-root/apcd-cms.
3. Report problems or concerns.