### PR TITLE
bug/WP-184: Admin submissions listing page showing wrong org name

### DIFF
--- a/apcd-cms/src/apps/utils/apcd_database.py
+++ b/apcd-cms/src/apps/utils/apcd_database.py
@@ -1003,7 +1003,7 @@ def get_all_submissions_and_logs():
                 'outcome', submissions.outcome,
                 'received_timestamp', submissions.received_timestamp,
                 'updated_at', submissions.updated_at,
-                'org_name', apcd_orgs.official_name,
+                'org_name', users.org_name,
                 'view_modal_content', (
                     SELECT COALESCE(json_agg(json_build_object(
                         'log_id', submission_logs.log_id,
@@ -1020,11 +1020,13 @@ def get_all_submissions_and_logs():
                 )
             )
             FROM submissions
-            JOIN apcd_orgs
-                ON submissions.apcd_id = apcd_orgs.apcd_id
+            LEFT JOIN submitter_users 
+                ON submitter_users.submitter_id = submissions.submitter_id 
+            LEFT JOIN users
+                ON users.user_id = submitter_users.user_id AND users.user_number = submitter_users.user_number
             LEFT JOIN submission_logs
                 ON submissions.submission_id = submission_logs.submission_id
-            GROUP BY (submissions.submission_id, apcd_orgs.official_name)
+            GROUP BY (submissions.submission_id, users.org_name)
             ORDER BY submissions.received_timestamp DESC
         """
         cur = conn.cursor()

--- a/apcd-cms/src/apps/utils/apcd_database.py
+++ b/apcd-cms/src/apps/utils/apcd_database.py
@@ -1003,7 +1003,7 @@ def get_all_submissions_and_logs():
                 'outcome', submissions.outcome,
                 'received_timestamp', submissions.received_timestamp,
                 'updated_at', submissions.updated_at,
-                'org_name', users.org_name,
+                'org_name', submitters.org_name,
                 'view_modal_content', (
                     SELECT COALESCE(json_agg(json_build_object(
                         'log_id', submission_logs.log_id,
@@ -1020,13 +1020,11 @@ def get_all_submissions_and_logs():
                 )
             )
             FROM submissions
-            LEFT JOIN submitter_users 
-                ON submitter_users.submitter_id = submissions.submitter_id 
-            LEFT JOIN users
-                ON users.user_id = submitter_users.user_id AND users.user_number = submitter_users.user_number
+            LEFT JOIN submitters 
+                ON submitters.submitter_id = submissions.submitter_id
             LEFT JOIN submission_logs
                 ON submissions.submission_id = submission_logs.submission_id
-            GROUP BY (submissions.submission_id, users.org_name)
+            GROUP BY (submissions.submission_id, submitters.org_name)
             ORDER BY submissions.received_timestamp DESC
         """
         cur = conn.cursor()


### PR DESCRIPTION
## Overview
Changed db query for admin submission listing page to show org name from submitters table rather than from apcd_orgs table
…

## Related

- [WP-184](https://jira.tacc.utexas.edu/browse/WP-184)
- [WP-187](https://jira.tacc.utexas.edu/browse/WP-187)
<!--
- requires https://github.com/TACC/Core-CMS/pull/117
-->…

## Changes
- In db util function for this page, joined `submitters` table to `submission` table to access `submitterss.org_name`
…

## Testing

1. Open http://localhost:8000/administration/list-submissions/
2. Confirm that, in 'Organization' column, 'TACC Test' now displays instead of 'chcd'

## UI
Before:
![image](https://github.com/TACC/Core-CMS-Custom/assets/43251554/f50d9c8b-90a4-44ce-b411-1ae9ea78e9da)


After:
![image](https://github.com/TACC/Core-CMS-Custom/assets/43251554/6b204ed8-521f-476d-bebe-4459b4e86b17)

…
## Notes
Thank you @happycodemonkey for writing the revised table query here!
