### PR TITLE
Updated extension admin org filter to display all first

### DIFF
--- a/apcd-cms/src/apps/admin_exception/templates/list_admin_exception.html
+++ b/apcd-cms/src/apps/admin_exception/templates/list_admin_exception.html
@@ -22,7 +22,6 @@
       <span><b>Filter by Organization: </b></span>
       <select id="organizationFilter" class="status-filter org-filter" onchange="sortByOrg()">
         <!-- Value set here so dropdown is not blank but set to All-->
-        <option class="dropdown-text" value={{selected_org.all}} {% if not selected_org %}selected{% else %} hidden {% endif %} disabled></option>
         {% for option in org_options %}
           <option class="dropdown-text" {% if option == selected_org %}selected{% endif %}>{{ option }}</option>
         {% endfor %}

--- a/apcd-cms/src/apps/admin_extension/templates/list_admin_extension.html
+++ b/apcd-cms/src/apps/admin_extension/templates/list_admin_extension.html
@@ -22,7 +22,6 @@
       <span><b>Filter by Organization: </b></span>
       <select id="organizationFilter" class="status-filter org-filter" onchange="sortByOrg()">
         <!-- Value set here so dropdown is not blank but set to All-->
-        <option class="dropdown-text" value={{selected_org.all}} {% if not selected_org %}selected{% else %} hidden {% endif %} disabled></option>
         {% for option in org_options %}
           <option class="dropdown-text" {% if option == selected_org %}selected{% endif %}>{{ option }}</option>
         {% endfor %}

--- a/apcd-cms/src/apps/admin_extension/views.py
+++ b/apcd-cms/src/apps/admin_extension/views.py
@@ -108,10 +108,10 @@ class AdminExtensionsTable(TemplateView):
             outcome = title_case(extension[8])
             if org_name not in context['org_options']:
                 context['org_options'].append(org_name)
-                context['org_options'] = sorted(context['org_options'])
+                context['org_options'] = sorted(context['org_options'], key=lambda x: (x != 'All', x))
             if status not in context['status_options']:
                 context['status_options'].append(status)
-                context['status_options'] = sorted(context['status_options'])
+                context['status_options'] = sorted(context['status_options'], key=lambda x: (x != 'All', x))
             if outcome not in context['outcome_options']:
                 context['outcome_options'].append(outcome)
                 context['outcome_options'] = context['outcome_options']


### PR DESCRIPTION
## Overview

To fix bug on extension admin table so that org filter displays All first and doesn't assign it to the first alphabetized org name.

## Related


- [WP-199](https://jira.tacc.utexas.edu/browse/WP-199)


## Changes

-Created function in extension admin view so that the view doesn't sort All as it iterates through and sorts organization names
- Removed empty drop down choice in org filter for both exceptions and extensions. No longer needed.

## Testing

1. Go to [http://localhost:8000/administration/list-extensions/]( http://localhost:8000/administration/list-extensions/)
2. Make sure that All is first on the list. Can test with stache production creds to see that All is no longer alphabetized.
3. Go to [http://localhost:8000/administration/list-exceptions/](http://localhost:8000/administration/list-exceptions/)
4. Make sure that All is first on the list and not a blank row. 

## UI
<h2>Extensions</h2>
<img width="1161" alt="Screenshot 2023-07-26 at 6 22 41 PM" src="https://github.com/TACC/Core-CMS-Custom/assets/96220951/25aef324-293a-4f10-b07a-e796fd791199">

<img width="1453" alt="Screenshot 2023-07-26 at 6 22 59 PM" src="https://github.com/TACC/Core-CMS-Custom/assets/96220951/dcf84de2-4c87-4187-9e8c-3178fbab9040">

No longer starts with blank row
<img width="1186" alt="Screenshot 2023-07-27 at 12 07 29 PM" src="https://github.com/TACC/Core-CMS-Custom/assets/96220951/3ce23371-698e-4a17-8a81-ada5eed6aa9f">


<h2>Exceptions</h2>
<img width="1227" alt="Screenshot 2023-07-27 at 12 06 55 PM" src="https://github.com/TACC/Core-CMS-Custom/assets/96220951/34929e9e-742c-4b59-8634-ce52b3cbd759">


