### PR TITLE
feat(apcd-cms): tweak "Types of Files" help text

### DIFF
--- a/apcd-cms/src/apps/submission_form/templates/submission_form/submission_form.html
+++ b/apcd-cms/src/apps/submission_form/templates/submission_form/submission_form.html
@@ -414,7 +414,7 @@
                 Types of Files<!-- no space --><span class="asterisk">*</span>
               </label>
               <div class="help-text">
-                At least one of the following types must be selected.
+                Eligibility/Enrollment files are mandatory. Select additional file types to be submitted.
               </div>
             </div>
 


### PR DESCRIPTION
## Overview / Changes

Tweak help text for "Types of Files".\
<sub>Duplicates, but isolates, 3082d09 from #16.</sub>

## Related

- [a design/dev agreement](https://tacc-team.slack.com/archives/C03B7899YD8/p1666110193691849?thread_ts=1666104477.412489&cid=C03B7899YD8)

## Testing

0. Change code in [`apcd-cms/src/apps/submission_form/views.py#L13-L21`](https://github.com/TACC/Core-CMS-Custom/blob/75ec406/apcd-cms/src/apps/submission_form/views.py#L13-L21) to set template and return response first.

    <details>

    From:
    ```python
        def get(self, request):
            template = loader.get_template('submission_form/submission_form.html')
            return HttpResponse(template.render({}, request))
            user = authenticate(request)
            if user:
                template = loader.get_template('submission_form/submission_form.html')
                return HttpResponse(template.render({}, request))
            else:
                return HttpResponseRedirect('/')
    ```
    To:
    ```python
        def get(self, request):
            template = loader.get_template('submission_form/submission_form.html')
            return HttpResponse(template.render({}, request))
            user = authenticate(request)
            if user:
                template = loader.get_template('submission_form/submission_form.html')
                return HttpResponse(template.render({}, request))
            else:
                return HttpResponseRedirect('/')
    ```

    </details>
1. Log in to CMS.
2. Load form at http://localhost:8000/register/request-to-submit/.
3. Confirm "Types of Files" field help text is:
    > Eligibility/Enrollment files are mandatory. Select additional file types to be submitted.

## UI

![tweak form text](https://user-images.githubusercontent.com/62723358/196524069-8c84620e-acdf-4bf4-a1ac-cf74715aef9d.png)