### PR TITLE
hotfix/APCD-PROD-page-displaying-html-attr

### DIFF
--- a/apcd-cms/src/apps/registrations/templates/submission_form/registration_form_scripts.html
+++ b/apcd-cms/src/apps/registrations/templates/submission_form/registration_form_scripts.html
@@ -419,7 +419,8 @@
         const addContactTextInputs = document.querySelectorAll(`
           input[name=contact_type_${contacts}{% if r %}_{{r.reg_id}}{% endif %}],
           input[name=contact_name_${contacts}{% if r %}_{{r.reg_id}}{% endif %}],
-          input[name=contact_phone_${contacts}{% if r %}_{{r.reg_id}}{% endif %}]
+          input[name=contact_phone_${contacts}{% if r %}_{{r.reg_id}}{% endif %}],
+          input[name=contact_email_${contacts}{% if r %}_{{r.reg_id}}{% endif %}]
         `);
         noEmptyInputs(addContactTextInputs);
 

--- a/apcd-cms/src/apps/registrations/templates/submission_form/registration_form_scripts.html
+++ b/apcd-cms/src/apps/registrations/templates/submission_form/registration_form_scripts.html
@@ -365,7 +365,7 @@
                 class="telephoneinput"
                 id="contact_phone_${contacts}{% if r %}_{{r.reg_id}}{% endif %}"
                 inputmode="tel"
-                pattern="^(\\+0?1\\s)?\\(?(?![{}'"<>\\/])\\d{3}\\)?(?![{}'"<>\\/])[\\s.-](?![{}'"<>\\/])\\d{3}(?![{}'"<>\\/])[\\s.-](?![{}'"<>\\/])\\d{4}$"
+                pattern="^(\\+0?1\\s)?\\(?\\d{3}\\)?[\\s.-]\\d{3}[\\s.-]\\d{4}$"
               />
               <div id="help-text-contact_phone_${contacts}" class="help-text">
                 <details>
@@ -418,7 +418,8 @@
 
         const addContactTextInputs = document.querySelectorAll(`
           input[name=contact_type_${contacts}{% if r %}_{{r.reg_id}}{% endif %}],
-          input[name=contact_name_${contacts}{% if r %}_{{r.reg_id}}{% endif %}]
+          input[name=contact_name_${contacts}{% if r %}_{{r.reg_id}}{% endif %}],
+          input[name=contact_phone_${contacts}{% if r %}_{{r.reg_id}}{% endif %}]
         `);
         noEmptyInputs(addContactTextInputs);
 


### PR DESCRIPTION
## Overview

This addresses the issue on prod that displays the pattern attribute for a telephone number input for an added contact

## Related

- [WP-232](https://jira.tacc.utexas.edu/browse/WP-232)
- [WP-233](https://jira.tacc.utexas.edu/browse/WP-233)
- [WP-234](https://jira.tacc.utexas.edu/browse/WP-234)
- mimics #195

## Changes

The checkForBlankInputs javascript was changed using whitelist methods to allow characters in input. At the same time, the script blacklists some explicit scripting character patterns. The innerHTML was causing some of the regrex escape characters to not be read correctly. Adjusted the use of the script within the add contact button's script.


## Testing

1. Go to [http://localhost:8000/register/request-to-submit/](http://localhost:8000/register/request-to-submit/)
2. Fill out form and add a contact
3. Try to input **<script> </script> javascript.exe, anything in "quotes" or 'quotes" { hello.exe } thisshouldwork@test.com into any field** into a contact name field and make sure invalid characters are removed
