### PR TITLE
hotfix: cms v3.12.0-beta

### DIFF
--- a/a2cps_cms/Dockerfile
+++ b/a2cps_cms/Dockerfile
@@ -1,5 +1,5 @@
 # TACC/Core-CMS#v3.12.0-beta.2 candidate
-FROM taccwma/core-cms:1775c45
+FROM taccwma/core-cms:55db2ed
 
 WORKDIR /code
 

--- a/a2cps_cms/Dockerfile
+++ b/a2cps_cms/Dockerfile
@@ -1,5 +1,5 @@
-# TACC/Core-CMS#v3.12.0-alpha.12
-FROM taccwma/core-cms:59f1592
+# TACC/Core-CMS#v3.12.0-beta.2 candidate
+FROM taccwma/core-cms:1775c45
 
 WORKDIR /code
 

--- a/apcd-cms/Dockerfile
+++ b/apcd-cms/Dockerfile
@@ -1,5 +1,5 @@
-# TACC/Core-CMS#v3.11.2 candidate
-FROM taccwma/core-cms:352339c
+# TACC/Core-CMS#v3.11.6
+FROM taccwma/core-cms:c5bea4c
 
 WORKDIR /code
 

--- a/demdata_cms/Dockerfile
+++ b/demdata_cms/Dockerfile
@@ -1,5 +1,5 @@
 # TACC/Core-CMS#v3.12.0-beta.2 candidate
-FROM taccwma/core-cms:1775c45
+FROM taccwma/core-cms:55db2ed
 
 WORKDIR /code
 

--- a/demdata_cms/Dockerfile
+++ b/demdata_cms/Dockerfile
@@ -1,5 +1,5 @@
-# TACC/Core-CMS#v3.12.0-alpha.5
-FROM taccwma/core-cms:511792b
+# TACC/Core-CMS#v3.12.0-beta.2 candidate
+FROM taccwma/core-cms:1775c45
 
 WORKDIR /code
 

--- a/matcssi_cms/Dockerfile
+++ b/matcssi_cms/Dockerfile
@@ -1,5 +1,5 @@
-# TACC/Core-CMS#v3.11.2 candidate
-FROM taccwma/core-cms:352339c
+# TACC/Core-CMS#v3.11.6
+FROM taccwma/core-cms:c5bea4c
 
 WORKDIR /code
 

--- a/tapisproject_cms/Dockerfile
+++ b/tapisproject_cms/Dockerfile
@@ -1,5 +1,5 @@
-# v3.11.4
-FROM taccwma/core-cms:cd2c989
+# TACC/Core-CMS#v3.11.6
+FROM taccwma/core-cms:c5bea4c
 
 WORKDIR /code
 


### PR DESCRIPTION
## Overview

Use image for Core-CMS since:
- https://github.com/TACC/Core-CMS/pull/697

## Related

- similar to https://github.com/TACC/Core-Portal-Deployments/pull/26
- similar to PR yet to be made

## Changes

- **changed** all Core-CMS image tags — updated each to latest patch version

## Testing

1. Build each.
2. Deploy each to test server.