### PR TITLE
CEPWMA-687 - hotfix/email-validation

### DIFF
--- a/apcd-cms/src/apps/exception/templates/exception_submission_form/exception_threshold_form.html
+++ b/apcd-cms/src/apps/exception/templates/exception_submission_form/exception_threshold_form.html
@@ -149,7 +149,7 @@
                 <div class="field-errors" style="display: none"></div>
 
                 <input type="email" name="requestor-email" required class="emailinput" autocomplete="email"
-                  id="requestor-email" />
+                  id="requestor-email" pattern="^[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,4}$" />
               </div>
             </div>
             <div class="field-wrapper textinput required"><label>

--- a/apcd-cms/src/apps/extension/templates/extension_submission_form/extension_submission_form.html
+++ b/apcd-cms/src/apps/extension/templates/extension_submission_form/extension_submission_form.html
@@ -132,7 +132,7 @@
                   <div class="field-errors" style="display: none"></div>
         
                   <input type="email" name="requestor-email" required class="emailinput" autocomplete="email"
-                    id="requestor-email" />
+                    id="requestor-email" pattern="^[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,4}$" />
                 </div>
               </div>
               <div class="field-wrapper textinput required"><label>

--- a/apcd-cms/src/apps/registrations/templates/submission_form/registration_form_body.html
+++ b/apcd-cms/src/apps/registrations/templates/submission_form/registration_form_body.html
@@ -839,6 +839,7 @@
                         required
                         class="emailinput"
                         id="contact_email_{{forloop.counter}}_{{r.reg_id}}"
+                        pattern="^[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,4}$"
                         value="{{ contact.email }}"
                         />
                     </div>
@@ -954,6 +955,7 @@
                     required
                     class="emailinput"
                     id="contact_email"
+                    pattern="^[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,4}$"
                 />
                 </div>
                 <div class="field-wrapper checkboxinput">

--- a/apcd-cms/src/apps/registrations/templates/submission_form/registration_form_scripts.html
+++ b/apcd-cms/src/apps/registrations/templates/submission_form/registration_form_scripts.html
@@ -289,6 +289,7 @@
                 autocomplete="email"
                 required
                 class="emailinput"
+                pattern="^[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,4}$"
                 id="contact_email_${contacts}{% if r %}_{{r.reg_id}}{% endif %}"
               />
             </div>

--- a/apcd-cms/src/apps/utils/apcd_database.py
+++ b/apcd-cms/src/apps/utils/apcd_database.py
@@ -688,7 +688,7 @@ def create_other_exception(form, sub_data):
             sub_data[2],
             sub_data[3],
             _clean_value(form['requestor-name']),
-            _clean_email_from_form(form['requestor-email']),
+            _clean_email(form['requestor-email']),
             "Other",
             _clean_date(form['expiration-date']),
             _clean_value(form['justification']),
@@ -744,7 +744,7 @@ def create_threshold_exception(form, sub_data):
             sub_data[2],
             sub_data[3],
             _clean_value(form['requestor-name']),
-            _clean_email_from_form(form['requestor-email']),
+            _clean_email(form['requestor-email']),
             "Threshold",
             _clean_date(form['expiration-date']),
             _clean_value(form['file_type']),
@@ -898,8 +898,8 @@ def create_extension(form, iteration, sub_data):
                 _clean_value(sub_data[1]),
                 _clean_value(sub_data[2]),
                 _clean_value(sub_data[3]),
-                _clean_email_from_form(form["requestor-name"]),
-                _clean_email_from_form(form["requestor-email"]),
+                _clean_value(form["requestor-name"]),
+                _clean_email(form["requestor-email"]),
                 _clean_value(form["justification"])
                 )
         else:
@@ -916,7 +916,7 @@ def create_extension(form, iteration, sub_data):
             _clean_value(sub_data[2]),
             _clean_value(sub_data[3]),
             _clean_value(form["requestor-name"]),
-            _clean_email_from_form(form["requestor-email"]),
+            _clean_email(form["requestor-email"]),
             _clean_value(form["justification"])
             )            
         operation = """INSERT INTO extensions(
@@ -1136,9 +1136,6 @@ def _clean_email(email):
 
 def _clean_value(value):
     return re.sub('[^a-zA-Z0-9 \.\-\,]', '', str(value))
-
-def _clean_email_from_form(email):
-    return re.sub('[^a-zA-Z0-9 \.\-\,\@]', '', str(email))
 
 def _clean_date(date_string):
     date_pattern = re.compile(r'^\d{4}-\d{2}-\d{2}$')


### PR DESCRIPTION

## Overview
Added frontend pattern checks to prevent malformed email submissions that don't get saved to the db because they don't match our data sanitizers

## Related
* [CEPWMA-687](https://jira.tacc.utexas.edu/browse/CEPWMA-687)

## Changes
Adds front-end check that prevents users from submitting malformed emails.

## Testing

1. Go to [Request to Submit](http://localhost:8000/register/request-to-submit/) page and try to add a contact with a malformed email, and make sure you are prevented from doing so.
2. Try to submit a correctly formatted email, and make sure that you are able to.

