### PR TITLE
fix: Eligibility/enrollment file type not storing correctly to database

### DIFF
--- a/apcd-cms/src/apps/utils/apcd_database.py
+++ b/apcd-cms/src/apps/utils/apcd_database.py
@@ -152,7 +152,7 @@ def create_registration(form):
             datetime.datetime.now(),
             None,
             None,
-            True if 'types_of_files_eligibility_enrollment' in form else False,
+            True,
             True if 'types_of_files_provider' in form else False,
             True if 'types_of_files_medical' in form else False,
             True if 'types_of_files_pharmacy' in form else False,


### PR DESCRIPTION
## Overview
Added fix for eligibility/enrollment file type not writing to db unless other file types selected
…

## Related

<!--
- [FP-123](https://jira.tacc.utexas.edu/browse/FP-123)
- requires https://github.com/TACC/Core-CMS/pull/117
-->…

## Changes
- In `create_registration` db function, I set `file_me` to always be set as `True` as this file type is mandatory for all registration requests
…

## Testing

1. No testing to do locally.

## UI

…

<!--
## Notes

…
-->
