### PR TITLE
task/WP-8: Add filtering and date-sorting to user's View Submissions

### DIFF
--- a/apcd-cms/src/apps/components/paginator/templates/paginator.html
+++ b/apcd-cms/src/apps/components/paginator/templates/paginator.html
@@ -7,7 +7,7 @@
         class="c-button c-button--as-link c-page-end"
         type="button"
         {% if page.has_previous %}
-            onclick="window.location.href='{% url pagination_url_namespaces %}{% if query_str %}{{ query_str }}{% else %}{% if selected_filter %}?filter={{selected_filter}}&{% else %}?{% endif %}{% endif %}page={{page.previous_page_number}}';"
+            onclick="window.location.href='{% url pagination_url_namespaces %}{% if query_str %}{{ query_str }}{% elif selected_filter %}?filter={{selected_filter}}&{% else %}?{% endif %}page={{page.previous_page_number}}';"
         {% else %}
             disabled
         {% endif %}
@@ -20,7 +20,7 @@
                 <button 
                 class="c-button c-button--secondary {% if page.number == i %}c-button--is-active{% endif %} c-button--size-small c-page-item c-page-link c-page-link--always-click"
                 type="button"
-                onclick="window.location.href='{% url pagination_url_namespaces %}{% if query_str %}{{ query_str }}{% else %}{% if selected_filter %}?filter={{selected_filter}}&{% else %}?{% endif %}{% endif %}page={{i}}';"
+                onclick="window.location.href='{% url pagination_url_namespaces %}{% if query_str %}{{ query_str }}{% elif selected_filter %}?filter={{selected_filter}}&{% else %}?{% endif %}page={{i}}';"
                 >
                     {{i}}
                 </button>
@@ -33,7 +33,7 @@
         class="c-button c-button--as-link c-page-end"
         type="button"
         {% if page.has_next %}
-            onclick="window.location.href='{% url pagination_url_namespaces %}{% if query_str %}{{ query_str }}{% else %}{% if selected_filter %}?filter={{selected_filter}}&{% else %}?{% endif %}{% endif %}page={{page.next_page_number}}';"
+            onclick="window.location.href='{% url pagination_url_namespaces %}{% if query_str %}{{ query_str }}{% elif selected_filter %}?filter={{selected_filter}}&{% else %}?{% endif %}page={{page.next_page_number}}';"
         {% else %}
             disabled
         {% endif %}

--- a/apcd-cms/src/apps/components/paginator/templates/paginator.html
+++ b/apcd-cms/src/apps/components/paginator/templates/paginator.html
@@ -7,7 +7,7 @@
         class="c-button c-button--as-link c-page-end"
         type="button"
         {% if page.has_previous %}
-            onclick="window.location.href='{% url pagination_url_namespaces %}{% if selected_filter %}?filter={{selected_filter}}&{% else %}?{% endif %}page={{page.previous_page_number}}';"
+            onclick="window.location.href='{% url pagination_url_namespaces %}{% if query_str %}{{ query_str }}{% else %}{% if selected_filter %}?filter={{selected_filter}}&{% else %}?{% endif %}{% endif %}page={{page.previous_page_number}}';"
         {% else %}
             disabled
         {% endif %}
@@ -20,7 +20,7 @@
                 <button 
                 class="c-button c-button--secondary {% if page.number == i %}c-button--is-active{% endif %} c-button--size-small c-page-item c-page-link c-page-link--always-click"
                 type="button"
-                onclick="window.location.href='{% url pagination_url_namespaces %}{% if selected_filter %}?filter={{selected_filter}}&{% else %}?{% endif %}page={{i}}';"
+                onclick="window.location.href='{% url pagination_url_namespaces %}{% if query_str %}{{ query_str }}{% else %}{% if selected_filter %}?filter={{selected_filter}}&{% else %}?{% endif %}{% endif %}page={{i}}';"
                 >
                     {{i}}
                 </button>
@@ -33,7 +33,7 @@
         class="c-button c-button--as-link c-page-end"
         type="button"
         {% if page.has_next %}
-            onclick="window.location.href='{% url pagination_url_namespaces %}{% if selected_filter %}?filter={{selected_filter}}&{% else %}?{% endif %}page={{page.next_page_number}}';"
+            onclick="window.location.href='{% url pagination_url_namespaces %}{% if query_str %}{{ query_str }}{% else %}{% if selected_filter %}?filter={{selected_filter}}&{% else %}?{% endif %}{% endif %}page={{page.next_page_number}}';"
         {% else %}
             disabled
         {% endif %}

--- a/apcd-cms/src/apps/submissions/templates/list_submissions.html
+++ b/apcd-cms/src/apps/submissions/templates/list_submissions.html
@@ -25,7 +25,7 @@
       </select>
       <span><b>Sort by: </b></span>
       <select id="dateSort" class="status-filter" onchange="sortByDate()">
-        <option class="dropdown-text" {% if not selected_sort %}selected{% endif %} disabled hidden>-- --</option>
+        <option class="dropdown-text" {% if not selected_sort %}selected{% else %}hidden{% endif %} disabled> </option>
         {% for option, display_text in sort_options.items %}
           <option class="dropdown-text" value={{option}} {% if option == selected_sort %}selected{% endif %}>{{ display_text }}</option>
         {% endfor %}

--- a/apcd-cms/src/apps/submissions/templates/list_submissions.html
+++ b/apcd-cms/src/apps/submissions/templates/list_submissions.html
@@ -5,6 +5,7 @@
 
 <link rel="stylesheet" href="{% static 'submissions/css/table.css' %}">
 <link rel="stylesheet" href="{% static 'submissions/css/modal.css' %}">
+<link rel="stylesheet" href="{% static 'admin_regis_table/css/table.css' %}">
 <link rel="stylesheet" href="{% static 'admin_regis_table/css/core-styles.c-form.css' %}">
 
 <div class="container">
@@ -14,6 +15,27 @@
   <hr />
   <p style="margin-bottom: 30px">A list of submissions by a user</p>
   <hr />
+  <div class="filter-container">
+    <div class="filter-content">
+      <span><b>Filter by Status: </b></span>
+      <select id="statusFilter" class="status-filter" onchange="filterTableByStatus()">
+        {% for option in filter_options %}
+          <option class="dropdown-text" {% if option == selected_filter %}selected{% endif %}>{{ option }}</option>
+        {% endfor %}
+      </select>
+      <span><b>Sort by: </b></span>
+      <select id="dateSort" class="status-filter" onchange="sortByDate()">
+        <option class="dropdown-text" {% if not selected_sort %}selected{% endif %} disabled hidden>-- --</option>
+        {% for option, display_text in sort_options.items %}
+          <option class="dropdown-text" value={{option}} {% if option == selected_sort %}selected{% endif %}>{{ display_text }}</option>
+        {% endfor %}
+      </select>
+      {% if selected_filter or selected_sort %}
+        <button onclick="clearSelections()">Clear Options</button>
+      {% endif %}
+    </div>
+  </div>
+
   <table id="submissionTable" class="submission-table">
       <thead>
           <tr>
@@ -41,4 +63,44 @@
 
   {% include 'paginator.html' %}
 </div>
+<script>
+    function filterTableByStatus() {
+        var filterDropdown, filterValue, url_params, url, xhr;
+        filterDropdown = document.getElementById("statusFilter");
+        filterValue =  filterDropdown.value;
+        url_params = `?filter=${filterValue}`;
+        {% if selected_sort %}
+            url_params = `?filter=${filterValue}&sort={{selected_sort}}`;
+        {% endif %}
+        url = `/submissions/list-submissions/${url_params}`;
+        xhr = new XMLHttpRequest();
+        xhr.open('GET', url);
+        xhr.send();
+        window.location.href = url;
+        window.location.load();
+    }
+    function sortByDate() {
+        var sortDropdown, sortValue, url_params, url, xhr;
+        sortDropdown = document.getElementById('dateSort');
+        sortValue =  sortDropdown.value;
+        url_params = `?sort=${sortValue}`;
+        {% if selected_filter %}
+            url_params = `?filter={{selected_filter}}&sort=${sortValue}`;
+        {% endif %}
+        url = `/submissions/list-submissions/${url_params}`;
+        xhr = new XMLHttpRequest();
+        xhr.open('GET', url);
+        xhr.send();
+        window.location.href = url;
+        window.location.load();
+    }
+    function clearSelections() {
+        var xhr;
+        xhr = new XMLHttpRequest();
+        xhr.open('GET', '/submissions/list-submissions/')
+        xhr.send()
+        window.location.href = '/submissions/list-submissions/';
+        window.location.load();
+    }
+</script>  
 {% endblock %}

--- a/apcd-cms/src/apps/submissions/urls.py
+++ b/apcd-cms/src/apps/submissions/urls.py
@@ -4,5 +4,8 @@ from apps.submissions.views import SubmissionsTable, check_submitter_role
 app_name = 'submissions'
 urlpatterns = [
     path('list-submissions/', SubmissionsTable.as_view(), name="list_submissions"),
+    path(r'list-submissions/?filter=(?P<filter>)/', SubmissionsTable.as_view(), name="list_submissions"),
+    path(r'list-submissions/?sort=(?P<sort>)/', SubmissionsTable.as_view(), name="list_submissions"),
+    path(r'list-submissions/?filter=(?P<filter>)&sort=(?P<sort>)/', SubmissionsTable.as_view(), name="list_submissions"),
     path('check-submitter-role/', check_submitter_role),
 ]

--- a/apcd-cms/src/apps/submissions/views.py
+++ b/apcd-cms/src/apps/submissions/views.py
@@ -33,7 +33,7 @@ class SubmissionsTable(TemplateView):
 
         def getDate(row):
             date = row['received_timestamp']
-            return parser.parse(date) if date is not None else parser.parse('1-1')
+            return parser.parse(date) if date is not None else parser.parse('1-1-3005') # put 'None' date entries all together at top/bottom depending on direction of sort
 
         if dateSort is not None:
             context['selected_sort'] = dateSort
@@ -67,13 +67,13 @@ class SubmissionsTable(TemplateView):
 
         context['header'] = ['Received', 'File Name', ' ', 'Outcome', 'Status', 'Last Updated', 'Actions']
         context['filter_options'] = ['All', 'In Process', 'Complete']
-        context['sort_options'] = {'newDate': 'Newest', 'oldDate': 'Oldest'}
+        context['sort_options'] = {'newDate': 'Newest Received', 'oldDate': 'Oldest Received'}
 
         queryStr = '?'
         if len(self.request.META['QUERY_STRING']) > 0:
             queryStr = queryStr + self.request.META['QUERY_STRING'].replace(f'page={page_num}', '') + ('&' if self.request.GET.get('page') is None else '')
         context['query_str'] = queryStr
-        context.update(paginator(self.request, submission_content))
+        context.update(paginator(self.request, submission_content, limit))
         context['pagination_url_namespaces'] = 'submissions:list_submissions'
 
         return context

--- a/apcd-cms/src/apps/utils/utils.py
+++ b/apcd-cms/src/apps/utils/utils.py
@@ -11,6 +11,13 @@ def title_case(value):
 
 
 def table_filter(filter, table_data, filtered_category):
-    filtered_data = [row for row in table_data if row[filtered_category] == filter or filter in row[filtered_category]]
+    filtered_data = []
+    formatted_filter = filter.lower()
+    for row in table_data:
+        if row[filtered_category] is None:
+            continue
+        formatted_value = row[filtered_category].lower()
+        if formatted_value == formatted_filter or formatted_filter in formatted_value:
+            filtered_data.append(row)
 
     return filtered_data


### PR DESCRIPTION
## Overview
Added filtering by submission status and sorting by date to the user submissions page.
…

## Related

- [WP-8](https://jira.tacc.utexas.edu/browse/WP-8)
<!--
- requires https://github.com/TACC/Core-CMS/pull/117
-->…

## Changes
- Added dropdown elements for filter and sort on page's template
- Added JS scripts on template to pass selected filter and/or sort to page's view
- Added sort and filter capability to view to modify data from url parameters
- Added needed url patterns to accommodate both url parameters
- Added check to paginator to look for this component's query string 
…

## Testing

1. Replace line 29 of `submissions/views.py` with the following:
   <details><summary>Snippet</summary>
     
        submission_content = [
        {
            'submission_id': None,
            'submitter_id': None,
            'file_name': None,
            'status': None,
            'outcome': None,
            'received_timestamp': None,
            'updated_at': None,
            'view_modal_content': None
        },
        {
            'submission_id': 2,
            'submitter_id': 1,
            'file_name': 'T_GLDNRLE_10000000_202303_202303.zip',
            'status': None,
            'outcome': 'failed',
            'received_timestamp': '2022-09-27T15:25:24.285442',
            'updated_at': '2022-09-27T15:25:24.285442',
            'view_modal_content': [
                {
                    'log_id': 3, 
                    'submission_id': 1, 
                    'file_type': 'ME', 
                    'validation_suite': 'eligibility_suite', 
                    'outcome': 'failed', 
                    'file_type_name': 'Member Eligibility'
                }
            ]
        },
        {
            'submission_id': 3,
            'submitter_id': 1,
            'file_name': 'T_GLDNRLE_10000000_202303_202303.zip',
            'status': 'complete',
            'outcome': 'failed',
            'received_timestamp': '2022-09-27T15:25:24.285442',
            'updated_at': '2022-09-27T15:25:24.285442',
            'view_modal_content': [
                {
                    'log_id': 5, 
                    'submission_id': 1, 
                    'file_type': 'PV', 
                    'validation_suite': 'provider_suite', 
                    'outcome': 'failed', 
                    'file_type_name': 'Provider'
                }
            ]
        },
        {
            'submission_id': 4,
            'submitter_id': 1,
            'file_name': 'T_GLDNRLE_10000000_202303_202303.zip',
            'status': 'complete',
            'outcome': 'failed',
            'received_timestamp': '2022-09-27T15:25:24.285442',
            'updated_at': '2022-09-27T15:25:24.285442',
            'view_modal_content': [
                {
                    'log_id': 2, 
                    'submission_id': 1, 
                    'file_type': '  ', 
                    'validation_suite': 'spark_medical_suite', 
                    'outcome': 'failed', 
                    'file_type_name': None
                }, 
                {
                    'log_id': 5, 
                    'submission_id': 1, 
                    'file_type': 'PV', 
                    'validation_suite': 'provider_suite', 
                    'outcome': 'failed', 
                    'file_type_name': 'Provider'
                }
            ]
        },
        {
            'submission_id': 5,
            'submitter_id': 1,
            'file_name': 'T_GLDNRLE_10000000_202303_202303.zip',
            'status': 'complete',
            'outcome': 'failed',
            'received_timestamp': '2022-11-27T15:25:24.285442',
            'updated_at': '2022-09-27T15:25:24.285442',
            'view_modal_content': [
                {
                    'log_id': 3, 
                    'submission_id': 1, 
                    'file_type': 'ME', 
                    'validation_suite': 'eligibility_suite', 
                    'outcome': 'failed', 
                    'file_type_name': 'Member Eligibility'
                }, 
                {
                    'log_id': 5, 
                    'submission_id': 1, 
                    'file_type': 'PV', 
                    'validation_suite': 'provider_suite', 
                    'outcome': 'failed', 
                    'file_type_name': 'Provider'
                }
            ]
        },
        {
            'submission_id': 6,
            'submitter_id': 1,
            'file_name': 'T_GLDNRLE_10000000_202303_202303.zip',
            'status': 'complete',
            'outcome': 'failed',
            'received_timestamp': '2012-09-27T15:25:24.285442',
            'updated_at': '2022-09-27T15:25:24.285442',
            'view_modal_content': [
                {
                    'log_id': 3, 
                    'submission_id': 1, 
                    'file_type': 'ME', 
                    'validation_suite': 'eligibility_suite', 
                    'outcome': 'failed', 
                    'file_type_name': 'Member Eligibility'
                }, 
                {
                    'log_id': 4, 
                    'submission_id': 1, 
                    'file_type': 'PC', 
                    'validation_suite': 'pharmacy_suite', 
                    'outcome': 'failed', 
                    'file_type_name': 'Pharmacy Claims'
                }
            ]
        },
        {
            'submission_id': 7,
            'submitter_id': 1,
            'file_name': 'T_GLDNRLE_10000000_202303_202303.zip',
            'status': 'complete',
            'outcome': 'failed',
            'received_timestamp': '2022-07-27T15:25:24.285442',
            'updated_at': '2022-09-27T15:25:24.285442',
            'view_modal_content': [
                {
                    'log_id': 3, 
                    'submission_id': 1, 
                    'file_type': 'ME', 
                    'validation_suite': 'eligibility_suite', 
                    'outcome': 'failed', 
                    'file_type_name': 'Member Eligibility'
                }
            ]
        },
        {
            'submission_id': 8,
            'submitter_id': 1,
            'file_name': 'T_GLDNRLE_10000000_202303_202303.zip',
            'status': 'complete',
            'outcome': 'failed',
            'received_timestamp': '2022-08-27T15:25:24.285442',
            'updated_at': '2022-09-27T15:25:24.285442',
            'view_modal_content': [
                {
                    'log_id': 3, 
                    'submission_id': 1, 
                    'file_type': 'ME', 
                    'validation_suite': 'eligibility_suite', 
                    'outcome': 'failed', 
                    'file_type_name': 'Member Eligibility'
                }, 
                {
                    'log_id': 4, 
                    'submission_id': 1, 
                    'file_type': 'PC', 
                    'validation_suite': 'pharmacy_suite', 
                    'outcome': 'failed', 
                    'file_type_name': 'Pharmacy Claims'
                }
            ]
        }
        ]  

        
    </details>
2. Test filter and sort separately for:
 - Accuracy: does the selected filter/sort show in the table?
 - Dropdown text: does the selected filter/sort show on the dropdown on page load?
 - Compatibility with paginator: does filter/sort persist when clicking through pages? (Change page size on lines 212 and 253)
3. After testing each, test that the 'Clear Options' button resets the table back to original state
4. Now, test the filter and sort together for the same items above.

## UI

…

<!--
## Notes
Performing this task showed that, with adding more request params to the url, that for future maintainability, the order in which these params are provided in the url will need to change with page # always being first. Follow up task will be done for this and other pages using the paginator component.
…
-->
