### PR TITLE
hotfix: Edit registration args needing string-wrap to read correctly

### DIFF
--- a/apcd-cms/src/apps/admin_regis_table/templates/edit_registration_error.html
+++ b/apcd-cms/src/apps/admin_regis_table/templates/edit_registration_error.html
@@ -1,12 +1,15 @@
 {% extends "standard.html" %}
 {% block content %}
+
+{% include 'snippets/tup-175-css-alerts-messages-ui-pattern.html' %}
+
 <div class="container">
     {% include "nav_cms_breadcrumbs.html" %}
 
     <h1>Edit Registration</h1>
     <hr />
     <p class="c-message c-message--error">
-        An error occurred while updating this registration . For help, <a href="/workbench/dashboard">submit a ticket</a>.
+        An error occurred while updating this registration. For help, <a href="/workbench/dashboard">submit a ticket</a>.
     </p>
     <a class="c-button c-button--primary" href="/administration/list-registration-requests">Back to List Registrations</a>
 </div>

--- a/apcd-cms/src/apps/utils/apcd_database.py
+++ b/apcd-cms/src/apps/utils/apcd_database.py
@@ -178,7 +178,7 @@ def update_registration(form, reg_id):
             city = {_clean_value(form['city'])},
             state = {form['state'][:2]},
             zip = {form['zip_code']},
-            updated_at={datetime.datetime.now}
+            updated_at='{datetime.datetime.now()}'
         WHERE registration_id = {reg_id}"""
         cur.execute(operation)
         conn.commit()

--- a/apcd-cms/src/apps/utils/apcd_database.py
+++ b/apcd-cms/src/apps/utils/apcd_database.py
@@ -163,6 +163,7 @@ def update_registration(form, reg_id):
             port=APCD_DB['port'],
             sslmode='require'
         )
+        cur = conn.cursor()
         operation = f"""UPDATE registrations
             SET
             file_pv = {True if 'types_of_files_provider' in form else False},
@@ -587,7 +588,7 @@ def create_submitter(form, reg_data):
             encryption_key,
             created_at,
             status
-        ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+        ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
         RETURNING submitter_id"""
         values = (
             reg_data[0],

--- a/apcd-cms/src/apps/utils/apcd_database.py
+++ b/apcd-cms/src/apps/utils/apcd_database.py
@@ -151,6 +151,7 @@ def create_registration(form):
         if conn is not None:
             conn.close()
 
+
 def update_registration(form, reg_id):
     cur = None
     conn = None
@@ -171,13 +172,13 @@ def update_registration(form, reg_id):
             file_pc = {True if 'types_of_files_pharmacy' in form else False},
             file_dc = {True if 'types_of_files_dental' in form else False},
             submitting_for_self = {True if form['on-behalf-of'] == 'true' else False},
-            submission_method = {_clean_value(form['submission_method'])},
-            org_type = {_clean_value(form['type'])},
-            business_name = {_clean_value(form['business-name'])},
-            mail_address = {_clean_value(form['mailing-address'])},
-            city = {_clean_value(form['city'])},
-            state = {form['state'][:2]},
-            zip = {form['zip_code']},
+            submission_method = '{_clean_value(form['submission_method'])}',
+            org_type = '{_clean_value(form['type'])}',
+            business_name = '{_clean_value(form['business-name'])}',
+            mail_address = '{_clean_value(form['mailing-address'])}',
+            city = '{_clean_value(form['city'])}',
+            state = '{form['state'][:2]}',
+            zip = '{form['zip_code']}',
             updated_at='{datetime.datetime.now()}'
         WHERE registration_id = {reg_id}"""
         cur.execute(operation)


### PR DESCRIPTION
## Overview

…

## Related

<!--
- [FP-123](https://jira.tacc.utexas.edu/browse/FP-123)
- requires https://github.com/TACC/Core-CMS/pull/117
-->…

## Changes
- Wrapped some args in `' '` to pick up entire input string from form
- Added error message styling to edit registration error page to show error message correctly
…

## Testing

1. Replace lines 13-15 in `apps/admin_regis_table/views.py` with the following:
   <details><summary>Snippet</summary>
     
          import datetime
          registrations_content = [
            (
                1,                                  #registration_id
                datetime.date(2022, 8, 3),          #posted_date
                12023,                              #applicable_period_start
                122023,                             #applicable_period_end
                True,                               #file_me
                False,                               #file_pv
                True,                               #file_mc
                True,                               #file_pc
                False,                              #file_dc
                True,                               #submitting_for_self
                'SFTP',                             #submission_method
                'received',                           #registration_status
                'insurance carrier',                #org_type
                'Golden Rule Insurance Company',    #business_name
                '7440 Woodland Drive',              #mail_address
                'Indianpolis',                      #city
                'IN',                               #state
                '46278     '                        #zip
            ),
            (
                2,                                  #registration_id
                datetime.date(2022, 8, 3),          #posted_date
                12023,                              #applicable_period_start
                122023,                             #applicable_period_end
                True,                               #file_me
                True,                               #file_pv
                True,                               #file_mc
                True,                               #file_pc
                False,                              #file_dc
                False,                               #submitting_for_self
                'SFTP',                             #submission_method
                'processing',                           #registration_status
                'pbm',                #org_type
                'Clay Tenant Insurance Company',    #business_name
                '440 Wood and Drive',              #mail_address
                'Indianapolis',                      #city
                'NY',                               #state
                '24444     '                        #zip
            ),
            (
                3,                                  #registration_id
                datetime.date(2022, 8, 3),          #posted_date
                12023,                              #applicable_period_start
                122023,                             #applicable_period_end
                True,                               #file_me
                True,                               #file_pv
                True,                               #file_mc
                True,                               #file_pc
                False,                              #file_dc
                True,                               #submitting_for_self
                'SFTP',                             #submission_method
                'complete',                        #registration_status
                'insurance carrier',                #org_type
                'Magenta Condition Insurance Company',    #business_name
                '742 Oddland Drive',              #mail_address
                'Indipolis',                      #city
                'MI',                               #state
                '62784     '                        #zip
            )
        ]
        registrations_entities = [
            (
                5, 1, 5, 46, 11111, 10001, 5, 'Garretts Test Business 2', '11-0001111'
            ),
            (
                5, 2, 50000, 47, 11010, 21101, 1, 'A Second Test Entity', '00-0000000'
            )
        ]
        registrations_contacts = [
            (
                52,
                1,
                False,
                'Test Role',
                'Garrett Test Tester',
                '2222222222',
                'notarealemail@emailplace.email'
            ),
            (
                53,
                1,
                False,
                'A 2nd Test Role',
                'Test Garrett 2 Test',
                '15555555555',
                'testemail@testemail.emailtest'
            ),
            (
                54,
                2,
                True,
                'A 3rd and final test role',
                'Test 3rd Role Name Garrett',
                '0000000000',
                None
            )
          ]
        
    </details>
2. Open http://localhost:8000/administration/list-registration-requests/
3. Open any of the Edit Registration links in the Actions column of the table
4. Submit form in modal, and confirm error page looks like screenshot below

## UI
<img width="1446" alt="image" src="https://user-images.githubusercontent.com/43251554/215884254-fe177cd4-6f4c-49cb-b4e6-25cb9b3431fd.png">

…

<!--
## Notes

…
-->
