### PR TITLE
task/WP-19: VIew users filtering in view rather than in template

### DIFF
--- a/apcd-cms/src/apps/utils/utils.py
+++ b/apcd-cms/src/apps/utils/utils.py
@@ -11,6 +11,6 @@ def title_case(value):
 
 
 def table_filter(filter, table_data, filtered_category):
-    filtered_data = [row for row in table_data if row[filtered_category] == filter]
+    filtered_data = [row for row in table_data if row[filtered_category] == filter or filter in row[filtered_category]]
 
     return filtered_data

--- a/apcd-cms/src/apps/view_users/templates/view_users.html
+++ b/apcd-cms/src/apps/view_users/templates/view_users.html
@@ -18,9 +18,8 @@
     <div class="filter-content">
       <span><b>View Users by Organization: </b></span>
       <select id="organizationFilter" class="organization-filter" onchange="filterTableByOrganization()">
-        <option class="dropdown-text" value="">All</option>
-        {% for r in rows %}
-        <option class="dropdown-text">{{r.org_name}}</option>
+        {% for option in filter_options %}
+          <option class="dropdown-text" {% if option == selected_filter %}selected{% endif %}>{{ option }}</option>
         {% endfor %}
       </select>
     </div>
@@ -54,21 +53,14 @@
 <script>
 /*filters by organization with dropdown*/
 function filterTableByOrganization() {
-  var dropdown, filter, newinput, bestinput, table, tr, td, i;
+  var filter, xhr;
   input = document.getElementById("organizationFilter");
-  filter = input.value.replace("&", "&amp;").replace("(", "").replace(")","");
-  table = document.getElementById("usersTableBody");
-  tr = table.getElementsByTagName("tr");
-  for (i = 0; i < tr.length; i++) {
-    td = tr[i].getElementsByTagName("td")[2];
-    if (td) {
-      if (td.innerHTML.replace("(", "").replace(")","").search(filter) > -1) {
-        tr[i].style.display = "";
-      } else {
-        tr[i].style.display = "none";  
-      }
-    }  
-  }
+  filter = input.value.replace("&", encodeURIComponent('&'));
+  xhr = new XMLHttpRequest();
+  xhr.open('GET', `/administration/view-users/?filter=${filter}`);
+  xhr.send();
+  window.location.href = `/administration/view-users/?filter=${filter}`;
+  window.location.load();
 }
 
 /* remove duplicates from dropdown */

--- a/apcd-cms/src/apps/view_users/urls.py
+++ b/apcd-cms/src/apps/view_users/urls.py
@@ -1,4 +1,4 @@
-from django.urls import path, re_path
+from django.urls import path
 from apps.view_users.views import ViewUsersTable
 
 app_name = 'administration'

--- a/apcd-cms/src/apps/view_users/urls.py
+++ b/apcd-cms/src/apps/view_users/urls.py
@@ -4,5 +4,5 @@ from apps.view_users.views import ViewUsersTable
 app_name = 'administration'
 urlpatterns = [
     path('view-users/', ViewUsersTable.as_view()),
-    re_path(r'view-users/?filter=(?P<filter>[\w\ ]+)/', ViewUsersTable.as_view()),
+    path('view-users/<str:filter>/', ViewUsersTable.as_view())
 ]

--- a/apcd-cms/src/apps/view_users/urls.py
+++ b/apcd-cms/src/apps/view_users/urls.py
@@ -1,7 +1,8 @@
-from django.urls import path
+from django.urls import path, re_path
 from apps.view_users.views import ViewUsersTable
 
 app_name = 'administration'
 urlpatterns = [
     path('view-users/', ViewUsersTable.as_view()),
+    re_path(r'view-users/?filter=(?P<filter>[\w\ ]+)/', ViewUsersTable.as_view()),
 ]


### PR DESCRIPTION
## Overview
Moved view users data filtering to view to accommodate upcoming pagination on page
…

## Related

- [WP-19](https://jira.tacc.utexas.edu/browse/WP-19)
- [WP-10](https://jira.tacc.utexas.edu/browse/WP-10)
<!--

- requires https://github.com/TACC/Core-CMS/pull/117
-->…

## Changes
- Pared down filter function in template to grab selected filter and pass back to view via XML request
- Added new user object value to remove parentheses from organization names (replicate filter check already happening on this page)
- Filtering data in view based on url parameter passed from template
- Moved filter options to view for setting up dropdown option as currently selected filter
- Added url pattern to `view-users/urls.py` which accommodates filter url parameter
- Edited filter util function to check for filter substring in queried category data 
…

## Testing

1. Replace line 12 of `view_users/views.py` with the following:
   <details><summary>Snippet</summary>
     
         user_content = [
        (
            6,
            4,
            '[aw@heck.org](mailto:aw@heck.org)',
            'Jon Heck',
            'UHC & Nop',
            'no create',
            'none update',
            'no notes',
            'True',
            7,
            'submitter'
        ),
        (
            5,
            4,
            '[aw@heck.org](mailto:aw@heck.org)',
            'Alex Hamilton',
            't and (t)',
            'no create',
            'none update',
            'no notes',
            'True',
            8,
            'submitter',
        ),
        (
            5,
            4,
            '[aw@heck.org](mailto:aw@heck.org)',
            'Penny Ante',
            'UHC',
            'no create',
            'none update',
            'no notes',
            'True',
            10,
            'submitter'
        ),
        ]
        
    </details>
2. Load http://localhost:8000/administration/view-users/
3. Click through the options in the filter dropdown and ensure:
    - Page is reloaded on filter selection, and table only shows entries where the organization matches (or partially matches) the organization on the page
    - Filter dropdown shows the filter you selected as the default option
 

## UI

…

<!--
## Notes

…
-->
