### PR TITLE
Handling for a few NoneType values in database in registrations listing

### DIFF
--- a/apcd-cms/src/apps/admin_regis_table/views.py
+++ b/apcd-cms/src/apps/admin_regis_table/views.py
@@ -48,7 +48,7 @@ class RegistrationsTable(TemplateView):
         def _set_registration(reg, reg_ents, reg_conts):
             return {
                     'biz_name': reg[13],
-                    'type': reg[12].title(),
+                    'type': reg[12].title() if reg[12] else None,
                     'location': '{city}, {state}'.format
                         (
                             city=reg[15],
@@ -103,7 +103,7 @@ class RegistrationsTable(TemplateView):
         def _set_modal_content(reg, reg_ent, reg_cont):
             return {
                 'biz_name': reg[13],
-                'type': reg[12].title(),
+                'type': reg[12].title() if reg[12] else None,
                 'city': reg[15],
                 'state': reg[16],
                 'address': reg[14],


### PR DESCRIPTION
## Overview
Added `NoneType` handling for organization type from APCD database for listing registrations page
…

## Related

<!--
- [FP-123](https://jira.tacc.utexas.edu/browse/FP-123)
- requires https://github.com/TACC/Core-CMS/pull/117
-->…

## Changes
- Added catch for value `None` when handling organization type in listing table & modals
…

## Testing

1. Replace lines 13-15 in `apps/admin_regis_table/views.py` with the following:
   <details><summary>Snippet</summary>
     
          import datetime
          registrations_content = [
            (
                1,                                  #registration_id
                datetime.date(2022, 8, 3),          #posted_date
                12023,                              #applicable_period_start
                122023,                             #applicable_period_end
                True,                               #file_me
                False,                               #file_pv
                True,                               #file_mc
                True,                               #file_pc
                False,                              #file_dc
                True,                               #submitting_for_self
                'SFTP',                             #submission_method
                'received',                           #registration_status
                None,                #org_type
                'Golden Rule Insurance Company',    #business_name
                '7440 Woodland Drive',              #mail_address
                'Indianpolis',                      #city
                'IN',                               #state
                '46278     '                        #zip
            ),
            (
                2,                                  #registration_id
                datetime.date(2022, 8, 3),          #posted_date
                12023,                              #applicable_period_start
                122023,                             #applicable_period_end
                True,                               #file_me
                True,                               #file_pv
                True,                               #file_mc
                True,                               #file_pc
                False,                              #file_dc
                False,                               #submitting_for_self
                'SFTP',                             #submission_method
                'processing',                           #registration_status
                'pbm',                #org_type
                'Clay Tenant Insurance Company',    #business_name
                '440 Wood and Drive',              #mail_address
                'Indianapolis',                      #city
                'NY',                               #state
                '24444     '                        #zip
            ),
            (
                3,                                  #registration_id
                datetime.date(2022, 8, 3),          #posted_date
                12023,                              #applicable_period_start
                122023,                             #applicable_period_end
                True,                               #file_me
                True,                               #file_pv
                True,                               #file_mc
                True,                               #file_pc
                False,                              #file_dc
                True,                               #submitting_for_self
                'SFTP',                             #submission_method
                'complete',                        #registration_status
                'insurance carrier',                #org_type
                'Magenta Condition Insurance Company',    #business_name
                '742 Oddland Drive',              #mail_address
                'Indipolis',                      #city
                'MI',                               #state
                '62784     '                        #zip
            )
        ]
        registrations_entities = [
            (
                5, 1, 5, 46, 11111, 0, 5, 'Garretts Test Business 2', '11-0001111'
            ),
            (
                5, 2, 50000, 47, 1010, 1101, 1, 'A Second Test Entity', '00-0000000'
            )
        ]
        registrations_contacts = [
            (
                52,
                1,
                False,
                'Test Role',
                'Garrett Test Tester',
                '2222222222',
                'notarealemail@emailplace.email'
            ),
            (
                53,
                1,
                False,
                'A 2nd Test Role',
                'Test Garrett 2 Test',
                '145555555555',
                'testemail@testemail.emailtest'
            ),
            (
                54,
                2,
                True,
                'A 3rd and final test role',
                'Test 3rd Role Name Garrett',
                '0000000000',
                None
            )
          ]
        
    </details>
2. Open http://localhost:8000/administration/list-registration-requests/
3. Check that, in the Type column, the first row shows value 'None'
4. Check that this value for this same row also appears in the 'View Record' modal

## UI
![image](https://user-images.githubusercontent.com/43251554/214151367-adec87ca-7546-4812-92bb-6efa2fb365d1.png)

…

<!--
## Notes

…
-->
