### PR TITLE
hotfix/WP-232-234-Include-text-areas-validation

### DIFF
--- a/apcd-cms/src/apps/exception/templates/exception_submission_form/exception_other_form.html
+++ b/apcd-cms/src/apps/exception/templates/exception_submission_form/exception_other_form.html
@@ -145,7 +145,7 @@
         <script src="{% static 'utils/js/checkForBlankInputs.js' %}"></script>
         {# Adds blank space listener to all text input fields on page load #}
         <script>
-          const formTextInputs = document.querySelectorAll('input');
+          const formTextInputs = document.querySelectorAll('input, textarea');
           noEmptyInputs(formTextInputs);          
         </script> 
         <!-- To require exception is not longer than a year -->

--- a/apcd-cms/src/apps/exception/templates/exception_submission_form/exception_threshold_form.html
+++ b/apcd-cms/src/apps/exception/templates/exception_submission_form/exception_threshold_form.html
@@ -214,7 +214,7 @@
         <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
         {# Adds blank space listener to all text input fields on page load #}
         <script>
-          const formTextInputs = document.querySelectorAll('input');
+          const formTextInputs = document.querySelectorAll('input, textarea');
           noEmptyInputs(formTextInputs);          
         </script> 
         <!-- To require exception is not longer than a year -->

--- a/apcd-cms/src/apps/extension/templates/extension_submission_form/extension_submission_form.html
+++ b/apcd-cms/src/apps/extension/templates/extension_submission_form/extension_submission_form.html
@@ -196,7 +196,7 @@
         <script src="{% static 'utils/js/checkForBlankInputs.js' %}"></script>
         <!--Adds blank space listener to all text input fields on page load #-->
         <script>
-          const formTextInputs = document.querySelectorAll('input');
+          const formTextInputs = document.querySelectorAll('input, textarea');
           noEmptyInputs(formTextInputs);
         </script> 
         <!-- To let user add and remove entities -->

--- a/apcd-cms/src/apps/registrations/templates/submission_form/registration_form_scripts.html
+++ b/apcd-cms/src/apps/registrations/templates/submission_form/registration_form_scripts.html
@@ -6,7 +6,7 @@
     <script src="{% static 'utils/js/checkForBlankInputs.js' %}"></script>
     {# Adds blank space listener to all text input fields on page load #}
     <script>
-      const formTextInputs = document.querySelectorAll('input');
+      const formTextInputs = document.querySelectorAll('input, textarea');
       noEmptyInputs(formTextInputs);
     </script>
     {# To require at least one "entity" identifier value #}

--- a/apcd-cms/src/apps/registrations/views.py
+++ b/apcd-cms/src/apps/registrations/views.py
@@ -10,10 +10,10 @@ import rt
 
 logger = logging.getLogger(__name__)
 
-# RT_HOST = getattr(settings, 'RT_HOST', '')
-# RT_UN = getattr(settings, 'RT_UN', '')
-# RT_PW = getattr(settings, 'RT_PW', '')
-# RT_QUEUE = getattr(settings, 'RT_QUEUE', '')
+RT_HOST = getattr(settings, 'RT_HOST', '')
+RT_UN = getattr(settings, 'RT_UN', '')
+RT_PW = getattr(settings, 'RT_PW', '')
+RT_QUEUE = getattr(settings, 'RT_QUEUE', '')
 
 
 class SubmissionFormView(View):
@@ -49,8 +49,8 @@ class SubmissionFormView(View):
             errors.append(_err_msg(reg_resp))
 
         # ===> Create Ticket
-        # tracker = rt.Rt(RT_HOST, RT_UN, RT_PW, http_auth=HTTPBasicAuth(RT_UN, RT_PW))
-        # tracker.login()
+        tracker = rt.Rt(RT_HOST, RT_UN, RT_PW, http_auth=HTTPBasicAuth(RT_UN, RT_PW))
+        tracker.login()
 
         subject = "New TX-APCD Portal Registration"
         description = "APCD Registration Details\n"
@@ -71,12 +71,12 @@ class SubmissionFormView(View):
             template = loader.get_template('submission_form/submission_success.html')
             response = HttpResponse(template.render(context, request))
 
-        # tracker.create_ticket(
-        #     Queue=RT_QUEUE,
-        #     Subject=subject,
-        #     Text=description,
-        #     Requestors=email
-        # )
+        tracker.create_ticket(
+            Queue=RT_QUEUE,
+            Subject=subject,
+            Text=description,
+            Requestors=email
+        )
 
         return response
 

--- a/apcd-cms/src/apps/registrations/views.py
+++ b/apcd-cms/src/apps/registrations/views.py
@@ -10,10 +10,10 @@ import rt
 
 logger = logging.getLogger(__name__)
 
-RT_HOST = getattr(settings, 'RT_HOST', '')
-RT_UN = getattr(settings, 'RT_UN', '')
-RT_PW = getattr(settings, 'RT_PW', '')
-RT_QUEUE = getattr(settings, 'RT_QUEUE', '')
+# RT_HOST = getattr(settings, 'RT_HOST', '')
+# RT_UN = getattr(settings, 'RT_UN', '')
+# RT_PW = getattr(settings, 'RT_PW', '')
+# RT_QUEUE = getattr(settings, 'RT_QUEUE', '')
 
 
 class SubmissionFormView(View):
@@ -49,8 +49,8 @@ class SubmissionFormView(View):
             errors.append(_err_msg(reg_resp))
 
         # ===> Create Ticket
-        tracker = rt.Rt(RT_HOST, RT_UN, RT_PW, http_auth=HTTPBasicAuth(RT_UN, RT_PW))
-        tracker.login()
+        # tracker = rt.Rt(RT_HOST, RT_UN, RT_PW, http_auth=HTTPBasicAuth(RT_UN, RT_PW))
+        # tracker.login()
 
         subject = "New TX-APCD Portal Registration"
         description = "APCD Registration Details\n"
@@ -71,12 +71,12 @@ class SubmissionFormView(View):
             template = loader.get_template('submission_form/submission_success.html')
             response = HttpResponse(template.render(context, request))
 
-        tracker.create_ticket(
-            Queue=RT_QUEUE,
-            Subject=subject,
-            Text=description,
-            Requestors=email
-        )
+        # tracker.create_ticket(
+        #     Queue=RT_QUEUE,
+        #     Subject=subject,
+        #     Text=description,
+        #     Requestors=email
+        # )
 
         return response
 


### PR DESCRIPTION
## Overview

The purpose of this hotfix is to fix bug where the script checking for bad characters doesn't check the justification fields on extension and exception forms.

Your thoroughness of testing is really appreciated! I know it's tedious. Using Django or React utilities in place of this band-aid is the long term goal once the fire is put out.


## Related

- [WP-232](https://jira.tacc.utexas.edu/browse/WP-232)
- [WP-233](https://jira.tacc.utexas.edu/browse/WP-233)
- [WP-234](https://jira.tacc.utexas.edu/browse/WP-234)
- follow up to #195

## Changes

The checkForBlankInputs javascript was changed using whitelist methods to allow characters in input. At the same time, the script blacklists some explicit scripting character patterns. This is a front end change to prevent bad characters from making it to the server. The DB utils remove bad characters server side in apcd_database.py. 


## Testing

1. Go to [http://localhost:8000/register/request-to-submit/](http://localhost:8000/register/request-to-submit/)
2. Try to input **<script> </script> javascript.exe, anything in "quotes" or 'quotes" { hello.exe } thisshouldwork@test.com into the field** into the  explanation justification field
3. On change. the field should be replaced  with **Try to input script script exe anything in quotes or quotes  helloexe  thisshouldworktestcom**
4. Go to [http://localhost:8000/submissions/threshold-exception/](http://localhost:8000/submissions/threshold-exception/)
5. Repeat steps 2 and 3
6. Go to [http://localhost:8000/submissions/other-exception/](http://localhost:8000/submissions/other-exception/)
7. Repeat steps 2 and 3
8. Go to [https://apcd-qa.tacc.utexas.edu/submissions/extension-request/](https://apcd-qa.tacc.utexas.edu/submissions/extension-request/)
9.  Repeat steps 2 and 3


## UI

###User input:

<img width="1434" alt="Screenshot 2023-08-22 at 6 07 51 PM" src="https://github.com/TACC/Core-CMS-Custom/assets/96220951/ae9b3058-e23f-43ca-b125-40f148f15a00">

###On change, text is changed to :

<img width="988" alt="Screenshot 2023-08-22 at 6 08 53 PM" src="https://github.com/TACC/Core-CMS-Custom/assets/96220951/7cac8006-4364-42dc-b8de-1bce45fc27d9">

