### PR TITLE
feat(apcd-cms): replace options on status filter change

### DIFF
--- a/apcd-cms/src/apps/admin_regis_table/templates/list_registrations.html
+++ b/apcd-cms/src/apps/admin_regis_table/templates/list_registrations.html
@@ -17,7 +17,7 @@
   <div class="filter-container">
     <div class="filter-content">
       <span><b>Filter by Status: </b></span>
-      <select id="statusFilter" class="status-filter" onchange="filterTableByStatus()">
+      <select id="statusFilter" class="status-filter" onchange="filterTableByStatus(); replaceActions();">
         <option class="dropdown-text">All</option>
         <option class="dropdown-text">Received</option>
         <option class="dropdown-text">Processing</option>
@@ -64,7 +64,42 @@
       </tbody>
   </table>
 </div>
+<template>
+  <template id="actionsOptions_All">
+    <option value="a">A</option>
+    <option value="b">B</option>
+    <option value="c">C</option>
+  </template>
+  <template id="actionsOptions_Received">
+    <option value="x">X</option>
+    <option value="y">Y</option>
+    <option value="z">Z</option>
+  </template>
+  <template id="actionsOptions_Processing">
+    <option value="1">One</option>
+    <option value="2">Two</option>
+    <option value="3">Three</option>
+  </template>
+  <template id="actionsOptions_Complete">
+    <option value="star">⭐️</option>
+    <option value="moon">🌖</option>
+    <option value="planet">🪐</option>
+  </template>
+</template>
 <script>
+  function replaceActions() {
+    const filterChoice = this.value;
+    const optionsTemplate = document.getElementById(`actionsOptions_${filterChoice}`);
+    const optionElements = template.content;
+    const actions = document.querySelectorAll(select[id^="actionsDropdown_"]);
+    /* NOTE: Using anonymous function so `optionElements` is accessible */
+    actions.forEach( dropdown => {
+      /* To delete old options (https://stackoverflow.com/a/3955238/11817077) */
+      dropdown.textContent = '';
+      /* To add new options */
+      dropdown.append(optionElements);
+    });
+  }
   function filterTableByStatus() {
     var dropdown, filter, table, rows, status, i;
     dropdown = document.getElementById("statusFilter");


### PR DESCRIPTION
⚠️ This is sample code. It has not been tested. It only has sample `<option>` elements. ⚠️

## Overview

Sample code to swap registration list options when status is changed.

## Related

<!--
- [FP-123](https://jira.tacc.utexas.edu/browse/FP-123)
- requires https://github.com/TACC/Core-CMS/pull/117
-->…

## Changes

- added template options
- added function to swap options
- added call to new function

## Testing

0. Open registration list table.
1. Change filter value.
2. Verify actions change.
3. Verify table is **still** filtered.

## UI

…

<!--
## Notes

…
-->
