### PR TITLE
hotfix: Check submitter role restored in prod

### DIFF
--- a/apcd-cms/src/apps/submissions/urls.py
+++ b/apcd-cms/src/apps/submissions/urls.py
@@ -3,6 +3,6 @@ from apps.submissions.views import SubmissionsTable, check_submitter_role
 
 app_name = 'submissions'
 urlpatterns = [
-    path('list-submissions/', SubmissionsTable.as_view()),
+    #path('list-submissions/', SubmissionsTable.as_view()),
     path('check-submitter-role/', check_submitter_role),
 ]

--- a/apcd-cms/src/apps/submissions/urls.py
+++ b/apcd-cms/src/apps/submissions/urls.py
@@ -3,6 +3,5 @@ from apps.submissions.views import SubmissionsTable, check_submitter_role
 
 app_name = 'submissions'
 urlpatterns = [
-    #path('list-submissions/', SubmissionsTable.as_view()),
     path('check-submitter-role/', check_submitter_role),
 ]

--- a/apcd-cms/src/apps/submissions/views.py
+++ b/apcd-cms/src/apps/submissions/views.py
@@ -8,7 +8,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-'''
+
 class SubmissionsTable(TemplateView):
 
     template_name = 'list_submissions.html'
@@ -62,7 +62,7 @@ class SubmissionsTable(TemplateView):
 
         return context
 
-'''
+
 @login_required
 def check_submitter_role(request):
     logger.info("Checking submitter access for user: %s", request.user.username)

--- a/apcd-cms/src/apps/submissions/views.py
+++ b/apcd-cms/src/apps/submissions/views.py
@@ -1,14 +1,14 @@
 from django.http import HttpResponseRedirect, JsonResponse
-from django.views.generic.base import TemplateView
+#from django.views.generic.base import TemplateView
 from django.contrib.auth.decorators import login_required
-from apps.utils.apcd_database import get_submissions, get_submission_logs
+#from apps.utils.apcd_database import get_submissions, get_submission_logs
 from apps.utils.apcd_groups import has_apcd_group
-from apps.utils.utils import title_case
+#from apps.utils.utils import title_case
 import logging
 
 logger = logging.getLogger(__name__)
 
-
+'''
 class SubmissionsTable(TemplateView):
 
     template_name = 'list_submissions.html'
@@ -62,7 +62,7 @@ class SubmissionsTable(TemplateView):
 
         return context
 
-
+'''
 @login_required
 def check_submitter_role(request):
     logger.info("Checking submitter access for user: %s", request.user.username)

--- a/apcd-cms/src/taccsite_cms/custom_app_settings.py
+++ b/apcd-cms/src/taccsite_cms/custom_app_settings.py
@@ -1,4 +1,4 @@
-CUSTOM_APPS = ['apps.apcd_login', 'apps.registrations', 'apps.utils']
+CUSTOM_APPS = ['apps.apcd_login', 'apps.registrations', 'apps.submissions', 'apps.utils']
 CUSTOM_MIDDLEWARE = []
 STATICFILES_DIRS = ('taccsite_custom/apcd-cms', 'apps/utils')
 # Removed apps not needed for prod 8.30.2023 

--- a/apcd-cms/src/taccsite_cms/urls_custom.py
+++ b/apcd-cms/src/taccsite_cms/urls_custom.py
@@ -10,5 +10,5 @@ custom_urls = [
     path('register/', include('apps.registrations.urls', namespace='register')),
     # path('submissions/', include('apps.extension.urls', namespace='extension')),
     # path('submissions/', include('apps.exception.urls', namespace='exception')),
-    # path('submissions/', include('apps.submissions.urls', namespace='submissions'))
+    path('submissions/', include('apps.submissions.urls', namespace='submissions'))
 ]

--- a/apcd-cms/src/taccsite_cms/urls_custom.py
+++ b/apcd-cms/src/taccsite_cms/urls_custom.py
@@ -1,14 +1,7 @@
 from django.urls import path, include
 # Removed admin feature pages, extension, and exception from prod
 custom_urls = [
-    # path('administration/', include('apps.admin_regis_table.urls', namespace='administration')),
-    # path('administration/', include('apps.view_users.urls', namespace='viewusers')),
-    # path('administration/', include('apps.admin_submissions.urls', namespace='admin_submission')),
-    # path('administration/', include('apps.admin_exception.urls', namespace='admin_exception')),
-    # path('administration/', include('apps.admin_extension.urls', namespace='admin_extension')),
     path('apcd-login/', include('apps.apcd_login.urls', namespace='apcd_login')),
     path('register/', include('apps.registrations.urls', namespace='register')),
-    # path('submissions/', include('apps.extension.urls', namespace='extension')),
-    # path('submissions/', include('apps.exception.urls', namespace='exception')),
     path('submissions/', include('apps.submissions.urls', namespace='submissions'))
 ]


### PR DESCRIPTION
## Overview
Adding back check submitter role endpoint for prod APCD
…

## Related

<!--
- [FP-123](https://jira.tacc.utexas.edu/browse/FP-123)
- requires https://github.com/TACC/Core-CMS/pull/117
-->…

## Changes
- Added relevant endpoint and view back to submissions custom app
- Added submissions custom app back to Django registry
…

## Testing

1. N/A

## UI

…

<!--
## Notes

…
-->
