### PR TITLE
Task/FP-1907 - Template path error

### DIFF
--- a/apcd-cms/Dockerfile
+++ b/apcd-cms/Dockerfile
@@ -1,4 +1,4 @@
-FROM taccwma/core-cms:abd48a2
+FROM taccwma/core-cms:977ecc0
 
 WORKDIR /code
 

--- a/apcd-cms/src/apps/registrations/views.py
+++ b/apcd-cms/src/apps/registrations/views.py
@@ -63,7 +63,8 @@ class SubmissionFormView(View):
             description += "Error(s):\n"
             for err_msg in errors:
                 description += "{}\n".format(err_msg)
-            response = HttpResponseRedirect('/error/page/goes/here')
+            template = loader.get_template('submission_form/submission_error.html')
+            response = HttpResponse(template.render({}, request))
         else:
             template = loader.get_template('submission_form/submission_success.html')
             response = HttpResponse(template.render({}, request))


### PR DESCRIPTION
## Overview

Fixed error template returned for submission errors.

## Related

- [FP-1907](https://jira.tacc.utexas.edu/browse/FP-1907)

## Changes

Replace error placeholder text with actual error template to be rendered upon receiving an error message.

## Testing

(locally)
1. If you do not have the RT secrets you'll need to grab them from stache and put them in you local secrets file. Otherwise, you will need to go to `apcd-cms/src/apps/registrations/views.py` comment out the lines in the `post` method related to the RT `tracker`
2. Submit a completed form with jibberish (It will fail and you should see the failure screen)
