### PR TITLE
bug/WP-195-Extension-Notes-Edit-Modal-Not-Displaying

### DIFF
--- a/apcd-cms/src/apps/admin_extension/static/admin_extension/css/table.css
+++ b/apcd-cms/src/apps/admin_extension/static/admin_extension/css/table.css
@@ -1,3 +1,6 @@
+.modal-cell {
+    padding-left: 0px;
+}
 /* SEE: https://css-tricks.com/responsive-data-tables/ */
 @media (max-width: 767px) {
     /* To label the cells */

--- a/apcd-cms/src/apps/admin_extension/templates/edit_extension_modal.html
+++ b/apcd-cms/src/apps/admin_extension/templates/edit_extension_modal.html
@@ -74,7 +74,7 @@
 
               <div class="field-errors" style="display: none"></div>
                 <textarea name="notes" cols="40" rows="5" class="textinput" type="text" id="notes"
-                  minlength="2" maxlength="2000">{{r.notes|default:''}}</textarea>
+                  minlength="2" maxlength="2000">{{r.notes}}</textarea>
                 <div class="help-text">
                   2000 character limit
                 </div>

--- a/apcd-cms/src/apps/admin_extension/templates/edit_extension_modal.html
+++ b/apcd-cms/src/apps/admin_extension/templates/edit_extension_modal.html
@@ -74,7 +74,7 @@
 
               <div class="field-errors" style="display: none"></div>
                 <textarea name="notes" cols="40" rows="5" class="textinput" type="text" id="notes"
-                  minlength="2" maxlength="2000" value="{{r.notes|default:''}}"></textarea>
+                  minlength="2" maxlength="2000">{{r.notes|default:''}}</textarea>
                 <div class="help-text">
                   2000 character limit
                 </div>

--- a/apcd-cms/src/apps/admin_extension/templates/list_admin_extension.html
+++ b/apcd-cms/src/apps/admin_extension/templates/list_admin_extension.html
@@ -50,10 +50,10 @@
                 <td class="outcome">{{r.outcome}}</td>
                 <td class="status">{{r.status}}</td>
                 <td class="approved-expiration-date">{{r.approved_expiration_date}}</td>
-                <td>
+                <td class="modal-cell">
                   {% include "view_admin_extension_modal.html" %}
                   {% include "edit_extension_modal.html" %}                   
-                    <select id='actionsDropdown_{{r.extension_id}}' class="modal-cell" onchange="openAction('{{r.extension_id}}')">
+                    <select id='actionsDropdown_{{r.extension_id}}'  onchange="openAction('{{r.extension_id}}')">
                       <div class="filter-container">
                         <div class="filter-content">
                           <option value="">Select Action</option>


### PR DESCRIPTION
## Overview

Render notes in Edit modal if not None

## Related


- [WP-195](https://jira.tacc.utexas.edu/browse/WP-195)



## Changes

Moved the notes being pulled from the DB from the value attribute of the text area of the Notes form to within the actual textarea element. Removed default setting for notes as it was causing bugs. Also formatted modal cell so it is no longer outside of the table.

## Testing

1. Go to [http://localhost:8000/administration/list-extensions/](http://localhost:8000/administration/list-extensions/)
2. Go to the Action drop down and select edit modal. Make sure notes appear if there are notes for that extension.
3. Try writing a new note and submitting the form. 
4. Open the edit and view modal and make sure the Notes are accurately updated.

## UI
<img width="1070" alt="Screenshot 2023-07-05 at 3 20 20 PM" src="https://github.com/TACC/Core-CMS-Custom/assets/96220951/c9973d01-5724-499a-893c-fd2286c9dd00">



