### PR TITLE
fix: Registration listing - dates incorrectly parsed

### DIFF
--- a/apcd-cms/src/apps/admin_regis_table/views.py
+++ b/apcd-cms/src/apps/admin_regis_table/views.py
@@ -226,7 +226,7 @@ class RegistrationsTable(TemplateView):
 
         def getDate(row):
             date = row[1]
-            return parser.parse(date) if date is not None else parser.parse('1-1-0001')  # put 'None' date entries all together at end of listing
+            return date if date is not None else parser.parse('1-1-0001')  # put 'None' date entries all together at end of listing
 
         registrations_content = sorted(registrations_content, key=lambda row:getDate(row), reverse=True)  # sort registrations by newest to oldest
 
@@ -237,7 +237,7 @@ class RegistrationsTable(TemplateView):
             registration_table_entries.append(_set_registration(registration, associated_entities, associated_contacts))
             org_name = registration[7]
             if org_name not in context['org_options']:
-                context['org_options'].append(org_name)            
+                context['org_options'].append(org_name)
 
         status_filter = self.request.GET.get('status')
         org_filter = self.request.GET.get('org')


### PR DESCRIPTION
## Overview

…

## Related

<!--
- [FP-123](https://jira.tacc.utexas.edu/browse/FP-123)
- requires https://github.com/TACC/Core-CMS/pull/117
-->…

## Changes
- Removed `dateutil parser.parse` function from date processing from database
…

## Testing

1. Replace lines 70-72 in `apps/admin_regis_table/views.py` with the following:
   <details><summary>Snippet</summary>
     
          import datetime
          registrations_content = [
            (76, datetime.date(2022, 10, 24), 202210, 202302, True, 'complete', 'carrier', 'GlobalHealth of Texas, Inc.', '210 Park Avenue, Suite 2800', 'Oklahoma City', 'OK', '73102     '),
            (77, datetime.date(2022, 10, 24), 202210, 202302, True, 'complete', 'carrier', 'Golden Rule Insurance Company', '7440 Woodland Drive', 'Indianapolis', 'IN', '46278     '),
            (78, datetime.date(2022, 10, 24), 202210, 202302, True, 'complete', 'carrier', 'Molina Healthcare of Texas', '1660 Westridge Circle North', 'Irving', 'TX', '75038     '),
            (86, datetime.date(2022, 11, 1), 202210, 202302, False, 'complete', 'pbm', 'CVS-PBM Part 1', '151 Farmington Avenue, RC61', 'Hartford', 'CT', '06156     '),
            (87, datetime.date(2022, 11, 1), 202210, 202302, False, 'complete', 'pbm', 'CVS-PBM Part 2', '151 Farmington Avenue, RC61', 'Hartford', 'CT', '06156     '),
            (88, datetime.date(2022, 11, 1), 202210, 202302, False, 'complete', 'pbm', 'CVS-PBM Part 3', '151 Farmington Avenue, RC61', 'Hartford', 'CT', '06156     '),
            (104, datetime.date(2022, 11, 10), 202210, 202302, True, 'complete', 'carrier', 'Cigna Health and Life Insurance Company', '900 Cottage Grove Road', 'Bloomfield', 'CT', '06002     '),
            (105, datetime.date(2022, 11, 10), 202210, 202302, False, 'processing', 'carrier', 'Baylor Scott and White Health Plan', '1206 West Campus Drive', 'Temple', 'TX', '76502     '),
            (106, datetime.date(2022, 11, 10), 202210, 202302, True, 'complete', 'carrier', 'Sendero Health Plans', '2028 E. Ben White Boulevard, Suite 400', 'Austin', 'TX', '78741     '),
            (107, datetime.date(2022, 11, 10), 202210, 202302, False, 'processing', 'carrier', 'Crum & Forster', '5 Christopher Way, 2nd Floor', 'Eatontown', 'NJ', '07724     '),
            (108, datetime.date(2022, 11, 10), 202210, 202302, True, 'complete', 'carrier', 'Integon National Insurance Company', '1515 North Rivercenter Drive, Suite 135', 'Milwaukee', 'WI', '53212     '),
            (110, datetime.date(2022, 11, 11), 202210, 202302, True, 'complete', 'tpa_aso', 'OptumHealth Care Solutions, Inc.', '11000 Optum Circle', 'Eden Prairie', 'MN', '55344     '),
            (112, datetime.date(2022, 11, 11), 202210, 202302, True, 'complete', 'carrier', 'National Health Insurance Company', '1515 North Rivercenter Drive, Suite 135', 'Milwaukee', 'WI', '53212     '),
            (114, datetime.date(2022, 11, 11), 202210, 202302, True, 'complete', 'carrier', 'Sun Life Assurance Company of Canada', '2323 Grand Boulevard', 'Kansas City', 'MO', '64108     '),
            (115, datetime.date(2022, 11, 11), 202210, 202302, True, 'complete', 'carrier', 'The Prudential Insurance Company of America', '751 Broad Street, 5th Floor', 'Newark', 'NJ', '07102     '),
            (116, datetime.date(2022, 11, 11), 202210, 202302, True, 'complete', 'carrier', 'UnitedHealthcare Medicare & Retirement', 'PO Box 9472', 'Minneapolis', 'MN', '55440     '),
            (117, datetime.date(2022, 11, 11), 202210, 202302, True, 'complete', 'carrier', 'MONY Life Insurance Company', '2801 Highway 280 South', 'Birmingham', 'AL', '35223     '),
            (118, datetime.date(2022, 11, 11), 202210, 202302, True, 'complete', 'carrier', 'Principal Life Insurance Company', '711 High Street', 'Des Moines', 'IA', '50392     '),
            (130, datetime.date(2022, 11, 17), 202210, 202302, False, 'complete', 'tpa_aso', 'TML MultiState Intergovernmental Employee Benefits Pool', '1821 Rutherford Lane, Suite 300', 'Austin', 'TX', '78754     '),
            (79, datetime.date(2022, 10, 25), 202210, 202302, True, 'complete', 'carrier', 'Wellfleet Insurance Company', '5814 Reed Road', 'Fort Wayne', 'IN', '46835     '),
            (80, datetime.date(2022, 10, 25), 202210, 202302, True, 'complete', 'carrier', 'Health Care Service Corporation', '300 East Randolph', 'Chicago', 'IL', '60601     '),
            (81, datetime.date(2022, 10, 25), 202210, 202302, True, 'complete', 'carrier', 'Humana', '500 West Main Street', 'Louisville', 'KY', '40202     '),
            (82, datetime.date(2022, 10, 25), 202210, 202302, True, 'complete', 'tpa_aso', 'Optum Behavioral Health Solutions', '6300 Olsen Memorial Highway', 'Minneapolis', 'MN', '55427     '),
            (124, datetime.date(2022, 11, 17), 202210, 202302, False, 'processing', 'tpa_aso', 'Devoted Health Services Inc.', '221 Crescent Street, Suite 202', 'Waltham', 'MA', '02435     '),
            (111, datetime.date(2022, 11, 11), 202210, 202302, True, 'complete', 'tpa_aso', 'EBIX Health Administration Exchange', '1 EBIX Way', 'Johns Creek', 'GA', '30097     '),
            (2, datetime.date(2022, 8, 3), 202210, 202302, True, 'complete', 'tpa_aso', 'TEST Meritan Health Inc', '300 Corporate Parkway', 'Amherst', 'NY', '14226     '),
            (3, datetime.date(2022, 8, 3), 202210, 202302, True, 'complete', 'carrier', 'TEST Friday Health Insurance Company, Inc', '700 Main Street', 'Alamosa', 'CO', '81101     '),
            (84, datetime.date(2022, 10, 29), 202210, 202302, True, 'processing', 'carrier', 'Reserve National Insurance Company', '601 E. Britton Road', 'Oklahoma City', 'OK', '73114     '),
            (191, datetime.date(2023, 2, 22), 202210, 202302, True, 'complete', 'carrier', 'UTHealth Houston-TEST', '7000 Fannin', 'Houston', 'TX', '77030     '),
            (203, datetime.date(2023, 3, 7), 202210, 202302, True, 'received', 'carrier', 'Garretts Test Business 3-7-23', 'test mailing address', 'Niagara Falls', 'MO', '50210     '),
            (173, datetime.date(2023, 2, 8), 202210, 202302, True, 'received', 'carrier', 'Garrett test business one million', 'Test ADDRESS Address that Tests Addresses ', 'Austin', 'AR', '50210     ')
         ]
         registrations_entities = [
            (
                5, 1, 5, 46, 11111, None, 5, 'Garretts Test Business 2', '11-0001111', True, True, True, True, False
            ),
            (
                5, 2, 50000, 47, 11010, 21101, 1, 'A Second Test Entity', '00-0000000', True, False, False, True, False
            )
         ]
         registrations_contacts = [
            (
                52,
                1,
                False,
                'Test Role',
                'Garrett Test Tester',
                '2222222222',
                'notarealemail@emailplace.com'
            ),
            (
                53,
                1,
                False,
                'A 2nd Test Role',
                'Test Garrett 2 Test',
                '15555555555',
                'testemail@testemail.net'
            ),
            (
                54,
                2,
                True,
                'A 3rd and final test role',
                'Test 3rd Role Name Garrett',
                '0000000000',
                'email@gmail.com'
            )
         ]
    </details>
2. Open http://localhost:8000/administration/list-registration-requests/
3. Confirm page opens with no errors and that all features are working

## UI

…

<!--
## Notes

…
-->
