### PR TITLE
fix: Registration listing - entities and contacts not writing correctly to database

### DIFF
--- a/apcd-cms/src/apps/admin_regis_table/views.py
+++ b/apcd-cms/src/apps/admin_regis_table/views.py
@@ -106,11 +106,11 @@ class RegistrationsTable(TemplateView):
                 'claim_val': reg_ent[0],
                 'ent_id': reg_ent[3],
                 'claim_and_enc_vol': reg_ent[2],
-                'license': reg_ent[4],
-                'naic': reg_ent[5],
+                'license': reg_ent[4] if reg_ent[4] else None,
+                'naic': reg_ent[5] if reg_ent[5] else None,
                 'no_covered': reg_ent[6],
                 'ent_name': reg_ent[7],
-                'fein': reg_ent[8]
+                'fein': reg_ent[8] if reg_ent[8] else None
             }
         def _set_contacts(reg_cont):
 

--- a/apcd-cms/src/apps/registrations/templates/submission_form/registration_form_body.html
+++ b/apcd-cms/src/apps/registrations/templates/submission_form/registration_form_body.html
@@ -438,8 +438,7 @@
                     minlength="10"
                     maxlength="10"
                     pattern="\d{2}-\d{7}"
-                    required
-                    value="{{ entity.fein }}"
+                    {% if entity.fein %} value="{{ entity.fein }}" {% endif %}
                     />
 
                     <div id="help-text-fein" class="help-text">
@@ -461,8 +460,7 @@
                     minlength="5"
                     maxlength="10"
                     pattern="^[1-9]\d{4}|^[1-9]\d{9}"
-                    required
-                    value="{{ entity.license }}"
+                    {% if entity.license %} value="{{ entity.license }}" {% endif %}
                     />
 
                     <div id="help-text-license_number" class="help-text">
@@ -484,8 +482,7 @@
                     minlength="5"
                     maxlength="5"
                     pattern="^[1-9]\d{4}"
-                    required
-                    value="{{ entity.naic }}"
+                    {% if entity.naic %} value="{{ entity.naic }}" {% endif %}
                     />
 
                     <div id="help-text-naic_company_code" class="help-text">

--- a/apcd-cms/src/apps/registrations/templates/submission_form/registration_form_scripts.html
+++ b/apcd-cms/src/apps/registrations/templates/submission_form/registration_form_scripts.html
@@ -321,17 +321,19 @@
     </script>
     {# To require at least one "entity" identifier value #}
     <script id="form-entity_id-required" type="module">
-      const inputs = Array.from(
-        document.querySelectorAll(`
-        input[name=fein{% if r %}_{{r.reg_id}}{% endif %}],
-        input[name=license_number{% if r %}_{{r.reg_id}}{% endif %}],
-        input[name=naic_company_code{% if r %}_{{r.reg_id}}{% endif %}]`)
-      );
-      const inputListener = e => {
-        inputs.filter(i => i !== e.target)
-              .forEach(i => (i.required = !e.target.value.length));
-      };
+      for (let ent_no = 1; ent_no < 6; ent_no++) {
+        const inputs = Array.from(
+          document.querySelectorAll(`
+          input[name=fein_${ent_no}{% if r %}_{{r.reg_id}}{% endif %}],
+          input[name=license_number_${ent_no}{% if r %}_{{r.reg_id}}{% endif %}],
+          input[name=naic_company_code_${ent_no}{% if r %}_{{r.reg_id}}{% endif %}]`)
+        );
+        const inputListener = e => {
+          inputs.filter(i => i !== e.target)
+                .forEach(i => (i.required = !e.target.value.length));
+        };
 
-      inputs.forEach(i => i.addEventListener('input', inputListener));
+        inputs.forEach(i => i.addEventListener('input', inputListener));
+      }
     </script>
 </aside>

--- a/apcd-cms/src/apps/utils/apcd_database.py
+++ b/apcd-cms/src/apps/utils/apcd_database.py
@@ -272,7 +272,7 @@ def create_registration_entity(form, reg_id, iteration, from_update_reg=None):
         if iteration > 1:
             if not _acceptable_entity(form, iteration, reg_id if from_update_reg else None):
                 return
-            str_end = f'{reg_id}_{iteration}' if from_update_reg else iteration
+            str_end = f'{iteration}{ f"_{reg_id}" if from_update_reg else "" }'
             values = (
                 reg_id,
                 _set_int(form['total_claims_value_{}'.format(str_end)]),
@@ -284,7 +284,7 @@ def create_registration_entity(form, reg_id, iteration, from_update_reg=None):
                 _clean_value(form['fein_{}'.format(str_end)])
             )
         else:            
-            str_end = f'_{reg_id}_{iteration}' if from_update_reg else ''
+            str_end = f'_{iteration}_{reg_id}' if from_update_reg else ''
             values = (
                 reg_id,
                 _set_int(form[f'total_claims_value{str_end}']),
@@ -336,12 +336,12 @@ def update_registration_entity(form, reg_id, iteration, no_entities):
     values = ()
     try:
         if not _acceptable_entity(form, iteration, reg_id):
-            if iteration <= no_entities:
+            if iteration <= no_entities: # entity is not in form but was in original entity list -> need to delete
                 return delete_registration_entity(reg_id, form[f'ent_id_{iteration}'])
             return
-        if iteration > no_entities:
+        if iteration > no_entities: # contact is in form but not in original list -> need to create
             return create_registration_entity(form, reg_id, iteration, True)
-        str_end = f'{reg_id}_{iteration}'
+        str_end = f'{iteration}_{reg_id}'
         values = (
             _set_int(form['total_claims_value_{}'.format(str_end)]),
             _set_int(form['claims_encounters_volume_{}'.format(str_end)]),
@@ -459,7 +459,7 @@ def create_registration_contact(form, reg_id, iteration, from_update_reg=None):
         if iteration > 1:
             if not _acceptable_contact(form, iteration, reg_id if from_update_reg else None):
                 return
-            str_end = f'{reg_id}_{iteration}' if from_update_reg else iteration
+            str_end = f'{iteration}{ f"_{reg_id}" if from_update_reg else "" }'
             values = (
                 reg_id,
                 True if 'contact_notifications_{}'.format(str_end) in form else False,
@@ -469,7 +469,7 @@ def create_registration_contact(form, reg_id, iteration, from_update_reg=None):
                 _clean_email(form['contact_email_{}'.format(str_end)])
             )
         else:
-            str_end = f'_{reg_id}_{iteration}' if from_update_reg else ''
+            str_end = f'_{iteration}_{reg_id}' if from_update_reg else ''
             values = (
                 reg_id,
                 True if f'contact_notifications{str_end}' in form else False,
@@ -517,12 +517,12 @@ def update_registration_contact(form, reg_id, iteration, no_contacts):
     values = ()
     try:
         if not _acceptable_contact(form, iteration, reg_id):
-            if iteration < no_contacts: # contact is not in form but was in original contact list -> need to delete
+            if iteration <= no_contacts: # contact is not in form but was in original contact list -> need to delete
                 return delete_registration_contact(reg_id, form[f'cont_id_{iteration}'])
             return
         if iteration > no_contacts: # contact is in form but not in original list -> need to create
             return create_registration_contact(form, reg_id, iteration)
-        str_end = f'{reg_id}_{iteration}'
+        str_end = f'{iteration}_{reg_id}'
         values = (
             True if 'contact_notifications_{}'.format(str_end) in form else False,
             _clean_value(form['contact_type_{}'.format(str_end)]),
@@ -1098,7 +1098,7 @@ def get_all_exceptions():
             conn.close()
 
 def _acceptable_entity(form, iteration, reg_id=None):
-    str_end = f'{reg_id}_{iteration}' if reg_id else iteration
+    str_end = f'{iteration}{ f"_{reg_id}" if reg_id else "" }'
     required_keys = [
         'total_claims_value_{}'.format(str_end),
         'claims_encounters_volume_{}'.format(str_end),
@@ -1119,7 +1119,7 @@ def _acceptable_entity(form, iteration, reg_id=None):
 
 
 def _acceptable_contact(form, iteration, reg_id=None):
-    str_end = f'{reg_id}_{iteration}' if reg_id else iteration
+    str_end = f'{iteration}{ f"_{reg_id}" if reg_id else "" }'
     required_keys = [
         'contact_type_{}'.format(str_end),
         'contact_name_{}'.format(str_end),


### PR DESCRIPTION
## Overview
Addressed a few bugs that made writing registration entities and contacts work inconsistently
…

## Related

<!--
- [FP-123](https://jira.tacc.utexas.edu/browse/FP-123)
- requires https://github.com/TACC/Core-CMS/pull/117
-->…

## Changes
- Swapped `iteration` number and `reg_id` in relevant util db functions to match templates
- Set default `None` value for entity identifiers (at least one of three required at time of registration)
- In template scripts, added entity number to fix how entity blocks were being grabbed by input listener script
- In template body, added conditionality to `value` parameter for entity identifiers for edit modal (see above)
…

## Testing

1. Replace lines 67-69 in `apps/admin_regis_table/views.py` with the following:
   <details><summary>Snippet</summary>
     
          import datetime
          registrations_content = [
            (
                1,                                  #registration_id
                datetime.date(2022, 8, 3),          #posted_date
                12023,                              #applicable_period_start
                122023,                             #applicable_period_end
                True,                               #file_me
                False,                               #file_pv
                True,                               #file_mc
                True,                               #file_pc
                False,                              #file_dc
                True,                               #submitting_for_self
                'SFTP',                             #submission_method
                'received',                           #registration_status
                'insurance carrier',                #org_type
                'Golden Rule Insurance Company',    #business_name
                '7440 Woodland Drive',              #mail_address
                'Indianpolis',                      #city
                'IN',                               #state
                '46278     '                        #zip
            ),
            (
                2,                                  #registration_id
                datetime.date(2022, 8, 3),          #posted_date
                12023,                              #applicable_period_start
                122023,                             #applicable_period_end
                True,                               #file_me
                True,                               #file_pv
                True,                               #file_mc
                True,                               #file_pc
                False,                              #file_dc
                False,                               #submitting_for_self
                'SFTP',                             #submission_method
                'processing',                           #registration_status
                'pbm',                #org_type
                'Clay Tenant Insurance Company',    #business_name
                '440 Wood and Drive',              #mail_address
                'Indianapolis',                      #city
                'NY',                               #state
                '24444     '                        #zip
            ),
            (
                3,                                  #registration_id
                datetime.date(2022, 8, 3),          #posted_date
                12023,                              #applicable_period_start
                122023,                             #applicable_period_end
                True,                               #file_me
                True,                               #file_pv
                True,                               #file_mc
                True,                               #file_pc
                False,                              #file_dc
                True,                               #submitting_for_self
                'SFTP',                             #submission_method
                'complete',                        #registration_status
                'insurance carrier',                #org_type
                'Magenta Condition Insurance Company',    #business_name
                '742 Oddland Drive',              #mail_address
                'Indipolis',                      #city
                'MI',                               #state
                '62784     '                        #zip
            )
        ]
        registrations_entities = [
            (
                5, 1, 5, 46, 11111, None, 5, 'Garretts Test Business 2', '11-0001111'
            ),
            (
                5, 2, 50000, 47, 11010, 21101, 1, 'A Second Test Entity', '00-0000000'
            )
        ]
        registrations_contacts = [
            (
                52,
                1,
                False,
                'Test Role',
                'Garrett Test Tester',
                '2222222222',
                'notarealemail@emailplace.com'
            ),
            (
                53,
                1,
                False,
                'A 2nd Test Role',
                'Test Garrett 2 Test',
                '15555555555',
                'testemail@testemail.net'
            ),
            (
                54,
                2,
                True,
                'A 3rd and final test role',
                'Test 3rd Role Name Garrett',
                '0000000000',
                'email@gmail.com'
            )
          ]
        
    </details>
2. Open http://localhost:8000/administration/list-registration-requests/
3. On Edit Record action in the first row, ensure you can hit submit without any catches on entity fields (without making changes)
4. On same action, try adding at least one more entity and ensure checks on the three numerical identifier fields still works (FEIN, License, and NAIC, one must be filled out, try submitting without filling out any and see that it catches you)
5. <i>Nothing to test locally for ensuring writing entities & contacts to database is working correctly</i>

## UI

…

<!--
## Notes

…
-->
