### PR TITLE
Fix: Add clear filter button if filter is selected on View Users page

### DIFF
--- a/apcd-cms/src/apps/view_users/templates/view_users.html
+++ b/apcd-cms/src/apps/view_users/templates/view_users.html
@@ -22,6 +22,9 @@
           <option class="dropdown-text" {% if option == selected_filter %}selected{% endif %}>{{ option }}</option>
         {% endfor %}
       </select>
+      {% if selected_filter %}
+        <button onclick="clearSelections()">Clear Filter</button>
+      {% endif %}
     </div>
   </div>
   <table id="usersTable" class="users-table sortable"><table class="o-fixed-header-table o-table-wrap--flexible-horz users-table">
@@ -62,6 +65,14 @@ function filterTableByOrganization() {
   xhr.send();
   window.location.href = `/administration/view-users/?filter=${filter}`;
   window.location.load();
+}
+function clearSelections() {
+        var xhr;
+        xhr = new XMLHttpRequest();
+        xhr.open('GET', '/administration/view-users/')
+        xhr.send()
+        window.location.href = '/administration/view-users/';
+        window.location.load();
 }
 
 /* remove duplicates from dropdown */


### PR DESCRIPTION
## Overview
Added button to redirect to main page with selected filter
…

## Related

<!--
- [FP-123](https://jira.tacc.utexas.edu/browse/FP-123)
- requires https://github.com/TACC/Core-CMS/pull/117
-->…

## Changes
- Added button to template which appears if context var for filter is populated
- Added script which redirects to /administration/view-users if clear button is clicked
…

## Testing

1. Replace line 13 of `view_users/views.py` with the following:
   <details><summary>Snippet</summary>
     
         user_content = [
        (
            6,
            4,
            '[aw@heck.org](mailto:aw@heck.org)',
            'Jon Heck',
            'UHC & Nop',
            'no create',
            'none update',
            'no notes',
            'True',
            7,
            'submitter'
        ),
        (
            5,
            4,
            '[aw@heck.org](mailto:aw@heck.org)',
            'Alex Hamilton',
            't and (t)',
            'no create',
            'none update',
            'no notes',
            'True',
            8,
            'submitter',
        ),
        (
            5,
            4,
            '[aw@heck.org](mailto:aw@heck.org)',
            'Penny Ante',
            'UHC',
            'no create',
            'none update',
            'no notes',
            'True',
            10,
            'submitter'
        ),
        ]
        
    </details>
2. Load http://localhost:8000/administration/view-users/
3. Click on a filter option in dropdown
4. After page reload, click 'Clear Filter' button and ensure redirect back to page with no filter applied

## UI

…

<!--
## Notes

…
-->
