### PR TITLE
task/WP-182-Extension-form-wording

### DIFF
--- a/apcd-cms/src/apps/extension/templates/extension_submission_form/extension_submission_form.html
+++ b/apcd-cms/src/apps/extension/templates/extension_submission_form/extension_submission_form.html
@@ -42,7 +42,7 @@
                 <select name='business-name_1' required='required' class="choicefield" id='business-name_1'>
                   {% for submitter in submitters %}
                   <option class="dropdown-text" value={{submitter.submitter_id}}>{{submitter.org_name}} - ID:
-                    {{submitter.submitter_id}} Payor Code: {{submitter.payor_code}}</option>
+                    {{submitter.submitter_id}}</option>
                   {% endfor %}
                 </select>
                 </div>
@@ -101,7 +101,7 @@
 
             <hr />
 
-            <h4>Request Justification</h4>
+            <h4>Request and Justification</h4>
 
             <div class="field-wrapper textarea required">
               Provide rationale for the exception request, outlining the reasons why the


### PR DESCRIPTION


## Overview
Update justification header, remove payor code from business name dropdown

## Related


- [WP-182](https://jira.tacc.utexas.edu/browse/WP-182)
- related to https://github.com/TACC/Core-CMS-Custom/pull/167 with some exception form wording changes

## Changes

- Changed justification header to Request and Justification
- Removed payor code from business name drop down to match the exception form

## Testing

1. Go to [http://localhost:8000/submissions/extension-request/](http://localhost:8000/submissions/extension-request/)
2. Make sure justification field says Request and Justification
3. Make sure business name drop down only shows business name and submitter ID

## UI
<img width="1433" alt="Screenshot 2023-06-21 at 9 37 25 AM" src="https://github.com/TACC/Core-CMS-Custom/assets/96220951/5aded8db-25bb-42ee-8d49-a8968cfb22f8">
