### PR TITLE
bug/FP-2005 Exception/Extension Forms - cited text numbering - UTH

### DIFF
--- a/apcd-cms/src/apps/exception/templates/exception_submission_form/exception_other_form.html
+++ b/apcd-cms/src/apps/exception/templates/exception_submission_form/exception_other_form.html
@@ -171,8 +171,8 @@
       <div class="o-section o-section--style-light">
         <hr />
         <small>
-          <sup>*</sup> Exceptions cannot be granted for periods longer than a year<br />
-          <sup>**</sup>Exceptions cannot be granted "from any requirement in insurance code Chapter 38"<br />
+          <sup>*</sup> Exceptions cannot be granted for periods longer than a year.<br />
+          <sup>**</sup>Exceptions cannot be granted "from any requirement in insurance code Chapter 38".<br />
         </small>
         <hr />
       </div>

--- a/apcd-cms/src/apps/exception/templates/exception_submission_form/exception_threshold_form.html
+++ b/apcd-cms/src/apps/exception/templates/exception_submission_form/exception_threshold_form.html
@@ -236,8 +236,8 @@
           <div class="o-section o-section--style-light">
             <hr />
             <small>
-              <sup>*</sup> Exceptions cannot be granted for periods longer than a year<br />
-              <sup>**</sup>Exceptions cannot be granted "from any requirement in insurance code Chapter 38"<br />
+              <sup>*</sup> Exceptions cannot be granted for periods longer than a year.<br />
+              <sup>**</sup>Exceptions cannot be granted "from any requirement in insurance code Chapter 38".<br />
             </small>
             <hr />
           </div>

--- a/apcd-cms/src/apps/extension/templates/extension_submission_form/extension_submission_form.html
+++ b/apcd-cms/src/apps/extension/templates/extension_submission_form/extension_submission_form.html
@@ -52,7 +52,7 @@
                 <div class="field-wrapper numberinput required" id="date-row">
                   <div class="field-errors" style="display: none"></div>
       
-                  <label for="applicable-data-period" name="date-row">Applicable Data Period<sup name="date-sup">3</sup></label><label name="extension-date-asterisk"><span class="asterisk">*</span></label>
+                  <label for="applicable-data-period" name="date-row">Applicable Data Period<sup name="date-sup">1</sup></label><label name="extension-date-asterisk"><span class="asterisk">*</span></label>
                   </label>
       
                   <input type="month" name="applicable-data-period" placeholder="YYYY/MM" class="numeric" inputmode="numeric" style="width:18ch"
@@ -64,7 +64,7 @@
                   <div class="field-wrapper numberinput required" id="date-row">
                     <div class="field-errors" style="display: none"></div>
       
-                    <label for="current-expected-date" name="date-row">Current Expected Date<sup>4</sup>
+                    <label for="current-expected-date" name="date-row">Current Expected Date<sup>2</sup>
                     </label><label name="extension-date-asterisk"><span class="asterisk">*</span></label>
       
                     <input type="date" name="current-expected-date" class="numeric" id="current-expected-date"
@@ -73,7 +73,7 @@
                   <div class="field-wrapper numberinput required" id="date-row">
                     <div class="field-errors" style="display: none"></div>
       
-                    <label for="request" name="date-row">Requested Target Date<sup>5</sup></label><label name="extension-date-asterisk"><span class="asterisk">*</span></label>
+                    <label for="request" name="date-row">Requested Target Date<sup>3</sup></label><label name="extension-date-asterisk"><span class="asterisk">*</span></label>
       
                     <input type="date" name="requested-target-date" class="numeric" id="requested-target-date"
                       inputmode="numeric" required />
@@ -229,7 +229,7 @@
             <div class="field-wrapper numberinput required" id="date-row">
               <div class="field-errors" style="display: none"></div>
 
-              <label for="applicable-data-period_${extension}" name="date-row">Applicable Data Period<sup>3</sup></label><label name="extension-date-asterisk"><span class="asterisk">*</span></label>
+              <label for="applicable-data-period_${extension}" name="date-row">Applicable Data Period<sup>1</sup></label><label name="extension-date-asterisk"><span class="asterisk">*</span></label>
               </label>
 
               <input type="month" name="applicable-data-period_${extension}" placeholder="YYYY/MM" class="numeric" inputmode="numeric" style="width:18ch"
@@ -241,7 +241,7 @@
             <div class="field-wrapper numberinput required" id="date-row">
               <div class="field-errors" style="display: none"></div>
 
-              <label for="current-expected-date_${extension}" name="date-row">Current Expected Date<sup>4</sup>
+              <label for="current-expected-date_${extension}" name="date-row">Current Expected Date<sup>2</sup>
               </label><label><span class="asterisk">*</span></label>
 
               <input type="date" name="current-expected-date_${extension}" class="numeric" id="current-expected-date_${extension}"
@@ -250,7 +250,7 @@
             <div class="field-wrapper numberinput required" id="date-row_${extension}">
               <div class="field-errors" style="display: none"></div>
 
-              <label for="requested-target-date_${extension}" name="date-row_${extension}">Requested Target Date<sup>5</sup></label><label name="extension-date-asterisk"><span class="asterisk">*</span></label>
+              <label for="requested-target-date_${extension}" name="date-row_${extension}">Requested Target Date<sup>3</sup></label><label name="extension-date-asterisk"><span class="asterisk">*</span></label>
 
               <input type="date" name="requested-target-date_${extension}" class="numeric" id="requested-target-date_${extension}"
                 inputmode="textinput" required />
@@ -302,11 +302,9 @@
     <hr />
     <p>
       <small
-        >¹ Federal Employer Identification Number (FEIN)<br />
-        ² National Association of Insurance Commissioners (NAIC)<br />
-        ³ Applicable data period – month/year in which claims data was adjudicated.<br />
-        ⁴ Current expected date – day/month/year in which applicable data was expected within the submission window.<br />
-        ⁵ Requested target date – requested day/month/year by which the data should be received (the extension date).<br />
+        >¹ Applicable data period – month/year in which claims data was adjudicated.<br />
+        ² Current expected date – day/month/year in which applicable data was expected within the submission window.<br />
+        ³ Requested target date – requested day/month/year by which the data should be received (the extension date).<br />
         </small
       >
     </p>


### PR DESCRIPTION
## Overview

UTHealth gave notes that subscripts were numbered 3, 4, 5 versus 1, 2, 3. Also, have extra notes at bottom of screen listed as 1 and 2 that need to be removed if not in use.

## Related

- [FP-2005](https://jira.tacc.utexas.edu/browse/FP-2005)


## Changes
For subscripts:

- Changed numbering 
- Removed unused subscripts
- Renumbered

## Testing

1. Put snippet on line 33 and 97 for exceptions/views.py <summary>Snippet <details>[ (2, 'TESTGOLD', 10000001, 'gmunoz1', 'CHCD'), (3, 'TESTGOLD', 10000002, 'gmunoz1', 'CHCD'), (1, 'TESTGOLD', 10000000, 'gmunoz1', 'CHCD') ]</details><summary>
2. Go to [http://localhost:8000/submissions/other-exception/](http://localhost:8000/submissions/other-exception/ ) and [http://localhost:8000/submissions/threshold-exception/](http://localhost:8000/submissions/threshold-exception/)
4. Make sure subscripts are renamed starting with * or ** and accurately describe the field it corresponds to
5. Using snippet above replace 24 for extensions/views.py
6. For each form, make sure the subscripts are numbered correctly. Make sure each corresponds to the correct fields on the form
7. Go to http://localhost:8000/submissions/extension-request/ and make sure there are only 3 subscripts and they match up to the correct field on the form.  


## UI

…

<!--
## Notes

…
-->
