### PR TITLE
Added functions to get registration data on page render

### DIFF
--- a/apcd-cms/src/apps/admin_regis_table/views.py
+++ b/apcd-cms/src/apps/admin_regis_table/views.py
@@ -73,6 +73,9 @@ class RegistrationsTable(TemplateView):
     def dispatch(self, request, *args, **kwargs):
         if not request.user.is_authenticated or not is_apcd_admin(request.user):
             return HttpResponseRedirect('/')
+        registrations_content = get_registrations()
+        registrations_entities = get_registration_entities()
+        registrations_contacts = get_registration_contacts()
         return super(RegistrationsTable, self).dispatch(request, *args, **kwargs)
 
     def get_context_data(self, registrations_content=registrations_content, registrations_entities=registrations_entities, registrations_contacts=registrations_contacts, *args, **kwargs):


### PR DESCRIPTION
## Overview
Hotfix to make `admin_regis_table` load the new data on render

## Changes
Added `get...` calls to the `dispatch()` function
…

## Testing

Can't test locally, will need to add to PPRD. 
1.  Navigate to https://apcd-qa.tacc.utexas.edu/administration/list-registration-requests/
2. Edit an entry.
3. Navigate through workflow
4. Make sure changes are visible when you lang back at the `list-registration-requests/` table

## UI

…

<!--
## Notes

…
-->
