### PR TITLE
Fixed link for data-submission page. APCD home was working correctly

### DIFF
--- a/apcd-cms/src/apps/exception/templates/exception_submission_form/exception_threshold_form.html
+++ b/apcd-cms/src/apps/exception/templates/exception_submission_form/exception_threshold_form.html
@@ -71,7 +71,7 @@
             <div id="exception_block_1">
               <h4>Requested Threshold Reduction</h4>
               <p>Please reference this <a
-                  href=https://sph.uth.edu/research/centers/chcd/apcd/techinical/TXPACD-Common_%20Data_Layout.pdf>data
+                  href=https://sph.uth.edu/research/centers/chcd/apcd/techinical/TXAPCD-Data_Submission_Guide.pdf>data
                   submission guide</a> to
                 find threshold field codes and minimum threshold percentages for your threshold reduction request.
 


### PR DESCRIPTION
## Overview

Fix data submission guide link on exception page. The APCD homepage link worked correctly

## Related

- [FP-2002](https://jira.tacc.utexas.edu/browse/FP-2002)


## Changes

Fixed link to go to the same page as in the Get Help page for the data submission guide.

## Testing

1. Put snippet on line 33 and 97 for exceptions/views.py <summary>Snippet <details>[ (2, 'TESTGOLD', 10000001, 'gmunoz1', 'CHCD'), (3, 'TESTGOLD', 10000002, 'gmunoz1', 'CHCD'), (1, 'TESTGOLD', 10000000, 'gmunoz1', 'CHCD') ]</details><summary>
2. Go to [http://localhost:8000/submissions/other-exception/](http://localhost:8000/submissions/other-exception/ ) and[http://localhost:8000/submissions/threshold-exception/](http://localhost:8000/submissions/threshold-exception/)
4. Make sure all links work on the threshold and other exception pages
5. Using snippet above replace line 24 for extensions/views.py
6. Go to http://localhost:8000/submissions/extension-request/ and make sure the links work.
7. Make sure all links work on the extension page


## UI

…

<!--
## Notes

…
-->
