### PR TITLE
hotfix/extension-wording-fix

### DIFF
--- a/apcd-cms/src/apps/extension/templates/extension_submission_form/extension_submission_form.html
+++ b/apcd-cms/src/apps/extension/templates/extension_submission_form/extension_submission_form.html
@@ -38,7 +38,7 @@
               </label>
               <div class="field-errors" style="display: none"></div>
               <select name='extension-type' required='required' class="choicefield" id='extension-type'>
-                <option class="dropdown-text" value="regular">Regularly Scheduled Extension</option>
+                <option class="dropdown-text" value="regular">Regularly Scheduled Submission</option>
                 <option class="dropdown-text" value="resubmission">Corrected Resubmission</option>
                 <option class="dropdown-text" value="small_carrier">Small Carrier (Fewer Than 10,000 Lives Covered)
                 </option>
@@ -234,7 +234,7 @@
                 </label>
                 <div class="field-errors" style="display: none"></div>
                   <select name='extension-type_${extension}' required='required' class="choicefield" id='extension-type_${extension}'>
-                    <option class="dropdown-text" value="regular">Regularly Scheduled Extension</option>
+                    <option class="dropdown-text" value="regular">Regularly Scheduled Submission</option>
                     <option class="dropdown-text" value="resubmission">Corrected Resubmission</option>
                     <option class="dropdown-text" value="small_carrier">Small Carrier (Fewer Than 10,000 Lives Covered)</option>
                 </select>


### PR DESCRIPTION
## Overview

Update extension type select drop down.

## Related


## Changes

Update extension type select drop down to say "Regularly Scheduled Submission" rather than "Regularly 
Schedule Extension".

## Testing

1. On line 24, add the following snippet to replace submitters
`submitters = [ (2, 'TESTGOLD', 10000001, 'gmunoz1', 'CHCD'), (3, 'TESTGOLD', 10000002, 'gmunoz1', 'CHCD'), (1, 'TESTGOLD', 10000000, 'gmunoz1', 'CHCD') ]`
3. Make sure the extension type drop down reflects the wording change

## UI
![Screenshot 2023-04-10 at 1 37 04 PM](https://user-images.githubusercontent.com/96220951/230969514-c0a7e117-45fd-460e-8640-0d92505291dd.png)
