### PR TITLE
changed column number to reflect change in table and show rolenames

### DIFF
--- a/apcd-cms/src/apps/view_users/views.py
+++ b/apcd-cms/src/apps/view_users/views.py
@@ -30,7 +30,7 @@ class ViewUsersTable(TemplateView):
                     'updated_at': usr[6],
                     'notes': usr[7],
                     'active': usr[8],
-                    'role_name': usr[9]
+                    'role_name': usr[10]
             }
 
         context['header'] = ['User ID', 'Email', 'Name', 'Organization', 'Role', 'Active', 'Created', 'Updated', 'Notes']


### PR DESCRIPTION
## Overview
Addition of 'user-number' to table led to column mismatch. in consultation with Carrie have created a fix to have table show role_names again

## Related

<!--
- [FP-123](https://jira.tacc.utexas.edu/browse/FP-123)
- requires https://github.com/TACC/Core-CMS/pull/117
-->…

## Changes
Changed  column number assigned to role_names from (9) to (10) as user_number was inserted before it.
…

## Testing

1. Can only test against database 

## UI

…

<!--
## Notes

…
-->
