### PR TITLE
Fix extension to store more than one extension request

### DIFF
--- a/apcd-cms/src/apps/extension/views.py
+++ b/apcd-cms/src/apps/extension/views.py
@@ -60,7 +60,7 @@ class ExtensionFormView(TemplateView):
                     break
 
             for iteration in range(max_iterations):
-                exten_resp = apcd_database.create_extension(form, iteration, submitter)
+                exten_resp = apcd_database.create_extension(form, iteration + 1, submitter)
                 if _err_msg(exten_resp):
                     errors.append(_err_msg(exten_resp))
 

--- a/apcd-cms/src/apps/utils/apcd_database.py
+++ b/apcd-cms/src/apps/utils/apcd_database.py
@@ -886,66 +886,97 @@ def create_extension(form, iteration, sub_data):
     conn = None
     values = ()
     try:
-        if iteration > 1:
-            values = (
+        while iteration > 0:
+            if iteration > 1:
+                values = (
+                    _clean_value(sub_data[0]),
+                    _clean_date(form['current-expected-date_{}'.format(iteration)]),
+                    _clean_date(form['requested-target-date_{}'.format(iteration)]),
+                    None,
+                    _clean_value(form['extension-type_{}'.format(iteration)]),
+                    int(form['applicable-data-period_{}'.format(iteration)].replace('-', '')),
+                    "Pending",
+                    _clean_value(sub_data[1]),
+                    _clean_value(sub_data[2]),
+                    _clean_value(sub_data[3]),
+                    _clean_email_from_form(form["requestor-name"]),
+                    _clean_email_from_form(form["requestor-email"]),
+                    _clean_value(form["justification"])
+                    )
+                operation = """INSERT INTO extensions(
+                    submitter_id,
+                    current_expected_date,
+                    requested_target_date,
+                    approved_expiration_date,
+                    extension_type,
+                    applicable_data_period,
+                    status,
+                    submitter_code,
+                    payor_code,
+                    user_id,
+                    requestor_name,
+                    requestor_email,
+                    explanation_justification
+                    ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+                """
+                conn = psycopg2.connect(
+                    host=APCD_DB['host'],
+                    dbname=APCD_DB['database'],
+                    user=APCD_DB['user'],
+                    password=APCD_DB['password'],
+                    port=APCD_DB['port'],
+                    sslmode='require'
+                )
+                cur = conn.cursor()
+                cur.execute(operation, values)
+                conn.commit()
+                iteration = iteration - 1
+            else:
+                values = (
                 _clean_value(sub_data[0]),
-                _clean_date(form['current-expected-date_{}'.format(iteration)]),
-                _clean_date(form['requested-target-date_{}'.format(iteration)]),
+                _clean_date(form['current-expected-date']),
+                _clean_date(form['requested-target-date']),
                 None,
-                _clean_value(form['extension-type_{}'.format(iteration)]),
-                int(form['applicable-data-period_{}'.format(iteration)].replace('-', '')),
+                _clean_value(form['extension-type']),
+                int(form['applicable-data-period'].replace('-', '')),
                 "Pending",
+
                 _clean_value(sub_data[1]),
                 _clean_value(sub_data[2]),
                 _clean_value(sub_data[3]),
-                _clean_email_from_form(form["requestor-name"]),
+                _clean_value(form["requestor-name"]),
                 _clean_email_from_form(form["requestor-email"]),
                 _clean_value(form["justification"])
+                )            
+                operation = """INSERT INTO extensions(
+                        submitter_id,
+                        current_expected_date,
+                        requested_target_date,
+                        approved_expiration_date,
+                        extension_type,
+                        applicable_data_period,
+                        status,
+                        submitter_code,
+                        payor_code,
+                        user_id,
+                        requestor_name,
+                        requestor_email,
+                        explanation_justification
+                        ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+                """
+                conn = psycopg2.connect(
+                    host=APCD_DB['host'],
+                    dbname=APCD_DB['database'],
+                    user=APCD_DB['user'],
+                    password=APCD_DB['password'],
+                    port=APCD_DB['port'],
+                    sslmode='require'
                 )
-        else:
-            values = (
-            _clean_value(sub_data[0]),
-            _clean_date(form['current-expected-date']),
-            _clean_date(form['requested-target-date']),
-            None,
-            _clean_value(form['extension-type']),
-            int(form['applicable-data-period'].replace('-', '')),
-            "Pending",
-
-            _clean_value(sub_data[1]),
-            _clean_value(sub_data[2]),
-            _clean_value(sub_data[3]),
-            _clean_value(form["requestor-name"]),
-            _clean_email_from_form(form["requestor-email"]),
-            _clean_value(form["justification"])
-            )            
-        operation = """INSERT INTO extensions(
-                submitter_id,
-                current_expected_date,
-                requested_target_date,
-                approved_expiration_date,
-                extension_type,
-                applicable_data_period,
-                status,
-                submitter_code,
-                payor_code,
-                user_id,
-                requestor_name,
-                requestor_email,
-                explanation_justification
-                ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
-            """
-        conn = psycopg2.connect(
-            host=APCD_DB['host'],
-            dbname=APCD_DB['database'],
-            user=APCD_DB['user'],
-            password=APCD_DB['password'],
-            port=APCD_DB['port'],
-            sslmode='require'
-        )
-        cur = conn.cursor()
-        cur.execute(operation, values)
-        conn.commit()
+                cur = conn.cursor()
+                cur.execute(operation, values)
+                conn.commit()
+                iteration = iteration - 1
+                
     except Exception as error:
         logger.error(error)
         return error

--- a/apcd-cms/src/apps/utils/apcd_database.py
+++ b/apcd-cms/src/apps/utils/apcd_database.py
@@ -886,96 +886,67 @@ def create_extension(form, iteration, sub_data):
     conn = None
     values = ()
     try:
-        while iteration > 0:
-            if iteration > 1:
-                values = (
-                    _clean_value(sub_data[0]),
-                    _clean_date(form['current-expected-date_{}'.format(iteration)]),
-                    _clean_date(form['requested-target-date_{}'.format(iteration)]),
-                    None,
-                    _clean_value(form['extension-type_{}'.format(iteration)]),
-                    int(form['applicable-data-period_{}'.format(iteration)].replace('-', '')),
-                    "Pending",
-                    _clean_value(sub_data[1]),
-                    _clean_value(sub_data[2]),
-                    _clean_value(sub_data[3]),
-                    _clean_email_from_form(form["requestor-name"]),
-                    _clean_email_from_form(form["requestor-email"]),
-                    _clean_value(form["justification"])
-                    )
-                operation = """INSERT INTO extensions(
-                    submitter_id,
-                    current_expected_date,
-                    requested_target_date,
-                    approved_expiration_date,
-                    extension_type,
-                    applicable_data_period,
-                    status,
-                    submitter_code,
-                    payor_code,
-                    user_id,
-                    requestor_name,
-                    requestor_email,
-                    explanation_justification
-                    ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
-                """
-                conn = psycopg2.connect(
-                    host=APCD_DB['host'],
-                    dbname=APCD_DB['database'],
-                    user=APCD_DB['user'],
-                    password=APCD_DB['password'],
-                    port=APCD_DB['port'],
-                    sslmode='require'
-                )
-                cur = conn.cursor()
-                cur.execute(operation, values)
-                conn.commit()
-                iteration = iteration - 1
-            else:
-                values = (
+        if iteration > 1:
+            values = (
                 _clean_value(sub_data[0]),
-                _clean_date(form['current-expected-date']),
-                _clean_date(form['requested-target-date']),
+                _clean_date(form['current-expected-date_{}'.format(iteration)]),
+                _clean_date(form['requested-target-date_{}'.format(iteration)]),
                 None,
-                _clean_value(form['extension-type']),
-                int(form['applicable-data-period'].replace('-', '')),
+                _clean_value(form['extension-type_{}'.format(iteration)]),
+                int(form['applicable-data-period_{}'.format(iteration)].replace('-', '')),
                 "Pending",
-
                 _clean_value(sub_data[1]),
                 _clean_value(sub_data[2]),
                 _clean_value(sub_data[3]),
-                _clean_value(form["requestor-name"]),
+                _clean_email_from_form(form["requestor-name"]),
                 _clean_email_from_form(form["requestor-email"]),
                 _clean_value(form["justification"])
-                )            
-                operation = """INSERT INTO extensions(
-                        submitter_id,
-                        current_expected_date,
-                        requested_target_date,
-                        approved_expiration_date,
-                        extension_type,
-                        applicable_data_period,
-                        status,
-                        submitter_code,
-                        payor_code,
-                        user_id,
-                        requestor_name,
-                        requestor_email,
-                        explanation_justification
-                        ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
-                """
-                conn = psycopg2.connect(
-                    host=APCD_DB['host'],
-                    dbname=APCD_DB['database'],
-                    user=APCD_DB['user'],
-                    password=APCD_DB['password'],
-                    port=APCD_DB['port'],
-                    sslmode='require'
                 )
-                cur = conn.cursor()
-                cur.execute(operation, values)
-                conn.commit()
-                iteration = iteration - 1
+        else:
+            values = (
+            _clean_value(sub_data[0]),
+            _clean_date(form['current-expected-date']),
+            _clean_date(form['requested-target-date']),
+            None,
+            _clean_value(form['extension-type']),
+            int(form['applicable-data-period'].replace('-', '')),
+            "Pending",
+
+            _clean_value(sub_data[1]),
+            _clean_value(sub_data[2]),
+            _clean_value(sub_data[3]),
+            _clean_value(form["requestor-name"]),
+            _clean_email_from_form(form["requestor-email"]),
+            _clean_value(form["justification"])
+            )   
+
+        operation = """INSERT INTO extensions(
+        submitter_id,
+        current_expected_date,
+        requested_target_date,
+        approved_expiration_date,
+        extension_type,
+        applicable_data_period,
+        status,
+        submitter_code,
+        payor_code,
+        user_id,
+        requestor_name,
+        requestor_email,
+        explanation_justification
+        ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+        """
+        conn = psycopg2.connect(
+            host=APCD_DB['host'],
+            dbname=APCD_DB['database'],
+            user=APCD_DB['user'],
+            password=APCD_DB['password'],
+            port=APCD_DB['port'],
+            sslmode='require'
+        )
+        cur = conn.cursor()
+        cur.execute(operation, values)
+        conn.commit()         
                 
     except Exception as error:
         logger.error(error)


### PR DESCRIPTION
## Overview

Update to allow extension form to make extension entries to DB for more than one extension per form using the add extension button

## Related

- [FP-1816](https://jira.tacc.utexas.edu/browse/FP-1816)

## Changes

Created a while loop and iterator to go through each extension field in form and insert

## Testing

1. Go to [http://localhost:8000/submissions/extension-request/](http://localhost:8000/submissions/extension-request/)
2. Use snippet below and put in extension/views.py on line 24 
```
submitters = [
        (2, 'TESTGOLD', 10000001, 'gmunoz1', 'CHCD'),
        (3, 'TESTGOLD', 10000002, 'gmunoz1', 'CHCD'),
        (1, 'TESTGOLD', 10000000, 'gmunoz1', 'CHCD')
        ]
```
3. Nothing to test locally - just make sure the extension form looks the same and doesn't display error template on submit.

## UI

…

<!--
## Notes

…
-->
