### PR TITLE
fix(apcd-cms): fp-1818 responsive table UI

### DIFF
--- a/apcd-cms/src/apps/admin_regis_table/static/admin_regis_table/registrations_table.css
+++ b/apcd-cms/src/apps/admin_regis_table/static/admin_regis_table/registrations_table.css
@@ -1,7 +1,8 @@
 .registration-table {
-    margin-right: auto;
-    text-align: center;
-    column-width: auto;
+    --cell-padding: 5px;
+
+    width: 100%;
+    table-layout: fixed;
 }
 .registration-table th, td {
     text-align: left;
@@ -9,8 +10,8 @@
     letter-spacing: 0px;
     color: #484848;
     opacity: 1;
-    padding-top: 5px;
-    padding-bottom: 5px;
+    padding-top: var(--cell-padding);
+    padding-bottom: var(--cell-padding);
     padding-left: 10px;
     padding-right: 40px;
     border-collapse: collapse;
@@ -18,14 +19,14 @@
     border-left: 1px solid #fff;
     border-top: 1px solid #fff;
     border-bottom: 1px solid rgba(0,0,0,1);
-white-space: nowrap;
+}
+.registration-table tr:nth-child(even) {
+    background-color: rgba(198, 198, 198, 0.1);
 }
 .registration-table td {
     border-bottom: 1px solid rgba(0,0,0,0.1);
 }
 .registration-table tr:nth-child(even) td {
-    background: 0% 0% no-repeat padding-box;
-    background-color: rgba(198, 198, 198, 0.1);
     border-right: rgba(198, 198, 198, 0.1);
     border-left: rgba(198, 198, 198, 0.1);
 }
@@ -40,6 +41,72 @@ white-space: nowrap;
     padding: 0;
     margin: 0;
 }
-.no-bullets li:not(:first-child) {
-    margin: 5px 0;
+.no-bullets li {
+    line-height: 1.9em; /* overwrite Core CMS site.css */
+}
+
+/* SEE: https://css-tricks.com/responsive-data-tables/ */
+@media (max-width: 767px) {
+    /* To remove border (that should probably be in Core anyway) */
+    .registration-table {
+        --row-padding: calc( var(--cell-padding) * 2 );
+
+        border: none; /* overwrite Core CMS site.css */
+    }
+
+    /* To escape table layout */
+    .registration-table,
+    .registration-table :is(thead, tbody, th, td, tr) { 
+        display: block; 
+    }
+
+    /* To hide table headers (but not `display: none;`, for a11y) */
+    .registration-table thead tr { 
+        position: absolute;
+        top: -9999px;
+        left: -9999px;
+    }
+
+    /* To restore row borders */
+    .registration-table tr:not(:last-of-type) {
+        border-bottom: var(--global-border-width--normal) solid var(--global-color-primary--light);
+    }
+
+    /* To make each cell behave like a "row" */
+    .registration-table td { border-top: none; }
+    .registration-table td:last-of-type { border-bottom: none; }
+    .registration-table td {
+        position: relative;
+        padding-left: 50%;
+    }
+
+    /* To add space between rows (for legibility) */
+    .registration-table tr {
+        padding-bottom: var(--row-padding);
+    }
+    .registration-table tr:not(:first-of-type) {
+        padding-top: var(--row-padding);
+    }
+
+    /* To make cells look like left-aligned labels */
+    .registration-table td:before {
+        position: absolute;
+        width: 45%;
+        padding-right: 10px;
+        white-space: nowrap;
+        font-weight: bold;
+
+        /* To mimic cell padding */
+        top: var(--cell-padding);
+        left: var(--cell-padding);
+    }
+    /* To label the cells */
+    /* RFE: Add `data-label` to each cell so we can use `attr(data-label)` */
+    .registration-table td:nth-of-type(1):before { content: "Business Name"; }
+    .registration-table td:nth-of-type(2):before { content: "Type"; }
+    .registration-table td:nth-of-type(3):before { content: "Location"; }
+    .registration-table td:nth-of-type(4):before { content: "Submission"; }
+    .registration-table td:nth-of-type(5):before { content: "Registration Status"; }
+    .registration-table td:nth-of-type(6):before { content: "Files to Submit"; }
+    .registration-table td:nth-of-type(7):before { content: "Actions"; }
 }

--- a/apcd-cms/src/apps/admin_regis_table/static/admin_regis_table/registrations_table.css
+++ b/apcd-cms/src/apps/admin_regis_table/static/admin_regis_table/registrations_table.css
@@ -2,7 +2,6 @@
     --cell-padding: 5px;
 
     width: 100%;
-    table-layout: fixed;
 }
 .registration-table th, td {
     text-align: left;

--- a/apcd-cms/src/apps/admin_regis_table/static/admin_regis_table/registrations_table.css
+++ b/apcd-cms/src/apps/admin_regis_table/static/admin_regis_table/registrations_table.css
@@ -2,6 +2,7 @@
     --cell-padding: 5px;
 
     width: 100%;
+    table-layout: fixed; /* allows table to shrink (reason unknown) */
 }
 .registration-table th, td {
     text-align: left;

--- a/apcd-cms/src/apps/admin_regis_table/templates/list_registrations.html
+++ b/apcd-cms/src/apps/admin_regis_table/templates/list_registrations.html
@@ -43,7 +43,11 @@
                     {% endfor %}
                   </ul>
                 </td>
-                <td><!--<a href='' data-toggle="modal" data-target="#myModal">View</a>-->
+                <td>
+                  {# FAQ: So cell "has layout" on narrow screen layout #}
+                  &nbsp;
+                  {# FAQ: Action functionality not available yet #}
+                  {# <a href='' data-toggle="modal" data-target="#myModal">View</a> #}
                 </td>
             </tr>
         {% endfor %}


### PR DESCRIPTION
## Overview

Responsive tables for Registration list.

## Related

- [FP-1818](https://jira.tacc.utexas.edu/browse/FP-1818)
- builds upon https://github.com/TACC/Core-CMS-Custom/pull/29

## Changes

- allow table to stretch and shrink
- use variable for cell padding
- move row background from cells to rows
- use line-height (not padding) for space between list items
- add responsive table styles
- add empty space and comment for missing action/s

## Testing

1. Follow "Testing" of https://github.com/TACC/Core-CMS-Custom/pull/29.
2. View table at different screen widths.
3. Verify table content is legible, accessible, aesthetic, et cetera.

[Designer review is in Slack.](https://tacc-team.slack.com/archives/CTBCB8ZD0/p1666721928626939)

## UI

| < 768px | > 768px | 1680px |
| - | - | - |
| ![768px](https://user-images.githubusercontent.com/62723358/197849210-7773a413-c774-4696-8b2c-b1e347c64e24.jpeg) | ![768px](https://user-images.githubusercontent.com/62723358/197849211-f524c59b-7238-4757-8870-b784912c3c41.jpeg) | ![1680px](https://user-images.githubusercontent.com/62723358/197849212-253f0467-5194-4968-a4a9-560e5afe5791.jpeg) |

## Notes

These styles will be migrated and polished into Core-Styles via [FP-1878](https://jira.tacc.utexas.edu/browse/FP-1878).