### PR TITLE
chore(tapis): CMS v3.11.4

### DIFF
--- a/tapisproject_cms/Dockerfile
+++ b/tapisproject_cms/Dockerfile
@@ -1,5 +1,5 @@
-# TACC/Core-CMS#668 (v3.11.4 candidate)
-FROM taccwma/core-cms:e89f9e4
+# v3.11.4
+FROM taccwma/core-cms:cd2c989
 
 WORKDIR /code
 


### PR DESCRIPTION
## Overview / Changes

Use official https://github.com/TACC/Core-CMS/releases/tag/v3.11.4 instead of candidate.

## Related

- follow-up to #181

## Testing / UI

https://pprd.tapisproject.tacc.utexas.edu/
