### PR TITLE
fix: Bad default arg for reg id util functions

### DIFF
--- a/apcd-cms/src/apps/utils/apcd_database.py
+++ b/apcd-cms/src/apps/utils/apcd_database.py
@@ -100,7 +100,7 @@ def get_registrations(reg_id=None):
                 registrations.city,
                 registrations.state,
                 registrations.zip
-                FROM registrations {f"WHERE registration_id = {str(reg_id) if reg_id is not None else ''}"}"""
+                FROM registrations {f"WHERE registration_id = {str(reg_id)}" if reg_id is not None else ''}"""
         cur = conn.cursor()
         cur.execute(query)
         return cur.fetchall()
@@ -249,7 +249,7 @@ def get_registration_entities(reg_id=None):
                 registration_entities.total_covered_lives,
                 registration_entities.entity_name,
                 registration_entities.fein
-                FROM registration_entities {f"WHERE registration_id = {str(reg_id) if reg_id is not None else ''}"}"""
+                FROM registration_entities {f"WHERE registration_id =  {str(reg_id)}" if reg_id is not None else ''}"""
         cur = conn.cursor()
         cur.execute(query)
         return cur.fetchall()
@@ -436,7 +436,7 @@ def get_registration_contacts(reg_id=None):
                 registration_contacts.contact_name,
                 registration_contacts.contact_phone,
                 registration_contacts.contact_email
-                FROM registration_contacts {f"WHERE registration_id = {str(reg_id) if reg_id is not None else ''}"}"""
+                FROM registration_contacts {f"WHERE registration_id = {str(reg_id)}" if reg_id is not None else ''}"""
         cur = conn.cursor()
         cur.execute(query)
         return cur.fetchall()

--- a/apcd-cms/src/apps/utils/apcd_database.py
+++ b/apcd-cms/src/apps/utils/apcd_database.py
@@ -81,7 +81,7 @@ def get_registrations(reg_id=None):
             port=APCD_DB['port'],
             sslmode='require'
         )
-        query = """SELECT
+        query = f"""SELECT
                 registrations.registration_id,
                 registrations.posted_date,
                 registrations.applicable_period_start,
@@ -100,9 +100,9 @@ def get_registrations(reg_id=None):
                 registrations.city,
                 registrations.state,
                 registrations.zip
-                FROM registrations WHERE registration_id = %s"""
+                FROM registrations {f"WHERE registration_id = {str(reg_id) if reg_id is not None else ''}"}"""
         cur = conn.cursor()
-        cur.execute(query, (reg_id if reg_id is not None else '',))
+        cur.execute(query)
         return cur.fetchall()
 
     except Exception as error:
@@ -239,7 +239,7 @@ def get_registration_entities(reg_id=None):
             port=APCD_DB['port'],
             sslmode='require'
         )
-        query = """SELECT
+        query = f"""SELECT
                 registration_entities.total_claims_value,
                 registration_entities.registration_id,
                 registration_entities.claims_and_encounters_volume,
@@ -249,9 +249,9 @@ def get_registration_entities(reg_id=None):
                 registration_entities.total_covered_lives,
                 registration_entities.entity_name,
                 registration_entities.fein
-                FROM registration_entities WHERE registration_id = %s"""
+                FROM registration_entities {f"WHERE registration_id = {str(reg_id) if reg_id is not None else ''}"}"""
         cur = conn.cursor()
-        cur.execute(query, (reg_id if reg_id is not None else '',))
+        cur.execute(query)
         return cur.fetchall()
 
     except Exception as error:
@@ -428,7 +428,7 @@ def get_registration_contacts(reg_id=None):
             port=APCD_DB['port'],
             sslmode='require'
         )
-        query = """SELECT
+        query = f"""SELECT
                 registration_contacts.registration_contact_id,
                 registration_contacts.registration_id,
                 registration_contacts.notify_flag,
@@ -436,9 +436,9 @@ def get_registration_contacts(reg_id=None):
                 registration_contacts.contact_name,
                 registration_contacts.contact_phone,
                 registration_contacts.contact_email
-                FROM registration_contacts WHERE registration_id = %s"""
+                FROM registration_contacts {f"WHERE registration_id = {str(reg_id) if reg_id is not None else ''}"}"""
         cur = conn.cursor()
-        cur.execute(query, (reg_id if reg_id is not None else '',))
+        cur.execute(query)
         return cur.fetchall()
 
     except Exception as error:


### PR DESCRIPTION
## Overview
Needed to change how `WHERE` clause in `get_registrations` & related util functions is included/excluded in SQL command
…

## Related

<!--
- [FP-123](https://jira.tacc.utexas.edu/browse/FP-123)
- requires https://github.com/TACC/Core-CMS/pull/117
-->…

## Changes
- Reverted to f-string solution to completely exclude `WHERE` from SQL command if `reg_id` is not passed
…

## Testing

1. Nothing to test locally.

## UI

…

<!--
## Notes

…
-->
