### PR TITLE
bug/FP-1977: Remove scroll wheels from numeric input fields

### DIFF
--- a/apcd-cms/src/apps/registrations/static/registrations/css/submission_form.css
+++ b/apcd-cms/src/apps/registrations/static/registrations/css/submission_form.css
@@ -63,5 +63,4 @@ input[name^="contact_phone"] {
 input::-webkit-outer-spin-button,
 input::-webkit-inner-spin-button {
   -webkit-appearance: none;
-  margin: 0;
 }

--- a/apcd-cms/src/apps/registrations/static/registrations/css/submission_form.css
+++ b/apcd-cms/src/apps/registrations/static/registrations/css/submission_form.css
@@ -60,7 +60,6 @@ input[name^="contact_phone"] {
 /* Field Content */
 
 /* to remove 'scroll arrows' from numeric input fields */
-input::-webkit-outer-spin-button,
 input::-webkit-inner-spin-button {
   -webkit-appearance: none;
 }

--- a/apcd-cms/src/apps/registrations/static/registrations/css/submission_form.css
+++ b/apcd-cms/src/apps/registrations/static/registrations/css/submission_form.css
@@ -56,3 +56,12 @@ input[name^="contact_phone"] {
     /* NOTE: A span 2 seems like enough, but only span 3+ does the job */
     grid-row: span 3;
 }
+
+/* Field Content */
+
+/* to remove 'scroll arrows' from numeric input fields */
+input::-webkit-outer-spin-button,
+input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}


### PR DESCRIPTION
## Overview
…

## Related

- [FP-1977](https://jira.tacc.utexas.edu/browse/FP-1977)
<!--
- requires https://github.com/TACC/Core-CMS/pull/117
-->…

## Changes
- Added CSS for `input` to hide scroll arrows from browser
…

## Testing

1. Navigate to http://localhost:8000/register/request-to-submit/
2. Fill out all required fields prior to entity 'coverage estimates'
3. On each coverage estimate field, check that:
   - There are no arrows on the right side of the field
   - Step size is still enforced on the input (whole integers for the first two fields, step of 0.01 for last field)
4. Ensure form can be submitted successfully after all input validation met

## UI
Before:
![17294E13-9417-4BFE-AD97-A04F4B8B3C60_1_102_o](https://user-images.githubusercontent.com/43251554/226709413-ebcc637b-76e4-4061-8a53-23fbc5277f51.jpeg)

After:
![6DC720EB-C525-458A-88FF-E3EC29F90F88_1_102_o](https://user-images.githubusercontent.com/43251554/226709462-335250c0-84e6-4090-821e-3fc1f1607550.jpeg)


…

<!--
## Notes

…
-->
