### PR TITLE
test(tapis): cms v2.0.1 candidate

### DIFF
--- a/tapisproject_cms/Dockerfile
+++ b/tapisproject_cms/Dockerfile
@@ -1,5 +1,5 @@
-# v3.11.4
-FROM taccwma/core-cms:cd2c989
+# TACC/Core-CMS#673 (v2.0.1 candidate)
+FROM taccwma/core-cms:1289d38
 
 WORKDIR /code
 


### PR DESCRIPTION
## Overview

Try to deploy old CMS, because v3.11 has not fixed v1→v2 migration bugs on this website.

## Status

> **Warning**
> Build failure. CMS crash. Incomplete. Do not use.

Replaced by https://github.com/TACC/Core-CMS-Custom/pull/191, which fixes v3 UI issues, making this moot.

## Related

- [WI-6](https://jira.tacc.utexas.edu/browse/WI-6)
- requires https://github.com/TACC/Core-CMS/pull/673

## Changes

- **changed** cms docker image

## Testing & UI

https://pprd.tapisproject.tacc.utexas.edu/
