### PR TITLE
task/WP-107-UTH-Extension-Requests

### DIFF
--- a/apcd-cms/src/apps/extension/static/forms/css/extension_submission_form.css
+++ b/apcd-cms/src/apps/extension/static/forms/css/extension_submission_form.css
@@ -1,15 +1,4 @@
 /* Field Widths */
-
-/* for an Entity*/
-input[name^="fein"],
-input[name^="license-number"],
-input[name^="naic-company-code"] {
-    width: 10ch;
-    box-sizing: content-box;
-}
-/* to make input type='month' the same width as type="date"*/
-input[name^="applicable-data-period"],
-input[name^="current-expected-date"],
 input[name^="requested-target-date"] {
     --length: 25ch;
     box-sizing: content-box;
@@ -22,15 +11,6 @@ input[name^="requested-target-date"] {
     margin-left: 0;
   }
 
-/* To put required for extension dates on another line to avoid cutting off text */
-label[name^="extension-date-asterisk"] {
-    padding: 0;
-    margin-left:0;
-}
-/* To make sure sup values are not cut off when set as a label*/
-label[name^="date-row"] {
-    margin-top: 1rem;
-}
 
 /* Field Layouts */
 /* To make (radio/check)box sets take up less vertical space */
@@ -39,14 +19,4 @@ label[name^="date-row"] {
     flex-wrap: wrap;
     column-gap: 1em;
     row-gap: 0.5em;
-}
-[id^="extension-block_"] {
-
-    /* Expectations:
-        - automatically enough columns
-        - maximum column count of 3 (i.e. minimum column width of 33%)
-        - equal width columns*/
-    display: grid;
-    grid-template-columns: repeat( auto-fill, var(--max-col-width));
-    max-width: calc( var(--global-space--grid-gap) + var(--max-col-width) *3 ); 
 }

--- a/apcd-cms/src/apps/extension/templates/extension_submission_form/extension_submission_form.html
+++ b/apcd-cms/src/apps/extension/templates/extension_submission_form/extension_submission_form.html
@@ -19,7 +19,7 @@
         This form should be completed and submitted by data submitters to request
         an extension to the deadline for submitting either a regular submission or
         a corrected resubmission. Please review the
-        <a href="https://sph.uth.edu/research/centers/chcd/apcd/techinical/TXAPCD-Data_Submission_Guide.pdf"
+        <a href="https://sph.uth.edu/research/centers/center-for-health-care-data/texas-all-payor-claims-database/payor-registration-information"
           target="_blank">Data Submission Guide</a> for details about completing and submitting this form, especially
         regarding
         the timeliness of the request.
@@ -31,55 +31,44 @@
           <form action="" method="POST">
             {% csrf_token %}
             <h4>Extension Information</h4>
-            <div class="field-wrapper textinput required">
-              <div class="field-errors" style="display: none"></div>
-              <label for="extension-type">
-                Extension Type<span class="asterisk">*</span>
-              </label>
-              <div class="field-errors" style="display: none"></div>
-              <select name='extension-type' required='required' class="choicefield" id='extension-type'>
-                <option class="dropdown-text" value="regular">Regularly Scheduled Submission</option>
-                <option class="dropdown-text" value="resubmission">Corrected Resubmission</option>
-                <option class="dropdown-text" value="small_carrier">Small Carrier (Fewer Than 10,000 Lives Covered)
-                </option>
-              </select>
-            </div>
-            <div id="extension-block_1">
-              <div class="o-grid o-grid--col-auto-count">
-                <div class="field-wrapper numberinput required" id="date-row">
-                  <div class="field-errors" style="display: none"></div>
+            <div id="extension-block_1" >
+              <div class="field-wrapper textinput required"><p>
+                This extension is on behalf of the following organization:
+              </p>
+                <label for="business-name_1">
+                  Business Name<span class="asterisk">*</span>
+                </label>
+                <div class="field-errors" style="display: none"></div>
+                <select name='business-name_1' required='required' class="choicefield" id='business-name_1'>
+                  {% for submitter in submitters %}
+                  <option class="dropdown-text" value={{submitter.submitter_id}}>{{submitter.org_name}} - Submitter ID:
+                    {{submitter.submitter_id}} Payor: {{submitter.payor_code}}</option>
+                  {% endfor %}
+                </select>
+                </div>
 
-                  <label for="applicable-data-period" name="date-row">Applicable Data Period<sup
-                      name="date-sup">1</sup></label><label name="extension-date-asterisk"><span
-                      class="asterisk">*</span></label>
+                <div class="field-wrapper textinput required">
+                  <div class="field-errors" style="display: none"></div>
+                  <label for="extension-type_1">
+                    Extension Type<span class="asterisk">*</span>
                   </label>
-
-                  <input type="month" name="applicable-data-period" placeholder="YYYY/MM" class="numeric"
-                    inputmode="numeric" style="width:18ch" id="applicable-data-period" pattern="\d{4}-\d{2}" required />
-                  <div id="help-text-applicable-data-period" class="help-text">
-                    Enter month and year
-                  </div>
+                  <select name='extension-type_1' required='required' class="choicefield" id='extension-type_1'>
+                    <option class="dropdown-text" value="regular">Regularly Scheduled Submission</option>
+                    <option class="dropdown-text" value="resubmission">Corrected Resubmission</option>
+                    <option class="dropdown-text" value="small_carrier">Small Carrier (Fewer Than 10,000 Lives Covered)
+                    </option>
+                  </select>
                 </div>
-                <div class="field-wrapper numberinput required" id="date-row">
+              
+                <div class="field-wrapper numberinput required">
                   <div class="field-errors" style="display: none"></div>
 
-                  <label for="current-expected-date" name="date-row">Current Expected Date<sup>2</sup>
-                  </label><label name="extension-date-asterisk"><span class="asterisk">*</span></label>
+                  <label for="requested-target-date_1">Requested Target Date<sup>1</sup><span class="asterisk">*</span></label>
 
-                  <input type="date" name="current-expected-date" class="numeric" id="current-expected-date"
-                    inputmode="numeric" required />
-                </div>
-                <div class="field-wrapper numberinput required" id="date-row">
-                  <div class="field-errors" style="display: none"></div>
-
-                  <label for="request" name="date-row">Requested Target Date<sup>3</sup></label><label
-                    name="extension-date-asterisk"><span class="asterisk">*</span></label>
-
-                  <input type="date" name="requested-target-date" class="numeric" id="requested-target-date"
+                  <input type="date" name="requested-target-date_1" class="numeric" id="requested-target-date_1"
                     inputmode="numeric" required />
                 </div>
               </div>
-            </div>
             <h4 id="extension-header_2" style="display:none">
               <hr />Extension Information 2
             </h4>
@@ -144,23 +133,6 @@
                   id="requestor-email" pattern="^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[a-z]{2,4}$" />
               </div>
             </div>
-            <div class="field-wrapper textinput required"><label>
-                I request an exception on behalf of:
-              </label></div>
-
-            <div class="field-wrapper textinput required">
-              <label for="business-name">
-                Business Name<span class="asterisk">*</span>
-              </label>
-              <div class="field-errors" style="display: none"></div>
-              <select name='business-name' required='required' class="choicefield" id='business-name'>
-                {% for submitter in submitters %}
-                <option class="dropdown-text" value={{submitter.submitter_id}}>{{submitter.org_name}} - ID:
-                  {{submitter.submitter_id}}</option>
-                {% endfor %}
-              </select>
-
-            </div>
 
             <div class="field-wrapper checkbox required">
               <div class="field-errors" style="display: none"></div>
@@ -177,10 +149,21 @@
               <button class="form-button" type="submit" value="Submit">
                 Submit
               </button>
+              </div>
+            </form>
+            <div class="o-section o-section--style-light">
+              <hr />
+              <p>
+                <small>¹ Requested target date – requested day/month/year by which the data should be received (the extension
+                  date).<br />
+                </small>
+              </p>
             </div>
-          </form>
+          </div>
         </div>
       </div>
+    </div>
+  </div>
 
 
       <div class="form-success" style="display: none">
@@ -226,57 +209,49 @@
             let extensionBlock = document.getElementById(`extension-block_${extension}`);
             document.getElementById(`extension-header_${extension}`).style.display = 'block';
             extensionBlock.innerHTML = `
-        <div id="extension-block_${extension}">
-          <div class="field-wrapper textinput required">
-            <div class="field-errors" style="display: none"></div>
-                <label for="extension-type">
-                  Extension Type<span class="asterisk">*</span>
+            <div id="extension-block_${extension}" >
+              <div class="field-wrapper textinput required"><p>
+                This extension is on behalf of the following organization:
+              </p>
+                <label for="business-name_${extension}">
+                  Business Name<span class="asterisk">*</span>
                 </label>
                 <div class="field-errors" style="display: none"></div>
+                <select name='business-name_${extension}' required='required' class="choicefield" id='business-name_${extension}'>
+                  {% for submitter in submitters %}
+                  <option class="dropdown-text" value={{submitter.submitter_id}}>{{submitter.org_name}} - ID:
+                    {{submitter.submitter_id}} Payor Code: {{submitter.payor_code}}</option>
+                  {% endfor %}
+                </select>
+                </div>
+
+                <div class="field-wrapper textinput required">
+                  <div class="field-errors" style="display: none"></div>
+                  <label for="extension-type_${extension}">
+                    Extension Type<span class="asterisk">*</span>
+                  </label>
                   <select name='extension-type_${extension}' required='required' class="choicefield" id='extension-type_${extension}'>
                     <option class="dropdown-text" value="regular">Regularly Scheduled Submission</option>
                     <option class="dropdown-text" value="resubmission">Corrected Resubmission</option>
-                    <option class="dropdown-text" value="small_carrier">Small Carrier (Fewer Than 10,000 Lives Covered)</option>
-                </select>
+                    <option class="dropdown-text" value="small_carrier">Small Carrier (Fewer Than 10,000 Lives Covered)
+                    </option>
+                  </select>
                 </div>
-          <div class="o-grid o-grid--col-auto-count" >
-            <div class="field-wrapper numberinput required" id="date-row">
-              <div class="field-errors" style="display: none"></div>
+              
+                <div class="field-wrapper numberinput required">
+                  <div class="field-errors" style="display: none"></div>
 
-              <label for="applicable-data-period_${extension}" name="date-row">Applicable Data Period<sup>1</sup></label><label name="extension-date-asterisk"><span class="asterisk">*</span></label>
-              </label>
+                  <label for="requested-target-date_${extension}">Requested Target Date<sup>1</sup><span class="asterisk">*</span></label>
 
-              <input type="month" name="applicable-data-period_${extension}" placeholder="YYYY/MM" class="numeric" inputmode="numeric" style="width:18ch"
-                id="applicable-data-period_${extension}" pattern="\d{4}-\d{2}" required />
-              <div id="help-text-applicable-data-period_${extension}" class="help-text">
-                Enter month and year
+                  <input type="date" name="requested-target-date_${extension}" class="numeric" id="requested-target-date_${extension}"
+                    inputmode="numeric" required />
+                </div>
               </div>
-            </div>
-            <div class="field-wrapper numberinput required" id="date-row">
-              <div class="field-errors" style="display: none"></div>
-
-              <label for="current-expected-date_${extension}" name="date-row">Current Expected Date<sup>2</sup>
-              </label><label><span class="asterisk">*</span></label>
-
-              <input type="date" name="current-expected-date_${extension}" class="numeric" id="current-expected-date_${extension}"
-                inputmode="textinput" required />
-            </div>
-            <div class="field-wrapper numberinput required" id="date-row_${extension}">
-              <div class="field-errors" style="display: none"></div>
-
-              <label for="requested-target-date_${extension}" name="date-row_${extension}">Requested Target Date<sup>3</sup></label><label name="extension-date-asterisk"><span class="asterisk">*</span></label>
-
-              <input type="date" name="requested-target-date_${extension}" class="numeric" id="requested-target-date_${extension}"
-                inputmode="textinput" required />
-            </div>
-          </div>
-        </div>
         `;
             const inputs = Array.from(
               document.querySelectorAll(`
             input[name=extension-type_${extension}],
-            input[name=applicable-data-period_${extension}],
-            input[name=current-expected-date_${extension}],
+            input[name=business-name_${extension}],
             input[name=requested-target-date_${extension}]
           `)
             );
@@ -298,17 +273,4 @@
         </script>
 
 
-        {# Footnotes #}
-        <div class="o-section o-section--style-light">
-          <hr />
-          <p>
-            <small>¹ Applicable data period – month/year in which claims data was adjudicated.<br />
-              ² Current expected date – day/month/year in which applicable data was expected within the submission
-              window.<br />
-              ³ Requested target date – requested day/month/year by which the data should be received (the extension
-              date).<br />
-            </small>
-          </p>
-          <hr />
-        </div>
         {% endblock %}

--- a/apcd-cms/src/apps/extension/views.py
+++ b/apcd-cms/src/apps/extension/views.py
@@ -55,17 +55,18 @@ class ExtensionFormView(TemplateView):
             errors= []
             submitters = request.session.get('submitters')
 
-            submitter = next(submitter for submitter in submitters if int(submitter[0]) == int(form['business-name']))
 
             max_iterations = 1
             
             for i in range(2, 6):
-                if form.get('current-expected-date_{}'.format(i)):
+                ## Pick a id from the form to count iterations
+                if form.get('requested-target-date_{}'.format(i)):
                     max_iterations += 1
                 else:
                     break
 
             for iteration in range(max_iterations):
+                submitter = next(submitter for submitter in submitters if int(submitter[0]) == int(form['business-name_{}'.format(iteration + 1)]))
                 exten_resp = apcd_database.create_extension(form, iteration + 1, submitter)
                 if _err_msg(exten_resp):
                     errors.append(_err_msg(exten_resp))

--- a/apcd-cms/src/apps/utils/apcd_database.py
+++ b/apcd-cms/src/apps/utils/apcd_database.py
@@ -1063,13 +1063,10 @@ def create_extension(form, iteration, sub_data):
     try:
         if iteration > 1:
             values = (
-                _clean_value(sub_data[0]),
-                _clean_date(form['current-expected-date_{}'.format(iteration)]),
+                _clean_value(form['business-name_{}'.format(iteration)]),
                 _clean_date(form['requested-target-date_{}'.format(iteration)]),
-                None,
                 _clean_value(form['extension-type_{}'.format(iteration)]),
-                int(form['applicable-data-period_{}'.format(iteration)].replace('-', '')),
-                "Pending",
+                "pending",
                 _clean_value(sub_data[1]),
                 _clean_value(sub_data[2]),
                 _clean_value(sub_data[3]),
@@ -1079,14 +1076,10 @@ def create_extension(form, iteration, sub_data):
                 )
         else:
             values = (
-            _clean_value(sub_data[0]),
-            _clean_date(form['current-expected-date']),
-            _clean_date(form['requested-target-date']),
-            None,
-            _clean_value(form['extension-type']),
-            int(form['applicable-data-period'].replace('-', '')),
-            "Pending",
-
+            _clean_value(form['business-name_{}'.format(iteration)]),
+            _clean_date(form['requested-target-date_{}'.format(iteration)]),
+            _clean_value(form['extension-type_{}'.format(iteration)]),
+            "pending",
             _clean_value(sub_data[1]),
             _clean_value(sub_data[2]),
             _clean_value(sub_data[3]),
@@ -1097,11 +1090,8 @@ def create_extension(form, iteration, sub_data):
 
         operation = """INSERT INTO extensions(
             submitter_id,
-            current_expected_date,
             requested_target_date,
-            approved_expiration_date,
             extension_type,
-            applicable_data_period,
             status,
             submitter_code,
             payor_code,
@@ -1109,7 +1099,7 @@ def create_extension(form, iteration, sub_data):
             requestor_name,
             requestor_email,
             explanation_justification
-        ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+        ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
         """
         conn = psycopg2.connect(
             host=APCD_DB['host'],
@@ -1152,13 +1142,11 @@ def get_submitter_for_extend_or_except(user):
                     submitters.submitter_code, 
                     submitters.payor_code, 
                     submitter_users.user_id, 
-                    apcd_orgs.official_name
+                    submitters.org_name
                 FROM submitter_users
                 JOIN submitters
                     ON submitter_users.submitter_id = submitters.submitter_id and submitter_users.user_id = (%s)
-                JOIN apcd_orgs
-                    ON submitters.apcd_id = apcd_orgs.apcd_id
-                ORDER BY submitters.apcd_id, submitter_users.submitter_id
+                ORDER BY submitter_users.submitter_id
             """
         cur = conn.cursor()
         cur.execute(query, (user,))


### PR DESCRIPTION
## Overview
Update extension form page to meet specs discussed in UTH meeting

## Related

- [WP-107](https://jira.tacc.utexas.edu/browse/WP-107)

## Changes

- Changed link at top of page to go to data submission help
- Allows payor code, submitter id, organization name to change per extension request
- Updated org name so it pulls from submitters table rather than apcd_org table
- No longer needs data period and expected date. That's filled in on the admin side. Users only enter requested target date
- Updated queries and view so the post uses different submitter data for each iteration of the form. Tested on VM

## Testing

1. Go to [extension form page](http://localhost:8000/submissions/extension-request/)
2. On line 24 of extensions/views.py use submitter data in snippet 
<details><summary>Snippet </summary>
<p>
[(34, 'AETNACAS', 20000027, 'cvs_apcd', 'Aetna - ACAS'),
 (39, 'AETNASH', 20000032, 'cvs_apcd', 'Aetna - ASH'),
 (40, 'AETNLEG', 20000033, 'cvs_apcd', 'Aetna - Legacy'),
 (41, 'AETNLEG', 20000034, 'cvs_apcd', 'Aetna - Legacy'),
 (57, 'AETNBOON', 20000050, 'cvs_apcd', 'Aetna - Boon'),
 (94, 'CVSPIII', 20000084, 'cvs_apcd', 'CVS-PBM Part 3')]


</p>
</details> 
3. Check to make sure form allows you to submit.

## UI
UTH Extension form  changes
![Screenshot 2023-05-24 at 11 47 10 AM](https://github.com/TACC/Core-CMS-Custom/assets/96220951/966f90fb-3efe-4885-93e4-9bf69bf30866)
![Screenshot 2023-05-24 at 11 53 44 AM](https://github.com/TACC/Core-CMS-Custom/assets/96220951/37b21579-8243-4fb5-b6a0-968145ad017e)


<!--
## Notes

…
-->
