### PR TITLE
fix(apcd-cms): dollar sign position & core styles v0.10.0

### DIFF
--- a/apcd-cms/Dockerfile
+++ b/apcd-cms/Dockerfile
@@ -1,4 +1,4 @@
-FROM taccwma/core-cms:ac03b3a
+FROM taccwma/core-cms:64a72e2
 
 WORKDIR /code
 

--- a/apcd-cms/src/apps/registrations/templates/submission_form/submission_form.html
+++ b/apcd-cms/src/apps/registrations/templates/submission_form/submission_form.html
@@ -508,7 +508,7 @@
               />
             </div>
 
-            <div class="field-wrapper numberinput required s-affixed-input-wrapper">
+            <div class="field-wrapper numberinput required s-affixed-input-wrapper s-affixed-input-wrapper--prefix">
               <div class="field-errors" style="display: none"></div>
 
               <label for="total_claims_value">
@@ -815,7 +815,7 @@
           <div id="help-text-claims_encounters_volume_${entities}" class="help-text">
           </div>
         </div>
-        <div class="field-wrapper numberinput required s-affixed-input-wrapper">
+        <div class="field-wrapper numberinput required s-affixed-input-wrapper s-affixed-input-wrapper--prefix">
           <div class="field-errors" style="display: none"></div>
           <label for="total_claims_value_${entities}">
             Total Claims Value (USD<sup>7</sup>)<span class="asterisk">*</span>


### PR DESCRIPTION
## Overview

Fix dollar sign position (via https://github.com/TACC/Core-CMS/pull/567).

Fix missing CSS (migrated to Core in #42).

## Related

- [FP-1823](https://jira.tacc.utexas.edu/browse/FP-1828)
- requires https://github.com/TACC/Core-Styles/pull/62
    available via https://github.com/TACC/Core-CMS/pull/567

## Changes

- add class for firefox
- load new cms image

## Testing

0. Use Firefox browser.
1. Open http://localhost:8000/register/request-to-submit/.
2. Verify "Total Claims Value" dollar sign is within input (not outside it).
3. Verify fields have a max-width again.
4. (optional) Verify other FP-1828 styles have been restored.

<sub>Build: https://jenkins01.tacc.utexas.edu/job/Core_CMS_Build/853/</sub>
<sub>Deploy: https://jenkins01.tacc.utexas.edu/job/Core_Portal_Deploy/2159</sub>

## UI

| Before | After |
| - | - |
| <img width="1104" alt="Before" src="https://user-images.githubusercontent.com/62723358/201527810-591c8ae2-515b-46dd-995a-2ed3dfcc67cb.png"> | <img width="1104" alt="After" src="https://user-images.githubusercontent.com/62723358/201530788-9f89b4aa-462b-42cc-b0d9-12df91de323a.png"> |