### PR TITLE
Fix: View users org dropdown not consistently populating with selected organization

### DIFF
--- a/apcd-cms/src/apps/view_users/templates/view_users.html
+++ b/apcd-cms/src/apps/view_users/templates/view_users.html
@@ -63,15 +63,6 @@ function filterTableByOrganization() {
   window.location.href = `/administration/view-users/?filter=${filter}`;
   window.location.load();
 }
-
-/* remove duplicates from dropdown */
-
-const options = []
-
-document.querySelectorAll('#organizationFilter > option').forEach((option) => {
-    if (options.includes(option.value)) option.remove()
-    else options.push(option.value)
-})
 </script>
 
 {% endblock %}

--- a/apcd-cms/src/apps/view_users/views.py
+++ b/apcd-cms/src/apps/view_users/views.py
@@ -5,7 +5,6 @@ from apps.utils.apcd_groups import is_apcd_admin
 from apps.utils.utils import table_filter
 from apps.components.paginator.paginator import paginator
 import logging
-import datetime
 
 logger = logging.getLogger(__name__)
 

--- a/apcd-cms/src/apps/view_users/views.py
+++ b/apcd-cms/src/apps/view_users/views.py
@@ -5,6 +5,7 @@ from apps.utils.apcd_groups import is_apcd_admin
 from apps.utils.utils import table_filter
 from apps.components.paginator.paginator import paginator
 import logging
+import datetime
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +43,9 @@ class ViewUsersTable(TemplateView):
         table_entries = []
         for user in user_content:
             table_entries.append(_set_user(user,))
-            context['filter_options'].append(user[4])
+            org_name = user[4]
+            if org_name not in context['filter_options']:  # prevent duplicates
+                context['filter_options'].append(user[4])
 
         filter = self.request.GET.get('filter')
 
@@ -53,5 +56,5 @@ class ViewUsersTable(TemplateView):
 
         context.update(paginator(self.request, table_entries))
         context['pagination_url_namespaces'] = 'administration:view_users'
-        
+
         return context


### PR DESCRIPTION
## Overview

…

## Related

<!--
- [FP-123](https://jira.tacc.utexas.edu/browse/FP-123)
- requires https://github.com/TACC/Core-CMS/pull/117
-->…

## Changes
- Instead of removing duplicates in the filter dropdown in the template, now preventing duplicates in the list which populates said dropdown in the page's view
…

## Testing

1. Replace line 12 of `view_users/views.py` with the following:
   <details><summary>Snippet</summary>
     
         user_content = [
        (
            6,
            4,
            '[aw@heck.org](mailto:aw@heck.org)',
            'Jon Heck',
            'UHC & Nop',
            'no create',
            'none update',
            'no notes',
            'True',
            7,
            'submitter'
        ),
        (
            6,
            4,
            '[aw@snow.org](mailto:aw@heck.org)',
            'Jon Snow',
            'UHC & Nop',
            'no create',
            'none update',
            'no notes',
            'True',
            11,
            'submitter'
        ),
        (
            5,
            4,
            '[aw@heck.org](mailto:aw@heck.org)',
            'Alex Hamilton',
            't and (t)',
            'no create',
            'none update',
            'no notes',
            'True',
            8,
            'submitter',
        ),
        (
            5,
            4,
            '[aw@heck.org](mailto:aw@heck.org)',
            'Penny Ante',
            'UHC',
            'no create',
            'none update',
            'no notes',
            'True',
            10,
            'submitter'
        ),
        ]
        
    </details>
2. Load http://localhost:8000/administration/view-users/
3. Click through the options in the filter dropdown and ensure, on page reload:
   - Correct entries are shown in table based on filter chosen
   - Chosen filter shows on dropdown

## UI

…


## Notes
From Slack: "<i>Found the bug - duplicates in the dropdown were being handled in the template, so when an org with multiple table entries was chosen, multiple <option> elements were created with the selected prop, and then all but one would be subsequently removed - as this isn't a multi-select-enabled element, just the last option would actually be shown in the dropdown, but just the first of the duplicates was kept in the list, so it wasn't shown.</i>"
<!--…
-->
