### PR TITLE
task/FP-1963: Move actions to dropdown

### DIFF
--- a/apcd-cms/src/apps/admin_regis_table/templates/create_submitter_modal.html
+++ b/apcd-cms/src/apps/admin_regis_table/templates/create_submitter_modal.html
@@ -48,15 +48,15 @@
 
           <div class="c-form__field">
             <label>Payor Code</label>
-            <input type="text" name="payor_code" autofocus>
+            <input type="text" name="payor_code" autofocus required inputmode="numeric">
           </div>
           <div class="c-form__field">
             <label>Submitter Code</label>
-            <input type="number" name="submit_code" maxlength="8">
+            <input type="text" name="submit_code" maxlength="8" required>
           </div>
           <div class="c-form__field">
             <label>Encryption Key</label>
-            <input type="text" name="encryption_key" maxlength="30">
+            <input type="text" name="encryption_key" maxlength="30" required>
           </div>
 
           <div class="c-form__buttons">

--- a/apcd-cms/src/apps/admin_regis_table/templates/create_submitter_modal.html
+++ b/apcd-cms/src/apps/admin_regis_table/templates/create_submitter_modal.html
@@ -1,4 +1,4 @@
-<div id="viewSubmitterModal_{{r.reg_id}}" class="modal fade" role="dialog">
+<div id="createSubmitterModal_{{r.reg_id}}" class="modal fade" role="dialog">
   <div class="modal-dialog modal-lg">
     <div class="modal-content">
       <div class="modal-header">

--- a/apcd-cms/src/apps/admin_regis_table/templates/list_registrations.html
+++ b/apcd-cms/src/apps/admin_regis_table/templates/list_registrations.html
@@ -52,9 +52,12 @@
                   </td>
                   <td>
                     {% include "view_registration_modal.html" %}
-                    <a href='' data-toggle="modal" data-target="#viewRegistrationModal_{{r.reg_id}}" data-backdrop="static">View Record</a>
                     {% include "create_submitter_modal.html" %}<br />
-                    <a href='' data-toggle="modal" data-target="#viewSubmitterModal_{{r.reg_id}}" data-backdrop="static"> Create New Submitter</a>
+                    <select id='actionsDropdown' class='status-filter' onchange="openAction('{{r.reg_id}}')">
+                      <option value="">Select Action</option>
+                      <option value="viewRegistration">View Record</option>
+                      <option value="createSubmitter">Create Submitter</option>
+                    </select>
                   </td>
               </tr>
           {% endfor %}
@@ -76,6 +79,14 @@
         row.style.display = "";
       }
     })
+  }
+  function openAction(reg_id) {
+    var dropdown, selectedOption, modal_id;
+    dropdown = document.getElementById('actionsDropdown');
+    selectedOption = dropdown.options[dropdown.selectedIndex].value;
+    modal_id = `${selectedOption}Modal_${reg_id}`;
+    $(`#${modal_id}`).modal({backdrop: "static"});
+    dropdown.selectedIndex = 0;
   }
 </script>
 

--- a/apcd-cms/src/apps/admin_regis_table/templates/list_registrations.html
+++ b/apcd-cms/src/apps/admin_regis_table/templates/list_registrations.html
@@ -21,7 +21,7 @@
         <option class="dropdown-text">All</option>
         <option class="dropdown-text">Received</option>
         <option class="dropdown-text">Processing</option>
-        <option class="dropdown-text">Completed</option>
+        <option class="dropdown-text">Complete</option>
       </select>
     </div>
   </div>

--- a/apcd-cms/src/apps/admin_regis_table/templates/list_registrations.html
+++ b/apcd-cms/src/apps/admin_regis_table/templates/list_registrations.html
@@ -86,7 +86,7 @@
     /* grabs dropdown option number selected by user via selectedIndex, 
       then grabs actual value associated with that option via 
       options[index].value */
-    selectedOption = actionsDropdown.options[dropdown.selectedIndex].value;
+    selectedOption = actionsDropdown.options[actionsDropdown.selectedIndex].value;
     modal_id = `${selectedOption}Modal_${reg_id}`;
     $(`#${modal_id}`).modal({backdrop: "static"}); /* modal appears manually */
     actionsDropdown.selectedIndex = 0; /* resets dropdown to display 'Select Action' again */

--- a/apcd-cms/src/apps/admin_regis_table/templates/list_registrations.html
+++ b/apcd-cms/src/apps/admin_regis_table/templates/list_registrations.html
@@ -53,7 +53,7 @@
                   <td>
                     {% include "view_registration_modal.html" %}
                     {% include "create_submitter_modal.html" %}<br />
-                    <select id='actionsDropdown' class='status-filter' onchange="openAction('{{r.reg_id}}')">
+                    <select id='actionsDropdown_{{r.reg_id}}' class='status-filter' onchange="openAction('{{r.reg_id}}')">
                       <option value="">Select Action</option>
                       <option value="viewRegistration">View Record</option>
                       <option value="createSubmitter">Create Submitter</option>
@@ -81,12 +81,15 @@
     })
   }
   function openAction(reg_id) {
-    var dropdown, selectedOption, modal_id;
-    dropdown = document.getElementById('actionsDropdown');
-    selectedOption = dropdown.options[dropdown.selectedIndex].value;
+    var actionsDropdown, selectedOption, modal_id;
+    actionsDropdown = document.getElementById(`actionsDropdown_${reg_id}`);
+    /* grabs dropdown option number selected by user via selectedIndex, 
+      then grabs actual value associated with that option via 
+      options[index].value */
+    selectedOption = actionsDropdown.options[dropdown.selectedIndex].value;
     modal_id = `${selectedOption}Modal_${reg_id}`;
-    $(`#${modal_id}`).modal({backdrop: "static"});
-    dropdown.selectedIndex = 0;
+    $(`#${modal_id}`).modal({backdrop: "static"}); /* modal appears manually */
+    actionsDropdown.selectedIndex = 0; /* resets dropdown to display 'Select Action' again */
   }
 </script>
 

--- a/apcd-cms/src/apps/admin_regis_table/views.py
+++ b/apcd-cms/src/apps/admin_regis_table/views.py
@@ -44,7 +44,6 @@ class RegistrationsTable(TemplateView):
 
     def get_context_data(self, registrations_content=registrations_content, registrations_entities=registrations_entities, registrations_contacts=registrations_contacts, *args, **kwargs):
         context = super(RegistrationsTable, self).get_context_data(*args, **kwargs)
-        actions = 'View'
 
         def _set_registration(reg, reg_ents, reg_conts):
             return {
@@ -65,7 +64,6 @@ class RegistrationsTable(TemplateView):
                     'sub_method': reg[10],
                     'reg_status': reg[11].title(),
                     'reg_id': reg[0],
-                    'actions': actions,
                     'view_modal_content': _set_modal_content(reg, reg_ents, reg_conts)
                 }
         def _set_entities(reg_ent):

--- a/apcd-cms/src/apps/utils/apcd_database.py
+++ b/apcd-cms/src/apps/utils/apcd_database.py
@@ -384,9 +384,9 @@ def create_submitter(form, reg_data):
             reg_data[8],
             reg_data[10],
             reg_data[9],
-            form['submit-code'],
-            form['payor-code'],
-            form['encryption-key'],
+            _set_int(form['submit_code']),
+            form['payor_code'],
+            form['encryption_key'],
             datetime.datetime.now()
         )
         cur.execute(operation, values)


### PR DESCRIPTION
## Overview
Converted links to action modals in 'Actions' column on admin registrations listing to a dropdown
…

## Related


- [FP-1963](https://jira.tacc.utexas.edu/browse/FP-1963)
<!--
- requires https://github.com/TACC/Core-CMS/pull/117
-->…

## Changes
- Removed links from actions column
- Added `select` element containing options corresponding to each action
- Added JSX function to open modal upon clicking in `select`
- Removed old code from table view 
…

## Testing

1. Replace lines 13-15 in `apps/admin_regis_table/views.py` with the following:
   <details><summary>Snippet</summary>
     
          import datetime
          registrations_content = [
            (
                1,                                  #registration_id
                datetime.date(2022, 8, 3),          #posted_date
                12023,                              #applicable_period_start
                122023,                             #applicable_period_end
                True,                               #file_me
                False,                               #file_pv
                True,                               #file_mc
                True,                               #file_pc
                False,                              #file_dc
                True,                               #submitting_for_self
                'SFTP',                             #submission_method
                'received',                           #registration_status
                'insurance carrier',                #org_type
                'Golden Rule Insurance Company',    #business_name
                '7440 Woodland Drive',              #mail_address
                'Indianpolis',                      #city
                'IN',                               #state
                '46278     '                        #zip
            ),
            (
                2,                                  #registration_id
                datetime.date(2022, 8, 3),          #posted_date
                12023,                              #applicable_period_start
                122023,                             #applicable_period_end
                True,                               #file_me
                True,                               #file_pv
                True,                               #file_mc
                True,                               #file_pc
                False,                              #file_dc
                False,                               #submitting_for_self
                'SFTP',                             #submission_method
                'processing',                           #registration_status
                'insurance carrier',                #org_type
                'Clay Tenant Insurance Company',    #business_name
                '440 Wood and Drive',              #mail_address
                'Indianapolis',                      #city
                'NY',                               #state
                '24444     '                        #zip
            ),
            (
                3,                                  #registration_id
                datetime.date(2022, 8, 3),          #posted_date
                12023,                              #applicable_period_start
                122023,                             #applicable_period_end
                True,                               #file_me
                True,                               #file_pv
                True,                               #file_mc
                True,                               #file_pc
                False,                              #file_dc
                True,                               #submitting_for_self
                'SFTP',                             #submission_method
                'complete',                        #registration_status
                'insurance carrier',                #org_type
                'Magenta Condition Insurance Company',    #business_name
                '742 Oddland Drive',              #mail_address
                'Indipolis',                      #city
                'MI',                               #state
                '62784     '                        #zip
            )
        ]
        registrations_entities = [
            (
                5, 1, 5, 46, 11111, 0, 5, 'Garretts Test Business 2', '11-0001111'
            ),
            (
                5, 2, 50000, 47, 1010, 1101, 1, 'A Second Test Entity', '00-0000000'
            )
        ]
        registrations_contacts = [
            (
                52,
                1,
                False,
                'Test Role',
                'Garrett Test Tester',
                '2222222222',
                'notarealemail@emailplace.email'
            ),
            (
                53,
                1,
                False,
                'A 2nd Test Role',
                'Test Garrett 2 Test',
                '145555555555',
                'testemail@testemail.emailtest'
            ),
            (
                54,
                2,
                True,
                'A 3rd and final test role',
                'Test 3rd Role Name Garrett',
                '0000000000',
                None
            )
          ]
        
    </details>
2. Open http://localhost:8000/administration/list-registration-requests/
3. Use any of the dropdowns within the 'Actions' column and test:
    - That when you select any action, the corresponding modal opens
    - The text of the dropdown you used (on the page) still reads 'Select Action'
    - The open modal cannot be closed by clicking outside of the modal
    - Clicking the 'X' button in the header successfully dismisses the modal


## UI
Before:
![image](https://user-images.githubusercontent.com/43251554/211661740-5f71254b-ee44-47bb-bf98-63dddb55b898.png)
After:
![image](https://user-images.githubusercontent.com/43251554/211661851-97cf47d7-16cf-4175-af79-fd6e6622a0f5.png)

…

<!--
## Notes

…
-->
