### PR TITLE
Admin Submissions Navigation Fix

### DIFF
--- a/apcd-cms/src/apps/admin_submissions/views.py
+++ b/apcd-cms/src/apps/admin_submissions/views.py
@@ -70,7 +70,10 @@ class AdminSubmissionsTable(TemplateView):
             submission_logs = get_submission_logs(submission[0])
             submission_with_logs.append(_set_submissions(submission, submission_logs))
 
-        page_num = self.request.GET.get('page')
+        try:
+            page_num = int(self.request.GET.get('page'))
+        except:
+            page_num = 1
 
         p = Paginator(submission_with_logs, 10)
 


### PR DESCRIPTION
## Overview

Fixed navigation to `/administration/list-submissions` if the `page` parameter is missing

## Related

- [FP-1924](https://jira.tacc.utexas.edu/browse/FP-1924)

## Changes

1. Added a catch for missing `page` parameter

## Testing

1. Follow same setup procedure as highlighted in the [previous PR](https://github.com/TACC/Core-CMS-Custom/pull/68)
2. Navigate to [http://localhost:8000/administration/list-submissions/](http://localhost:8000/administration/list-submissions/) and ensure page loads and navigates to the first page

