### PR TITLE
hotfix: SESSION_COOKIE_SECURE = True

### DIFF
--- a/apcd-cms/src/taccsite_cms/settings_custom.py
+++ b/apcd-cms/src/taccsite_cms/settings_custom.py
@@ -2,6 +2,14 @@
 # TACC WMA CMS SITE:
 # *.APCD.TACC.UTEXAS.EDU
 
+########################
+# CORE CMS SETTINGS
+# FAQ: These are in future versions of Core-CMS
+########################
+
+# NOTE: Already in Core-CMS v3.12.0-beta.2, v3.11.6, and (untested) v3.9.5
+# whether the session cookie should be secure (https:// only)
+SESSION_COOKIE_SECURE = True
 
 ########################
 # DJANGO CMS SETTINGS


### PR DESCRIPTION
## Overview

Hotfix setting `SESSION_COOKIE_SECURE = True`.

> **Warning**
> Unable to test on an environment that mirrors produciton.

## Related

- mimics https://github.com/TACC/Core-CMS/pull/695
- alternative to https://github.com/TACC/Core-CMS-Custom/pull/196

## Changes

- **added** new setting

## Testing

### Portal Login Cookie

1. In Chrome/ium DevTools > Application > Cookies
2. Confirm "Secure" column for "sessionid" cookie is **checked**.

### Any CMS Page

Confirm style on CMS pages is unchanged from https://txapcd.org/.

## UI

Skipped.