### PR TITLE
task/FP-1985: Util function for checking inputs for whitespace only

### DIFF
--- a/apcd-cms/src/apps/registrations/templates/submission_form/registration_form_scripts.html
+++ b/apcd-cms/src/apps/registrations/templates/submission_form/registration_form_scripts.html
@@ -1,3 +1,5 @@
+{% load static %}
+
 <aside>
     {# To let user add and remove entities #}
     {# RFE: Do not duplicate entity markup #}
@@ -337,4 +339,6 @@
         inputs.forEach(i => i.addEventListener('input', inputListener));
       }
     </script>
+    {# To check for blank space only in text inputs #}
+    <script src="{% static 'utils/js/checkForBlankInputs.js' %}"></script> 
 </aside>

--- a/apcd-cms/src/apps/registrations/templates/submission_form/registration_form_scripts.html
+++ b/apcd-cms/src/apps/registrations/templates/submission_form/registration_form_scripts.html
@@ -1,6 +1,13 @@
 {% load static %}
 
 <aside>
+    {# To check for blank space only in text inputs #}
+    <script src="{% static 'utils/js/checkForBlankInputs.js' %}"></script>
+    {# Adds blank space listener to all text input fields on page load #}
+    <script>
+      const formTextInputs = document.querySelectorAll('input[type=text]');
+      noEmptyInputs(formTextInputs);
+    </script> 
     {# To let user add and remove entities #}
     {# RFE: Do not duplicate entity markup #}
     {# IDEA: HTML template for any instance; used by markup for 0, JS for 1+ #}
@@ -185,6 +192,10 @@
                 .forEach(i => (i.required = !e.target.value.length));
         };
         inputs.forEach(i => i.addEventListener('input', inputListener));
+
+        const addEntityNameInput = document.querySelectorAll(`input[name=entity_name_${entities}{% if r %}_{{r.reg_id}}{% endif %}]`);
+        noEmptyInputs(addEntityNameInput);
+
         btnStatus();
       });
 
@@ -310,6 +321,13 @@
               </div>
             </div>
         `;
+
+        const addContactTextInputs = document.querySelectorAll(`
+          input[name=contact_type_${contacts}{% if r %}_{{r.reg_id}}{% endif %}],
+          input[name=contact_name_${contacts}{% if r %}_{{r.reg_id}}{% endif %}]
+        `);
+        noEmptyInputs(addContactTextInputs);
+
         btnStatus();
       });
 
@@ -339,6 +357,4 @@
         inputs.forEach(i => i.addEventListener('input', inputListener));
       }
     </script>
-    {# To check for blank space only in text inputs #}
-    <script src="{% static 'utils/js/checkForBlankInputs.js' %}"></script> 
 </aside>

--- a/apcd-cms/src/apps/utils/static/utils/js/checkForBlankInputs.js
+++ b/apcd-cms/src/apps/utils/static/utils/js/checkForBlankInputs.js
@@ -1,0 +1,6 @@
+const formTextInputs = document.querySelectorAll('input[type=text]');
+formTextInputs.forEach(i => i.addEventListener('change', () => {
+    if (i.value.replace(/ /g, '') === '') { 
+      i.value = ''; // if input is all spaces, want to clear it out to leverage <input>'s required prop
+    }
+}))

--- a/apcd-cms/src/apps/utils/static/utils/js/checkForBlankInputs.js
+++ b/apcd-cms/src/apps/utils/static/utils/js/checkForBlankInputs.js
@@ -1,6 +1,7 @@
-const formTextInputs = document.querySelectorAll('input[type=text]');
-formTextInputs.forEach(i => i.addEventListener('change', () => {
-    if (i.value.replace(/ /g, '') === '') { 
-      i.value = ''; // if input is all spaces, want to clear it out to leverage <input>'s required prop
-    }
-}))
+function noEmptyInputs(inputArr) {
+  inputArr.forEach(i => i.addEventListener('change', () => {
+      if (i.value.replace(/ /g, '') === '') { 
+        i.value = ''; // if input is all spaces, want to clear it out to leverage <input>'s required prop
+      }
+  }))
+}

--- a/apcd-cms/src/taccsite_cms/custom_app_settings.py
+++ b/apcd-cms/src/taccsite_cms/custom_app_settings.py
@@ -1,4 +1,4 @@
-CUSTOM_APPS = ['apps.admin_regis_table', 'apps.apcd_login', 'apps.registrations', 'apps.submissions', 'apps.exception', 'apps.admin_submissions', 'apps.admin_extension', 'apps.admin_exception', 'apps.extension', 'apps.view_users', 'apps.components.paginator']
+CUSTOM_APPS = ['apps.admin_regis_table', 'apps.apcd_login', 'apps.registrations', 'apps.submissions', 'apps.exception', 'apps.admin_submissions', 'apps.admin_extension', 'apps.admin_exception', 'apps.extension', 'apps.view_users', 'apps.components.paginator', 'apps.utils']
 CUSTOM_MIDDLEWARE = []
-STATICFILES_DIRS = ('taccsite_custom/apcd-cms', 'apps/admin_regis_table', 'apps/submissions', 'apps/exception', 'apps/extension', 'apps/view_users', 'apps/components/paginator')
+STATICFILES_DIRS = ('taccsite_custom/apcd-cms', 'apps/admin_regis_table', 'apps/submissions', 'apps/exception', 'apps/extension', 'apps/view_users', 'apps/components/paginator', 'apps/utils')
 


### PR DESCRIPTION
## Overview
…

## Related

- [FP-1985](https://jira.tacc.utexas.edu/browse/FP-1985)
- [FP-1974](https://jira.tacc.utexas.edu/browse/FP-1974)
- [FP-1976](https://jira.tacc.utexas.edu/browse/FP-1976)
<!--
- requires https://github.com/TACC/Core-CMS/pull/117
-->…

## Changes
- Added `.js` script for checking an `<input>` for spaces only, and resetting said `<input>`'s value to nothing so the tag's `required` prop can catch it
- Registered `utils` as custom app for above JS script
- Implemented whitespace check on registration form
…

## Testing

1. Load http://localhost:8000/register/request-to-submit/
2. Fill out form as normal, but fill some text-only inputs with spaces, and try to submit form
3. Confirm form does not successfully submit, and instead redirects back to first field filled with spaces & that said field is now blank (ie with <i>no</i> spaces)
4. Continue trying to submit (depending on number of fields you filled with spaces only) to ensure form catches every instance
5. Now, add at least one additional entity and contact and test whitespace check as before.
6. Also, confirm that, if input with spaces in an additional contact/entity is caught, removing said entity/contact does not block form submission.
7. Confirm that, once all required fields are not whitespace, that form submits.

## UI

…

## Notes
This PR <i>only</i> addresses FP-1985; it contains code to be used in FP-1974 & FP-1976 (apologies for poorly-named branch)
…
