### PR TITLE
bug/FP 1974 and 1976 No Whitespace Input on Excp/Ext Forms

### DIFF
--- a/apcd-cms/src/apps/exception/templates/exception_submission_form/exception_other_form.html
+++ b/apcd-cms/src/apps/exception/templates/exception_submission_form/exception_other_form.html
@@ -141,6 +141,16 @@
 
       {# Scripts #}
       <aside>
+        <!--To check for blank space only in text inputs #}-->
+        <script src="{% static 'utils/js/checkForBlankInputs.js' %}"></script>
+        {# Adds blank space listener to all text input fields on page load #}
+        <script>
+          const formTextInputs = document.querySelectorAll('input[type=text');
+          const formTextAreaInputs = document.querySelectorAll('textarea');
+          noEmptyInputs(formTextInputs);
+          noEmptyInputs(formTextAreaInputs);
+          
+        </script> 
         <!-- To require exception is not longer than a year -->
         <script id="form-exception_length_less_than_year" type="module">
           $(function(){

--- a/apcd-cms/src/apps/exception/templates/exception_submission_form/exception_other_form.html
+++ b/apcd-cms/src/apps/exception/templates/exception_submission_form/exception_other_form.html
@@ -145,11 +145,8 @@
         <script src="{% static 'utils/js/checkForBlankInputs.js' %}"></script>
         {# Adds blank space listener to all text input fields on page load #}
         <script>
-          const formTextInputs = document.querySelectorAll('input[type=text');
-          const formTextAreaInputs = document.querySelectorAll('textarea');
-          noEmptyInputs(formTextInputs);
-          noEmptyInputs(formTextAreaInputs);
-          
+          const formTextInputs = document.querySelectorAll('input[type=text], textarea');
+          noEmptyInputs(formTextInputs);          
         </script> 
         <!-- To require exception is not longer than a year -->
         <script id="form-exception_length_less_than_year" type="module">

--- a/apcd-cms/src/apps/exception/templates/exception_submission_form/exception_threshold_form.html
+++ b/apcd-cms/src/apps/exception/templates/exception_submission_form/exception_threshold_form.html
@@ -214,10 +214,8 @@
           <script src="{% static 'utils/js/checkForBlankInputs.js' %}"></script>
           <!--Adds blank space listener to all text input fields on page load #-->
           <script>
-          const formTextInputs = document.querySelectorAll('input[type=text');
-          const formTextAreaInputs = document.querySelectorAll('textarea');
+          const formTextInputs = document.querySelectorAll('input[type=text], textarea');
           noEmptyInputs(formTextInputs);
-          noEmptyInputs(formTextAreaInputs);
           </script> 
           <!-- To require exception is not longer than a year -->
             <script id="form-exception_length_less_than_year" type="module">

--- a/apcd-cms/src/apps/exception/templates/exception_submission_form/exception_threshold_form.html
+++ b/apcd-cms/src/apps/exception/templates/exception_submission_form/exception_threshold_form.html
@@ -210,6 +210,15 @@
       {# Scripts #}
 
         <aside>
+          <!-- To check for blank space only in text inputs-->
+          <script src="{% static 'utils/js/checkForBlankInputs.js' %}"></script>
+          <!--Adds blank space listener to all text input fields on page load #-->
+          <script>
+          const formTextInputs = document.querySelectorAll('input[type=text');
+          const formTextAreaInputs = document.querySelectorAll('textarea');
+          noEmptyInputs(formTextInputs);
+          noEmptyInputs(formTextAreaInputs);
+          </script> 
           <!-- To require exception is not longer than a year -->
             <script id="form-exception_length_less_than_year" type="module">
               $(function(){

--- a/apcd-cms/src/apps/extension/templates/extension_submission_form/extension_submission_form.html
+++ b/apcd-cms/src/apps/extension/templates/extension_submission_form/extension_submission_form.html
@@ -200,8 +200,16 @@
       </aside>
 
       {# Scripts #}
-      {# WARNING: Many are cruft that created this now-static markup, but not all #}
       <aside>
+        <!-- To check for blank space only in text inputs-->
+        <script src="{% static 'utils/js/checkForBlankInputs.js' %}"></script>
+        <!--Adds blank space listener to all text input fields on page load #-->
+        <script>
+          const formTextInputs = document.querySelectorAll('input[type=text');
+          const formTextAreaInputs = document.querySelectorAll('textarea');
+          noEmptyInputs(formTextInputs);
+          noEmptyInputs(formTextAreaInputs);
+        </script> 
         <!-- To let user add and remove entities -->
         {# RFE: Do not duplicate entity markup #}
         {# IDEA: HTML template for any instance; used by markup for 0, JS for 1+ #}

--- a/apcd-cms/src/apps/extension/templates/extension_submission_form/extension_submission_form.html
+++ b/apcd-cms/src/apps/extension/templates/extension_submission_form/extension_submission_form.html
@@ -205,10 +205,8 @@
         <script src="{% static 'utils/js/checkForBlankInputs.js' %}"></script>
         <!--Adds blank space listener to all text input fields on page load #-->
         <script>
-          const formTextInputs = document.querySelectorAll('input[type=text');
-          const formTextAreaInputs = document.querySelectorAll('textarea');
+          const formTextInputs = document.querySelectorAll('input[type=text], textarea');
           noEmptyInputs(formTextInputs);
-          noEmptyInputs(formTextAreaInputs);
         </script> 
         <!-- To let user add and remove entities -->
         {# RFE: Do not duplicate entity markup #}


### PR DESCRIPTION
## Overview

To audit form fields to make sure they're not only whitespace submissions

## Related


- [FP-1974](https://jira.tacc.utexas.edu/browse/FP-1974)
 - [FP-1976](https://jira.tacc.utexas.edu/browse/FP-1976)

## Changes

- Used Garrett's script in the other-exception, threshold-exception and extension form template
- Used script on textareas as well so that if more textarea fields are added in the future (besides justification), it will check those as well

## Testing

1. In Exception/views.py add the following snippet to the line 105 and 37

<details>

submitters = [ (2, 'TESTGOLD', 10000001, 'gmunoz1', 'CHCD'), (3, 'TESTGOLD', 10000002, 'gmunoz1', 'CHCD'), (1, 'TESTGOLD', 10000000, 'gmunoz1', 'CHCD') ]
</details>

2. Go to  [http://localhost:8000/submissions/threshold-exception/](http://localhost:8000/submissions/threshold-exception/) and [http://localhost:8000/submissions/other-exception/](http://localhost:8000/submissions/other-exception/)
3. Make sure page looks submits correctly and does not allow whitespace only as input. 
4. In extension/views.py add the following snippet to the line 24

<details>

submitters = [ (2, 'TESTGOLD', 10000001, 'gmunoz1', 'CHCD'), (3, 'TESTGOLD', 10000002, 'gmunoz1', 'CHCD'), (1, 'TESTGOLD', 10000000, 'gmunoz1', 'CHCD') ]
</details>

5. Go to  [http://localhost:8000/submissions/extension-request/](http://localhost:8000/submissions/extension-request/) 
6. Make sure page looks submits correctly and does not allow whitespace only as input. 


## UI

…

<!--
## Notes

…
-->
