### PR TITLE
fix(tapis): CMS v3.11.2 accent color via v3.11.3

### DIFF
--- a/tapisproject_cms/Dockerfile
+++ b/tapisproject_cms/Dockerfile
@@ -1,5 +1,5 @@
-# v3.11.3
-FROM taccwma/core-cms:5cc1b06
+# TACC/Core-CMS#668 (v3.11.4 candidate)
+FROM taccwma/core-cms:e89f9e4
 
 WORKDIR /code
 

--- a/tapisproject_cms/Dockerfile
+++ b/tapisproject_cms/Dockerfile
@@ -1,5 +1,5 @@
-# v3.11.0
-FROM taccwma/core-cms:c19e0d7
+# v3.11.3
+FROM taccwma/core-cms:5cc1b06
 
 WORKDIR /code
 


### PR DESCRIPTION
## Overview

Fix accent color via new CMS image.

## Related

- [WI-6](https://jira.tacc.utexas.edu/browse/WI-6)
- relies on https://github.com/TACC/Core-CMS/releases/tag/v3.11.2
- also includes https://github.com/TACC/Core-CMS/releases/tag/v3.11.3

## Changes

- **changed** cms image

## Testing

0. Deploy.
1. Verify accent color is changed.
2. Verify no other style changes occur.*

<sup>\* Content differences are independent of this code change.</sup>

## UI

| v3.N<br><sup>tapis-project.org</sup> | v3.9<br><sup>\*.tapisproject.…</sup> | v3.11<br><sup>\*.tapisproject.…</sup> | fixed<br><sup>(this pull request)</sup> |
| - | - | - | - |
| ![live-tapis--v3-N](https://github.com/TACC/Core-CMS-Custom/assets/62723358/cc0e07a5-3be5-4b62-90b9-7fe89cdbdfb0) | ![prod-tapis--v3-9-0](https://github.com/TACC/Core-CMS-Custom/assets/62723358/92f439f5-b26c-4970-9cf5-26d7a21f452a) | ![prod-tapis--v3-11-0](https://github.com/TACC/Core-CMS-Custom/assets/62723358/ecfa49ae-93c5-4ba9-a887-a6613ca926c8) | ![pprd-tapis--v3-11-4-candidate](https://github.com/TACC/Core-CMS-Custom/assets/62723358/cb141a03-be0f-47e2-bfe9-c2c67609ee29) |
| 🪦 (light) blue links | ❌ purple links | ❌ purple links | ✅ (dark) blue links |