### PR TITLE
fix: Add correct codes for org type to reg form template

### DIFF
--- a/apcd-cms/src/apps/registrations/templates/submission_form/registration_form_body.html
+++ b/apcd-cms/src/apps/registrations/templates/submission_form/registration_form_body.html
@@ -74,13 +74,11 @@
                 </option>
                 {% endfor %}
             {% else %}
-            <option value="Insurance Carrier">Insurance Carrier</option>
-
-                <option value="Plan Administrator">
+                <option value="carrier">Insurance Carrier</option>
+                <option value="tpa_aso">
                     Plan Administrator¹ (TPA/ASO)
                 </option>
-
-                <option value="PBM">
+                <option value="pbm">
                     Pharmacy Benefit Manager (PBM)
                 </option>
             {% endif %}


### PR DESCRIPTION
## Overview

…

## Related

<!--
- [FP-123](https://jira.tacc.utexas.edu/browse/FP-123)
- requires https://github.com/TACC/Core-CMS/pull/117
-->…

## Changes
- On registration form (for new registration, not edit), modified values of `option` elements to match codes from standard codes table
…

## Testing

1. Nothing to test locally; confirmed on QA and standard codes table that these codes are correct

## UI

…

<!--
## Notes

…
-->
