### PR TITLE
hotfix: Create submitter modal - swapped payor and submitter codes

### DIFF
--- a/apcd-cms/src/apps/admin_regis_table/templates/create_submitter_modal.html
+++ b/apcd-cms/src/apps/admin_regis_table/templates/create_submitter_modal.html
@@ -48,7 +48,7 @@
 
           <div class="c-form__field">
             <label>Payor Code</label>
-            <input type="text" name="payor_code" autofocus required inputmode="numeric">
+            <input type="number" name="payor_code" autofocus required inputmode="numeric">
           </div>
           <div class="c-form__field">
             <label>Submitter Code</label>

--- a/apcd-cms/src/apps/admin_regis_table/templates/create_submitter_modal.html
+++ b/apcd-cms/src/apps/admin_regis_table/templates/create_submitter_modal.html
@@ -48,15 +48,15 @@
 
           <div class="c-form__field">
             <label>Payor Code</label>
-            <input type="text" name="payor_code" autofocus>
+            <input type="text" name="payor_code" autofocus required inputmode="numeric">
           </div>
           <div class="c-form__field">
             <label>Submitter Code</label>
-            <input type="number" name="submit_code" maxlength="8">
+            <input type="text" name="submit_code" maxlength="8" required>
           </div>
           <div class="c-form__field">
             <label>Encryption Key</label>
-            <input type="text" name="encryption_key" maxlength="30">
+            <input type="text" name="encryption_key" maxlength="30" required>
           </div>
 
           <div class="c-form__buttons">

--- a/apcd-cms/src/apps/admin_regis_table/templates/list_registrations.html
+++ b/apcd-cms/src/apps/admin_regis_table/templates/list_registrations.html
@@ -21,7 +21,7 @@
         <option class="dropdown-text">All</option>
         <option class="dropdown-text">Received</option>
         <option class="dropdown-text">Processing</option>
-        <option class="dropdown-text">Completed</option>
+        <option class="dropdown-text">Complete</option>
       </select>
     </div>
   </div>

--- a/apcd-cms/src/apps/utils/apcd_database.py
+++ b/apcd-cms/src/apps/utils/apcd_database.py
@@ -384,8 +384,8 @@ def create_submitter(form, reg_data):
             reg_data[8],
             reg_data[10],
             reg_data[9],
-            _set_int(form['submit_code']),
-            form['payor_code'],
+            form['submit_code'],
+            _set_int(form['payor_code']),
             form['encryption_key'],
             datetime.datetime.now()
         )

--- a/apcd-cms/src/apps/utils/apcd_database.py
+++ b/apcd-cms/src/apps/utils/apcd_database.py
@@ -384,9 +384,9 @@ def create_submitter(form, reg_data):
             reg_data[8],
             reg_data[10],
             reg_data[9],
-            form['submit-code'],
-            form['payor-code'],
-            form['encryption-key'],
+            _set_int(form['submit_code']),
+            form['payor_code'],
+            form['encryption_key'],
             datetime.datetime.now()
         )
         cur.execute(operation, values)


### PR DESCRIPTION
## Overview

…

## Related


- [FP-1819](https://jira.tacc.utexas.edu/browse/FP-1819)
<!--
- requires https://github.com/TACC/Core-CMS/pull/117
-->…

## Changes
Changed value for `payor_code` to now process as an int
…

## Testing

1. **Testing database reading/writing locally will not work, so expect to get an error when trying to submit create submitter form**
2. Replace lines 13-15 in `apps/admin_regis_table/views.py` with the following:
   <details><summary>Snippet</summary>
     
          import datetime
          registrations_content = [
            (
                1,                                  #registration_id
                datetime.date(2022, 8, 3),          #posted_date
                12023,                              #applicable_period_start
                122023,                             #applicable_period_end
                True,                               #file_me
                False,                               #file_pv
                True,                               #file_mc
                True,                               #file_pc
                False,                              #file_dc
                True,                               #submitting_for_self
                'SFTP',                             #submission_method
                'received',                           #registration_status
                'insurance carrier',                #org_type
                'Golden Rule Insurance Company',    #business_name
                '7440 Woodland Drive',              #mail_address
                'Indianpolis',                      #city
                'IN',                               #state
                '46278     '                        #zip
            ),
            (
                2,                                  #registration_id
                datetime.date(2022, 8, 3),          #posted_date
                12023,                              #applicable_period_start
                122023,                             #applicable_period_end
                True,                               #file_me
                True,                               #file_pv
                True,                               #file_mc
                True,                               #file_pc
                False,                              #file_dc
                False,                               #submitting_for_self
                'SFTP',                             #submission_method
                'processing',                           #registration_status
                'insurance carrier',                #org_type
                'Clay Tenant Insurance Company',    #business_name
                '440 Wood and Drive',              #mail_address
                'Indianapolis',                      #city
                'NY',                               #state
                '24444     '                        #zip
            ),
            (
                3,                                  #registration_id
                datetime.date(2022, 8, 3),          #posted_date
                12023,                              #applicable_period_start
                122023,                             #applicable_period_end
                True,                               #file_me
                True,                               #file_pv
                True,                               #file_mc
                True,                               #file_pc
                False,                              #file_dc
                True,                               #submitting_for_self
                'SFTP',                             #submission_method
                'complete',                        #registration_status
                'insurance carrier',                #org_type
                'Magenta Condition Insurance Company',    #business_name
                '742 Oddland Drive',              #mail_address
                'Indipolis',                      #city
                'MI',                               #state
                '62784     '                        #zip
            )
        ]
        registrations_entities = [
            (
                5, 1, 5, 46, 11111, 0, 5, 'Garretts Test Business 2', '11-0001111'
            ),
            (
                5, 2, 50000, 47, 1010, 1101, 1, 'A Second Test Entity', '00-0000000'
            )
        ]
        registrations_contacts = [
            (
                52,
                1,
                False,
                'Test Role',
                'Garrett Test Tester',
                '2222222222',
                'notarealemail@emailplace.email'
            ),
            (
                53,
                1,
                False,
                'A 2nd Test Role',
                'Test Garrett 2 Test',
                '145555555555',
                'testemail@testemail.emailtest'
            ),
            (
                54,
                2,
                True,
                'A 3rd and final test role',
                'Test 3rd Role Name Garrett',
                '0000000000',
                None
            )
          ]
        
    </details>
3. Open http://localhost:8000/administration/list-registration-requests/
4. Open 'Create Submitter' link on any row
5. Confirm the form cannot be submitted without all input fields being filled

## UI

…

<!--
## Notes

…
-->
