### PR TITLE
task/FP-1818: Custom app for view registrations table

### DIFF
--- a/apcd-cms/src/apps/admin_regis_table/apps.py
+++ b/apcd-cms/src/apps/admin_regis_table/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class CustomExampleConfig(AppConfig):
+    name = 'custom_example'

--- a/apcd-cms/src/apps/admin_regis_table/templates/list_registrations.html
+++ b/apcd-cms/src/apps/admin_regis_table/templates/list_registrations.html
@@ -1,0 +1,67 @@
+{% extends "base.html" %}
+{% block content %}
+<style>
+  .registration-table {
+    margin-left: auto;
+    margin-right: auto;
+    text-align: center;
+    column-width: auto;
+  }
+  .registration-table th, td {
+      padding-left: 5px;
+      padding-right: 5px;
+  }
+  .page-text {
+    text-indent: 30px;
+  }
+  #myModal {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+  }
+</style>
+<h1 class="page-text">List Registrations</h1>
+<p class="page-text">This is a list of all registrations for review. Click on the View button to see the entire submitted form.</p>
+<table class="registration-table">
+    <thead>
+        <tr>
+            {% for k in header %}
+            <th>{{k}}</th>
+            {% endfor %}
+        </tr>
+    </thead>
+    <tbody>
+        {% for r in rows %}
+            <tr>
+                <td>{{r.biz_name}}</td>
+                <td>{{r.type}}</td>
+                <td>{{r.location}}</td>
+                <td>{{r.files_type}}</td>
+                <td>{{r.sub_method}}</td>
+                <td>{{r.reg_status}}</td>
+                <td><a href='' data-toggle="modal" data-target="#myModal">View</a>
+                </td>
+            </tr>
+        {% endfor %}
+    </tbody>
+</table>
+<div id="myModal" class="modal fade" role="dialog">
+  <div class="modal-dialog">
+
+    <!-- Modal content-->
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title">View Registration</h4>
+      </div>
+      <div class="modal-body">
+        <p>{{modal_content}}</p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+      </div>
+    </div>
+
+  </div>
+</div>
+{%endblock %}

--- a/apcd-cms/src/apps/admin_regis_table/urls.py
+++ b/apcd-cms/src/apps/admin_regis_table/urls.py
@@ -1,0 +1,7 @@
+from django.urls import re_path
+from .views import RegistrationsTable
+
+app_name = 'admin_regis_table'
+urlpatterns = [
+    re_path(r'^list-registration-requests/$', RegistrationsTable.as_view(), name='ListRegis'),
+]

--- a/apcd-cms/src/apps/admin_regis_table/views.py
+++ b/apcd-cms/src/apps/admin_regis_table/views.py
@@ -1,0 +1,24 @@
+from curses.ascii import HT
+from django.http import HttpResponse
+from django.conf import settings
+from django.template import loader
+from django.views.generic.base import TemplateView
+
+
+class RegistrationsTable(TemplateView):
+    template_name = 'list_registrations.html'
+
+    def get_context_data(self, **kwargs):
+        ctx = super(RegistrationsTable, self).get_context_data(**kwargs)
+        actions = 'View'
+        ctx['header'] = ['Business Name', 'Type', 'City, State', 'Files to Submit', 'Submission Method', 'Registration Status', 'Actions']
+        ctx['rows'] = [
+            {'biz_name': 'charlie1', 'type': 'Insurance Carrier', 'location': 'Austin, TX', 'files_type': 'Eligibility/Enrollment', 'sub_method': 'HTTPS', 'reg_status': 'Active', 'actions': actions},
+            {'biz_name': 'charlie1', 'type': 'Insurance Carrier', 'location': 'Austin, TX', 'files_type': 'Eligibility/Enrollment', 'sub_method': 'HTTPS', 'reg_status': 'Active', 'actions': actions},
+            {'biz_name': 'charlie1', 'type': 'Insurance Carrier', 'location': 'Austin, TX', 'files_type': 'Eligibility/Enrollment', 'sub_method': 'HTTPS', 'reg_status': 'Active', 'actions': actions},
+            {'biz_name': 'charlie1', 'type': 'Insurance Carrier', 'location': 'Austin, TX', 'files_type': 'Eligibility/Enrollment', 'sub_method': 'HTTPS', 'reg_status': 'Active', 'actions': actions},
+            {'biz_name': 'charlie1', 'type': 'Insurance Carrier', 'location': 'Austin, TX', 'files_type': 'Eligibility/Enrollment', 'sub_method': 'HTTPS', 'reg_status': 'Active', 'actions': actions}
+        ]
+        ctx['modal_content'] = 'This is modal content'
+        return ctx
+


### PR DESCRIPTION
## Overview
Django custom app to display details of a registration on APCD and a function to view the full registration in a modal
…

## Related

<!--
- [FP-1818](https://jira.tacc.utexas.edu/browse/FP-1818)
- requires https://github.com/TACC/Core-CMS/pull/117
-->…

## Changes
- Made a class-based view for the table
- Table and modal can be dynamically filled in with data from database* via context
…

## Testing

1. Go to http://localhost:8000/administration/list-registration-requests/
2. Confirm UI looks like screenshot below
3. Confirm 'View' link open modals in window
4. Confirm clicking outside of modal or 'Close' successfully closes modal

## UI
![image](https://user-images.githubusercontent.com/43251554/194135736-0e6b922c-64fe-4080-afcf-fafb0e364a49.png)

…

<!--
## Notes
* Pulling from database still to-do
…
-->
