### PR TITLE
task/WP-88: URL Parameters reordering w/ paginator

### DIFF
--- a/apcd-cms/src/apps/admin_extension/views.py
+++ b/apcd-cms/src/apps/admin_extension/views.py
@@ -19,14 +19,14 @@ class AdminExtensionsTable(TemplateView):
     def post(self, request):
 
         form = request.POST.copy()
-        
+
         def _err_msg(resp):
             if hasattr(resp, 'pgerror'):
                 return resp.pgerror
             if isinstance(resp, Exception):
                 return str(resp)
             return None
-        
+
         def _edit_extension(form):
             errors = []
             extension_response = update_extension(form)
@@ -39,7 +39,7 @@ class AdminExtensionsTable(TemplateView):
                 logger.debug(print("success"))
                 template = loader.get_template('edit_extension_success.html')
             return template
-        
+
         template = _edit_extension(form)
         return HttpResponse(template.render({}, request))
     def get(self, request, *args, **kwargs):
@@ -96,7 +96,7 @@ class AdminExtensionsTable(TemplateView):
             return date if date is not None else parser.parse('1-1-0001')
 
         extension_content = sorted(extension_content, key=lambda row:getDate(row), reverse=True)  # sort extensions by newest to oldest
-        
+
         extension_table_entries = []       
         for extension in extension_content:
             # to be used by paginator
@@ -116,23 +116,22 @@ class AdminExtensionsTable(TemplateView):
                 context['outcome_options'].append(outcome)
                 context['outcome_options'] = context['outcome_options']
 
+        queryStr = ''
         status_filter = self.request.GET.get('status')
         org_filter = self.request.GET.get('org')
 
         context['selected_status'] = None
         if status_filter is not None and status_filter != 'All':
             context['selected_status'] = status_filter
+            queryStr += f'&status={status_filter}'
             extension_table_entries = table_filter(status_filter, extension_table_entries, 'status')
 
         context['selected_org'] = None
         if org_filter is not None and org_filter != 'All':
             context['selected_org'] = org_filter
+            queryStr += f'&org={org_filter}'
             extension_table_entries = table_filter(org_filter.replace("(", "").replace(")",""), extension_table_entries, 'org_name')
 
-
-        queryStr = '?'
-        if len(self.request.META['QUERY_STRING']) > 0:
-            queryStr = queryStr + self.request.META['QUERY_STRING'].replace(f'page={page_num}', '') + ('&' if self.request.GET.get('page') is None else '')
         context['query_str'] = queryStr
         context.update(paginator(self.request, extension_table_entries))
         context['pagination_url_namespaces'] = 'admin_extension:list_extensions'
@@ -141,7 +140,7 @@ class AdminExtensionsTable(TemplateView):
 
 # function converts int value in the format YYYYMM to a string with abbreviated month and year
 def _get_applicable_data_period(value):
-    try: 
+    try:
         return datetime.strptime(str(value), '%Y%m').strftime('%b. %Y')
     except:
         return None

--- a/apcd-cms/src/apps/admin_regis_table/views.py
+++ b/apcd-cms/src/apps/admin_regis_table/views.py
@@ -239,22 +239,22 @@ class RegistrationsTable(TemplateView):
             if org_name not in context['org_options']:
                 context['org_options'].append(org_name)
 
+        queryStr = ''
         status_filter = self.request.GET.get('status')
         org_filter = self.request.GET.get('org')
 
         context['selected_status'] = None
         if status_filter is not None and status_filter != 'All':
             context['selected_status'] = status_filter
+            queryStr += f'&status={status_filter}'
             registration_table_entries = table_filter(status_filter, registration_table_entries, 'reg_status')
 
         context['selected_org'] = None
         if org_filter is not None and org_filter != 'All':
             context['selected_org'] = org_filter
+            queryStr += f'&org={org_filter}'
             registration_table_entries = table_filter(org_filter.replace("(", "").replace(")",""), registration_table_entries, 'biz_name')
 
-        queryStr = '?'
-        if len(self.request.META['QUERY_STRING']) > 0:
-            queryStr = queryStr + self.request.META['QUERY_STRING'].replace(f'page={page_num}', '') + ('&' if self.request.GET.get('page') is None else '')
         context['query_str'] = queryStr
         context.update(paginator(self.request, registration_table_entries))
         context['pagination_url_namespaces'] = 'administration:admin_regis_table'

--- a/apcd-cms/src/apps/admin_submissions/templates/list_admin_submissions.html
+++ b/apcd-cms/src/apps/admin_submissions/templates/list_admin_submissions.html
@@ -22,7 +22,7 @@
       <span><b>Filter by Status: </b></span>
       <select id="statusFilter" class="status-filter" onchange="filterTableByStatus()">
         {% for option in filter_options %}
-          <option class="dropdown-text" {% if option == selected_filter %}selected{% endif %}>{{ option }}</option>
+          <option class="dropdown-text" {% if option == selected_status %}selected{% endif %}>{{ option }}</option>
         {% endfor %}
       </select>
       <span><b>Sort by: </b></span>
@@ -32,7 +32,7 @@
           <option class="dropdown-text" value={{option}} {% if option == selected_sort %}selected{% endif %}>{{ display_text }}</option>
         {% endfor %}
       </select>
-      {% if selected_filter or selected_sort %}
+      {% if selected_status or selected_sort %}
         <button onclick="clearSelections()">Clear Options</button>
       {% endif %}
     </div>
@@ -71,9 +71,9 @@
       var filterDropdown, filterValue, url_params, url, xhr;
       filterDropdown = document.getElementById("statusFilter");
       filterValue =  filterDropdown.value;
-      url_params = `?filter=${filterValue}`;
+      url_params = `?status=${filterValue}`;
       {% if selected_sort %}
-          url_params = `?filter=${filterValue}&sort={{selected_sort}}`;
+          url_params = `?sort={{selected_sort}}&status=${filterValue}`;
       {% endif %}
       url = `/administration/list-submissions/${url_params}`;
       xhr = new XMLHttpRequest();
@@ -87,8 +87,8 @@
       sortDropdown = document.getElementById('dateSort');
       sortValue =  sortDropdown.value;
       url_params = `?sort=${sortValue}`;
-      {% if selected_filter %}
-          url_params = `?filter={{selected_filter}}&sort=${sortValue}`;
+      {% if selected_status %}
+          url_params = `?sort=${sortValue}&status={{selected_status}}`;
       {% endif %}
       url = `/administration/list-submissions/${url_params}`;
       xhr = new XMLHttpRequest();

--- a/apcd-cms/src/apps/admin_submissions/urls.py
+++ b/apcd-cms/src/apps/admin_submissions/urls.py
@@ -4,7 +4,7 @@ from apps.admin_submissions.views import AdminSubmissionsTable
 app_name = 'administration'
 urlpatterns = [
     path('list-submissions/', AdminSubmissionsTable.as_view(), name="admin_submissions"),
-    path(r'list-submissions/?filter=(?P<filter>)/', AdminSubmissionsTable.as_view(), name="admin_submissions"),
+    path(r'list-submissions/?status=(?P<status>)/', AdminSubmissionsTable.as_view(), name="admin_submissions"),
     path(r'list-submissions/?sort=(?P<sort>)/', AdminSubmissionsTable.as_view(), name="admin_submissions"),
-    path(r'list-submissions/?filter=(?P<filter>)&sort=(?P<sort>)/', AdminSubmissionsTable.as_view(), name="admin_submissions"),
+    path(r'list-submissions/?sort=(?P<sort>)&filter=(?P<status>)/', AdminSubmissionsTable.as_view(), name="admin_submissions"),
 ]

--- a/apcd-cms/src/apps/admin_submissions/views.py
+++ b/apcd-cms/src/apps/admin_submissions/views.py
@@ -24,8 +24,9 @@ class AdminSubmissionsTable(TemplateView):
 
         submission_content = get_all_submissions_and_logs()
 
-        filter = self.request.GET.get('filter')
+        queryStr = ''
         dateSort = self.request.GET.get('sort')
+        status_filter = self.request.GET.get('status')
 
         def getDate(row):
             date = row['received_timestamp']
@@ -33,6 +34,7 @@ class AdminSubmissionsTable(TemplateView):
 
         if dateSort is not None:
             context['selected_sort'] = dateSort
+            queryStr += f'&sort={dateSort}'
             submission_content = sorted(submission_content, key=lambda row:getDate(row), reverse=(dateSort == 'newDate'))
 
         try:
@@ -40,10 +42,11 @@ class AdminSubmissionsTable(TemplateView):
         except:
             page_num = 1
 
-        context['selected_filter'] = None
-        if filter is not None and filter != 'All':
-            context['selected_filter'] = filter
-            submission_content = table_filter(filter, submission_content, 'status')
+        context['selected_status'] = None
+        if status_filter is not None and status_filter != 'All':
+            context['selected_status'] = status_filter
+            queryStr += f'&status={status_filter}'
+            submission_content = table_filter(status_filter, submission_content, 'status')
 
         limit = 50
         offset = limit * (page_num - 1)
@@ -64,9 +67,6 @@ class AdminSubmissionsTable(TemplateView):
         context['filter_options'] = ['All', 'In Process', 'Complete']
         context['sort_options'] = {'newDate': 'Newest Received', 'oldDate': 'Oldest Received'}
 
-        queryStr = '?'
-        if len(self.request.META['QUERY_STRING']) > 0:
-            queryStr = queryStr + self.request.META['QUERY_STRING'].replace(f'page={page_num}', '') + ('&' if self.request.GET.get('page') is None else '')
         context['query_str'] = queryStr
         context.update(paginator(self.request, submission_content, limit))
         context['pagination_url_namespaces'] = 'admin_submission:admin_submissions'

--- a/apcd-cms/src/apps/components/paginator/templates/paginator.html
+++ b/apcd-cms/src/apps/components/paginator/templates/paginator.html
@@ -7,7 +7,7 @@
         class="c-button c-button--as-link c-page-end"
         type="button"
         {% if page.has_previous %}
-            onclick="window.location.href='{% url pagination_url_namespaces %}{% if query_str %}{{ query_str }}{% elif selected_filter %}?filter={{selected_filter}}&{% elif selected_status %}?status={{selected_status}}&{% elif selected_org %}?org={{selected_org}}&{% else %}?{% endif %}page={{page.previous_page_number}}';"
+            onclick="window.location.href='{% url pagination_url_namespaces %}?page={{page.previous_page_number}}{{ query_str }}';"
         {% else %}
             disabled
         {% endif %}
@@ -20,7 +20,7 @@
                 <button 
                 class="c-button c-button--secondary {% if page.number == i %}c-button--is-active{% endif %} c-button--size-small c-page-item c-page-link c-page-link--always-click"
                 type="button"
-                onclick="window.location.href='{% url pagination_url_namespaces %}{% if query_str %}{{ query_str }}{% elif selected_filter %}?filter={{selected_filter}}&{% elif selected_status %}?status={{selected_status}}&{% elif selected_org %}?org={{selected_org}}&{% else %}?{% endif %}page={{i}}';"
+                onclick="window.location.href='{% url pagination_url_namespaces %}?page={{i}}{{ query_str }}';"
                 >
                     {{i}}
                 </button>
@@ -33,7 +33,7 @@
         class="c-button c-button--as-link c-page-end"
         type="button"
         {% if page.has_next %}
-            onclick="window.location.href='{% url pagination_url_namespaces %}{% if query_str %}{{ query_str }}{% elif selected_filter %}?filter={{selected_filter}}&{% elif selected_status %}?status={{selected_status}}&{% elif selected_org %}?org={{selected_org}}&{% else %}?{% endif %}page={{page.next_page_number}}';"
+            onclick="window.location.href='{% url pagination_url_namespaces %}?page={{page.next_page_number}}{{ query_str }}';"
         {% else %}
             disabled
         {% endif %}

--- a/apcd-cms/src/apps/submissions/templates/list_submissions.html
+++ b/apcd-cms/src/apps/submissions/templates/list_submissions.html
@@ -21,7 +21,7 @@
       <span><b>Filter by Status: </b></span>
       <select id="statusFilter" class="status-filter" onchange="filterTableByStatus()">
         {% for option in filter_options %}
-          <option class="dropdown-text" {% if option == selected_filter %}selected{% endif %}>{{ option }}</option>
+          <option class="dropdown-text" {% if option == selected_status %}selected{% endif %}>{{ option }}</option>
         {% endfor %}
       </select>
       <span><b>Sort by: </b></span>
@@ -31,7 +31,7 @@
           <option class="dropdown-text" value={{option}} {% if option == selected_sort %}selected{% endif %}>{{ display_text }}</option>
         {% endfor %}
       </select>
-      {% if selected_filter or selected_sort %}
+      {% if selected_status or selected_sort %}
         <button onclick="clearSelections()">Clear Options</button>
       {% endif %}
     </div>
@@ -69,9 +69,9 @@
         var filterDropdown, filterValue, url_params, url, xhr;
         filterDropdown = document.getElementById("statusFilter");
         filterValue =  filterDropdown.value;
-        url_params = `?filter=${filterValue}`;
+        url_params = `?status=${filterValue}`;
         {% if selected_sort %}
-            url_params = `?filter=${filterValue}&sort={{selected_sort}}`;
+            url_params = `?sort={{selected_sort}}&status=${filterValue}`;
         {% endif %}
         url = `/submissions/list-submissions/${url_params}`;
         xhr = new XMLHttpRequest();
@@ -85,8 +85,8 @@
         sortDropdown = document.getElementById('dateSort');
         sortValue =  sortDropdown.value;
         url_params = `?sort=${sortValue}`;
-        {% if selected_filter %}
-            url_params = `?filter={{selected_filter}}&sort=${sortValue}`;
+        {% if selected_status %}
+            url_params = `?sort=${sortValue}&status={{selected_status}}`;
         {% endif %}
         url = `/submissions/list-submissions/${url_params}`;
         xhr = new XMLHttpRequest();

--- a/apcd-cms/src/apps/submissions/urls.py
+++ b/apcd-cms/src/apps/submissions/urls.py
@@ -4,8 +4,8 @@ from apps.submissions.views import SubmissionsTable, check_submitter_role
 app_name = 'submissions'
 urlpatterns = [
     path('list-submissions/', SubmissionsTable.as_view(), name="list_submissions"),
-    path(r'list-submissions/?filter=(?P<filter>)/', SubmissionsTable.as_view(), name="list_submissions"),
+    path(r'list-submissions/?status=(?P<status>)/', SubmissionsTable.as_view(), name="list_submissions"),
     path(r'list-submissions/?sort=(?P<sort>)/', SubmissionsTable.as_view(), name="list_submissions"),
-    path(r'list-submissions/?filter=(?P<filter>)&sort=(?P<sort>)/', SubmissionsTable.as_view(), name="list_submissions"),
+    path(r'list-submissions/?sort=(?P<sort>)&status=(?P<status>)/', SubmissionsTable.as_view(), name="list_submissions"),
     path('check-submitter-role/', check_submitter_role),
 ]

--- a/apcd-cms/src/apps/submissions/views.py
+++ b/apcd-cms/src/apps/submissions/views.py
@@ -73,7 +73,7 @@ class SubmissionsTable(TemplateView):
         context['sort_options'] = {'newDate': 'Newest Received', 'oldDate': 'Oldest Received'}
 
         context['query_str'] = queryStr
-        context.update(paginator(self.request, submission_content, 1))
+        context.update(paginator(self.request, submission_content, limit))
         context['pagination_url_namespaces'] = 'submissions:list_submissions'
 
         return context

--- a/apcd-cms/src/apps/submissions/views.py
+++ b/apcd-cms/src/apps/submissions/views.py
@@ -28,8 +28,9 @@ class SubmissionsTable(TemplateView):
 
         submission_content = get_user_submissions_and_logs(user)
 
-        filter = self.request.GET.get('filter')
+        queryStr = ''
         dateSort = self.request.GET.get('sort')
+        status_filter = self.request.GET.get('status')
 
         def getDate(row):
             date = row['received_timestamp']
@@ -37,6 +38,7 @@ class SubmissionsTable(TemplateView):
 
         if dateSort is not None:
             context['selected_sort'] = dateSort
+            queryStr += f'&sort={dateSort}'
             submission_content = sorted(submission_content, key=lambda row:getDate(row), reverse=(dateSort == 'newDate'))
 
         try:
@@ -44,10 +46,11 @@ class SubmissionsTable(TemplateView):
         except:
             page_num = 1
 
-        context['selected_filter'] = None
-        if filter is not None and filter != 'All':
-            context['selected_filter'] = filter
-            submission_content = table_filter(filter, submission_content, 'status')
+        context['selected_status'] = None
+        if status_filter is not None and status_filter != 'All':
+            context['selected_status'] = status_filter
+            queryStr += f'&status={status_filter}'
+            submission_content = table_filter(status_filter, submission_content, 'status')
 
         limit = 50
         offset = limit * (page_num - 1)
@@ -69,11 +72,8 @@ class SubmissionsTable(TemplateView):
         context['filter_options'] = ['All', 'In Process', 'Complete']
         context['sort_options'] = {'newDate': 'Newest Received', 'oldDate': 'Oldest Received'}
 
-        queryStr = '?'
-        if len(self.request.META['QUERY_STRING']) > 0:
-            queryStr = queryStr + self.request.META['QUERY_STRING'].replace(f'page={page_num}', '') + ('&' if self.request.GET.get('page') is None else '')
         context['query_str'] = queryStr
-        context.update(paginator(self.request, submission_content, limit))
+        context.update(paginator(self.request, submission_content, 1))
         context['pagination_url_namespaces'] = 'submissions:list_submissions'
 
         return context

--- a/apcd-cms/src/apps/view_users/views.py
+++ b/apcd-cms/src/apps/view_users/views.py
@@ -50,12 +50,14 @@ class ViewUsersTable(TemplateView):
             if org_name not in context['filter_options']:  # prevent duplicates
                 context['filter_options'].append(user[4])
 
+        queryStr = ''
         status_filter = self.request.GET.get('status')
         org_filter = self.request.GET.get('org')
 
         context['selected_status'] = None
         if status_filter is not None and status_filter !='All':
             context['selected_status'] = status_filter
+            queryStr += f'&status={status_filter}'
             table_entries = table_filter(status_filter, table_entries, 'status', False)
 
 
@@ -63,13 +65,11 @@ class ViewUsersTable(TemplateView):
         context['selected_org'] = None
         if org_filter is not None and org_filter != 'All':
             context['selected_org'] = org_filter
+            queryStr += f'&org={org_filter}'
             table_entries = table_filter(org_filter.replace("(", "").replace(")",""), table_entries, 'org_name_no_parens')
 
-        queryStr = '?'
-        if len(self.request.META['QUERY_STRING']) > 0:
-            queryStr = queryStr + self.request.META['QUERY_STRING'].replace(f'page={page_num}', '') + ('&' if self.request.GET.get('page') is None else '')
         context['query_str'] = queryStr
-        context.update(paginator(self.request, table_entries))
+        context.update(paginator(self.request, table_entries, 2))
         context['pagination_url_namespaces'] = 'administration:view_users'
 
         return context

--- a/apcd-cms/src/apps/view_users/views.py
+++ b/apcd-cms/src/apps/view_users/views.py
@@ -69,7 +69,7 @@ class ViewUsersTable(TemplateView):
             table_entries = table_filter(org_filter.replace("(", "").replace(")",""), table_entries, 'org_name_no_parens')
 
         context['query_str'] = queryStr
-        context.update(paginator(self.request, table_entries, 2))
+        context.update(paginator(self.request, table_entries))
         context['pagination_url_namespaces'] = 'administration:view_users'
 
         return context


### PR DESCRIPTION
## Overview
For consistency and simplicity across listing pages, updated order for url parameters passed to paginator
…

## Related

- [WP-88](https://jira.tacc.utexas.edu/browse/WP-88)
<!--
- requires https://github.com/TACC/Core-CMS/pull/117
-->…

## Changes
- On paginator, now the page # is passed first in paginator buttons, and any filters are tagged on the end via context variable in each view
- In each view for listing pages, updated to read any non-page # to a context variable `query_str` for above
- For user and admin submissions, renamed status filter vars & url param to be consistent with other pages 
…

## Testing

1. On each listing page (urls listed below), check that:
    - Filter(s) function correctly (selected option populates drop down default value on page reload, url parameter populates in url)
    - Paginator functions normally
    - Both paginator and filters work correctly together
    - **Note: you will likely need to lower the # entries per page for all of these pages so the paginator has more than one button; you can do that on the line `context.update(paginator(self.request, ....` in each view by passing a third integer argument to the `paginator` function here


URLs:
- http://localhost:8000/administration/list-registration-requests/
- http://localhost:8000/administration/list-submissions/
- http://localhost:8000/administration/view-users/
- http://localhost:8000/administration/list-exceptions/
- http://localhost:8000/administration/list-extensions/
- http://localhost:8000/submissions/list-submissions/
## UI

…

<!--
## Notes

…
-->
