### PR TITLE
hotfix: Create submitter and edit registration not writing to database

### DIFF
--- a/apcd-cms/src/apps/utils/apcd_database.py
+++ b/apcd-cms/src/apps/utils/apcd_database.py
@@ -178,7 +178,7 @@ def update_registration(form, reg_id):
             city = {_clean_value(form['city'])},
             state = {form['state'][:2]},
             zip = {form['zip_code']},
-            updated_at={datetime.datetime.now}
+            updated_at='{datetime.datetime.now()}'
         WHERE registration_id = {reg_id}"""
         cur.execute(operation)
         conn.commit()

--- a/apcd-cms/src/apps/utils/apcd_database.py
+++ b/apcd-cms/src/apps/utils/apcd_database.py
@@ -163,6 +163,7 @@ def update_registration(form, reg_id):
             port=APCD_DB['port'],
             sslmode='require'
         )
+        cur = conn.cursor()
         operation = f"""UPDATE registrations
             SET
             file_pv = {True if 'types_of_files_provider' in form else False},
@@ -587,7 +588,7 @@ def create_submitter(form, reg_data):
             encryption_key,
             created_at,
             status
-        ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+        ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
         RETURNING submitter_id"""
         values = (
             reg_data[0],


### PR DESCRIPTION
## Overview
Fixes for edit registration and create submitter actions on list registration requests admin page
…

## Related

<!--
- [FP-123](https://jira.tacc.utexas.edu/browse/FP-123)
- requires https://github.com/TACC/Core-CMS/pull/117
-->…

## Changes
- Added a missing value field for create submitter SQL operation command
- Added missing `cur` definition in update registration util function
- Reformatted current time call for update registration operation
…

## Testing

1. Will have to test on QA server, I've tested the revised util functions separately and they work.
2. Therefore, nothing to test locally.

## UI

…

<!--
## Notes

…
-->
