### PR TITLE
Remove admin, exception, extension, and submission table from prod

### DIFF
--- a/apcd-cms/src/taccsite_cms/custom_app_settings.py
+++ b/apcd-cms/src/taccsite_cms/custom_app_settings.py
@@ -1,4 +1,5 @@
-CUSTOM_APPS = ['apps.admin_regis_table', 'apps.apcd_login', 'apps.registrations', 'apps.submissions', 'apps.exception', 'apps.admin_submissions', 'apps.admin_extension', 'apps.admin_exception', 'apps.extension', 'apps.view_users', 'apps.utils']
+CUSTOM_APPS = ['apps.apcd_login', 'apps.registrations', 'apps.components.paginator', 'apps.utils']
 CUSTOM_MIDDLEWARE = []
-STATICFILES_DIRS = ('taccsite_custom/apcd-cms', 'apps/admin_regis_table', 'apps/submissions', 'apps/exception', 'apps/extension','apps/view_users')
-
+STATICFILES_DIRS = ('taccsite_custom/apcd-cms', 'apps/components/paginator', 'apps/utils')
+# Removed apps not needed for prod 8.30.2023 
+# Check file history to add back admin, exception, extension, and submission apps

--- a/apcd-cms/src/taccsite_cms/urls_custom.py
+++ b/apcd-cms/src/taccsite_cms/urls_custom.py
@@ -1,14 +1,14 @@
 from django.urls import path, include
-
+# Removed admin feature pages, extension, and exception from prod
 custom_urls = [
-    path('administration/', include('apps.admin_regis_table.urls', namespace='administration')),
-    path('administration/', include('apps.view_users.urls', namespace='viewusers')),
-    path('administration/', include('apps.admin_submissions.urls', namespace='admin_submission')),
-    path('administration/', include('apps.admin_exception.urls', namespace='admin_exception')),
-    path('administration/', include('apps.admin_extension.urls', namespace='admin_extension')),
+    # path('administration/', include('apps.admin_regis_table.urls', namespace='administration')),
+    # path('administration/', include('apps.view_users.urls', namespace='viewusers')),
+    # path('administration/', include('apps.admin_submissions.urls', namespace='admin_submission')),
+    # path('administration/', include('apps.admin_exception.urls', namespace='admin_exception')),
+    # path('administration/', include('apps.admin_extension.urls', namespace='admin_extension')),
     path('apcd-login/', include('apps.apcd_login.urls', namespace='apcd_login')),
     path('register/', include('apps.registrations.urls', namespace='register')),
-    path('submissions/', include('apps.extension.urls', namespace='extension')),
-    path('submissions/', include('apps.exception.urls', namespace='exception')),
-    path('submissions/', include('apps.submissions.urls', namespace='submissions'))
+    # path('submissions/', include('apps.extension.urls', namespace='extension')),
+    # path('submissions/', include('apps.exception.urls', namespace='exception')),
+    # path('submissions/', include('apps.submissions.urls', namespace='submissions'))
 ]


### PR DESCRIPTION
## Overview

To remove apps from prod so that only request to submit is allowed 

## Related


## Changes

Removed custom urls and apps for pages we do not need.

## Testing

1. Ensure that http://localhost:8000/register/request-to-submit/ still works and has input validators the same as previous PRs for prod
2. Go to each page below and make sure there is no error, but no page loads either. 

- http://localhost:8000/administration/list-registration-requests/
-  http://localhost:8000/submissions/exception/ 
- http://localhost:8000/submissions/extension-request/
- http://localhost:8000/administration/view-users/
- http://localhost:8000/administration/list-exceptions/
- http://localhost:8000/administration/list-extensions/
- http://localhost:8000/administration/list-submissions/

NOTE: There still is communication with the server this way. This is simply making the templates not render at all on the page. This does cause a 404

## UI

…

<!--
## Notes

…
-->
