### PR TITLE
hotfix/create-extension-bug

### DIFF
--- a/apcd-cms/src/apps/utils/apcd_database.py
+++ b/apcd-cms/src/apps/utils/apcd_database.py
@@ -1014,7 +1014,6 @@ def create_extension(form, iteration, sub_data):
     try:
         if iteration > 1:
             values = (
-                None,
                 _clean_value(sub_data[0]),
                 _clean_date(form['current-expected-date_{}'.format(iteration)]),
                 _clean_date(form['requested-target-date_{}'.format(iteration)]),
@@ -1035,7 +1034,6 @@ def create_extension(form, iteration, sub_data):
                 )
         else:
             values = (
-            None,
             _clean_value(sub_data[0]),
             _clean_date(form['current-expected-date']),
             _clean_date(form['requested-target-date']),
@@ -1055,7 +1053,6 @@ def create_extension(form, iteration, sub_data):
             None
             )            
         operation = """INSERT INTO extensions(
-                extension_id,
                 submitter_id,
                 current_expected_date,
                 requested_target_date,
@@ -1073,7 +1070,8 @@ def create_extension(form, iteration, sub_data):
                 requestor_email,
                 explanation_justification,
                 notes
-                ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)"""
+                ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+            """
         conn = psycopg2.connect(
             host=APCD_DB['host'],
             dbname=APCD_DB['database'],
@@ -1109,13 +1107,12 @@ def get_submitter_for_extend_or_except(user):
         )
         cur = conn.cursor()
         query = """
-                SELECT submitters.submitter_id, submitters.submitter_code, submitters.payor_code, submitter_users.user_id, users.org_name
-                FROM submitters
-                JOIN submitter_users
-                    ON submitters.submitter_id = submitter_users.submitter_id
-                JOIN users
-                    ON submitter_users.user_id = users.user_id
-                WHERE submitter_users.user_id = (%s)
+                SELECT submitter_users.submitter_id, submitters.submitter_code, submitters.payor_code, submitter_users.user_id, apcd_orgs.official_name
+                FROM submitter_users
+                JOIN submitters
+                    ON submitter_users.submitter_id = submitters.submitter_id and submitter_users.user_id = (%s)
+                JOIN apcd_orgs
+                    ON submitters.apcd_id = apcd_orgs.apcd_id
             """
         cur = conn.cursor()
         cur.execute(query, (user,))
@@ -1162,12 +1159,13 @@ def get_all_extensions():
                 extensions.requestor_email,
                 extensions.explanation_justification,
                 extensions.notes,
-                users.org_name
+                submitters.apcd_id,
+                apcd_orgs.official_name
             FROM extensions
-            JOIN submitter_users
-                ON extensions.submitter_id = submitter_users.submitter_id
-            JOIN users
-                ON submitter_users.user_id = users.user_id
+            JOIN submitters
+                ON extensions.submitter_id = submitters.submitter_id
+            JOIN apcd_orgs
+                ON submitters.apcd_id = apcd_orgs.apcd_id
             ORDER BY extensions.created_at DESC
         """ 
         cur = conn.cursor()
@@ -1215,12 +1213,12 @@ def get_all_exceptions():
                 exceptions.approved_expiration_date,
                 exceptions.status,
                 exceptions.notes,
-                users.org_name
+                apcd_orgs.official_name
             FROM exceptions
-            JOIN submitter_users
-                ON exceptions.submitter_id = submitter_users.submitter_id
-            JOIN users
-                ON submitter_users.user_id = users.user_id
+            JOIN submitters
+                ON exceptions.submitter_id = submitters.submitter_id
+            JOIN apcd_orgs
+                ON submitters.apcd_id = apcd_orgs.apcd_id
             ORDER BY exceptions.created_at DESC
         """ 
         cur = conn.cursor()


### PR DESCRIPTION
## Overview

Fix for data not saving to database after creating extension. Also tweaked queries that were pulling in the org names for a user. The org names displayed should be correct now.

## Related

<!--
- [FP-123](https://jira.tacc.utexas.edu/browse/FP-123)
- requires https://github.com/TACC/Core-CMS/pull/117
-->…

## Changes

- Removed insertion of primary key when creating an extension (key auto increments)
- Tweaked queries to get org name from `apcd_orgs` table instead which should be a more accurate table to use to get organizations

## Testing

- No testing to be done locally. After this gets deployed will need to test creating an extension as well as make sure the correct org names are displayed for users.
