### PR TITLE
Fix: Syntax error in registration entities util function

### DIFF
--- a/apcd-cms/src/apps/utils/apcd_database.py
+++ b/apcd-cms/src/apps/utils/apcd_database.py
@@ -245,7 +245,7 @@ def get_registration_entities(reg_id=None):
                 registration_entities.file_pv,
                 registration_entities.file_mc,
                 registration_entities.file_pc,
-                registration_entities.file_dc,
+                registration_entities.file_dc
                 FROM registration_entities {f"WHERE registration_id =  {str(reg_id)}" if reg_id is not None else ''}"""
         cur = conn.cursor()
         cur.execute(query)


### PR DESCRIPTION
## Overview

…

## Related

<!--
- [FP-123](https://jira.tacc.utexas.edu/browse/FP-123)
- requires https://github.com/TACC/Core-CMS/pull/117
-->…

## Changes
- Removed trailing comma before FROM in SELECT command for registration entities
…

## Testing

1. Nothing to test locally; I tested the current query + the fixed query on QA machine with database and replicated the error and confirmed this fix resolves the issue.

## UI

…

<!--
## Notes

…
-->
