### PR TITLE
remove sort script to fix broken list

### DIFF
--- a/apcd-cms/src/apps/view_users/templates/view_users.html
+++ b/apcd-cms/src/apps/view_users/templates/view_users.html
@@ -72,7 +72,7 @@ function filterTableByOrganization() {
   }
 }
 
-/***remove duplicates from dropdown */
+/* remove duplicates from dropdown */
 
 const options = []
 
@@ -80,8 +80,6 @@ document.querySelectorAll('#organizationFilter > option').forEach((option) => {
     if (options.includes(option.value)) option.remove()
     else options.push(option.value)
 })
-
-
 
 </script>
 

--- a/apcd-cms/src/apps/view_users/templates/view_users.html
+++ b/apcd-cms/src/apps/view_users/templates/view_users.html
@@ -74,41 +74,12 @@ function filterTableByOrganization() {
 
 /***remove duplicates from dropdown */
 
- const options = []
+const options = []
 
 document.querySelectorAll('#organizationFilter > option').forEach((option) => {
     if (options.includes(option.value)) option.remove()
     else options.push(option.value)
 })
-
-/*sorts dropdown list*/
-function sortlist()
-{
-    var cl = document.getElementById('organizationFilter');
-    var clTexts = new Array();
-
-    for(i = 1; i < cl.length; i++)
-    {
-        clTexts[i-1] =
-            cl.options[i].text.toUpperCase() + "," +
-            cl.options[i].text + "," +
-            cl.options[i].value;
-    }
-
-    clTexts.sort();
-
-    for(i = 1; i < cl.length; i++)
-    {
-        var parts = clTexts[i-1].split(',');
-        
-        cl.options[i].text = parts[1];
-        cl.options[i].value = parts[2];
-    }
-}
-
-sortlist();
-
-
 
 
 


### PR DESCRIPTION
## Overview

…Had a sort script to alphabetize dropdown which became redundant after SQL query fixed. Script also made list look wonky

## Related

<!--
- [FP-123](https://jira.tacc.utexas.edu/browse/FP-123)
- requires https://github.com/TACC/Core-CMS/pull/117
-->…

## Changes
Removed unneeded script
…

## Testing

1. Tested using fake data
2. user_content = [
            (
                6,
                4,
                'aw@heck.org',
                'Jon Heck',
                'UHC',
                'no create',
                'none update',
                'no notes',
                't',
                'submitter'

            ),
            (
                5,
                4,
                'aw@heck.org',
                'Jon Heck',
                't',
                'no create',
                'none update',
                'no notes',
                't',
                'submitter'

            ),
             (
                 5,
                 4,
                'aw@heck.org',
                'Jon Heck',
                'UHC',
                'no create',
                'none update',
                'no notes',
                't',
                'submitter'
            ),           
            
        ]


## UI

…Looks the same

<!--
## Notes

…Should work as before just without broken name list in dropdown
-->
