### PR TITLE
docs: don't forget portal favicon when porting

### DIFF
--- a/docs/port-project.md
+++ b/docs/port-project.md
@@ -37,6 +37,20 @@ Follow steps in [Create a New Project](./develop-project.md#create-a-new-project
 
 ### Known Gotchas
 
+#### Has a [Core Portal]
+
+**If** the custom project has a [Core Portal] i.e. settings has `FAVICON` and:
+
+- **either** settings has `INCLUDES_CORE_PORTAL = True`
+- **or** settings does **not** have `INCLUDES_CORE_PORTAL`
+
+Then:
+
+1. You must edit [Core Portal Deployments].
+2. Edit `custom_project_dir/camino/prod.settings_custom.py`.
+3. Change `_PORTAL_ICON_FILENAME` to:\
+    `/static/` + ( the `img_file_src` of `FAVICON` )
+
 #### Old Custom Templates Directory
 
 **If** the custom project directory:
@@ -121,5 +135,7 @@ Then:
 <!-- Link Aliases -->
 
 [Core CMS]: https://github.com/TACC/Core-CMS
+[Core Portal]: https://github.com/TACC/Core-Portal
 [Core CMS Custom]: https://github.com/TACC/Core-CMS-Custom
 [Core CMS Resources]: https://github.com/TACC/Core-CMS-Resources
+[Core Portal Deployments]: https://github.com/TACC/Core-Portal-Deployments

--- a/docs/port-project.md
+++ b/docs/port-project.md
@@ -47,7 +47,7 @@ Follow steps in [Create a New Project](./develop-project.md#create-a-new-project
 Then:
 
 1. You must edit [Core Portal Deployments].
-2. Edit `custom_project_dir/camino/___.settings_custom.py` (not `___.cms`).
+2. Edit `custom_project_dir/camino/___.settings_custom.py` (not `___.cms.…`).
 3. Change `_PORTAL_ICON_FILENAME` to:\
     `/static/` + ( the `img_file_src` of `FAVICON` )
 

--- a/docs/port-project.md
+++ b/docs/port-project.md
@@ -47,7 +47,7 @@ Follow steps in [Create a New Project](./develop-project.md#create-a-new-project
 Then:
 
 1. You must edit [Core Portal Deployments].
-2. Edit `custom_project_dir/camino/prod.settings_custom.py`.
+2. Edit `custom_project_dir/camino/___.settings_custom.py` (not `___.cms`).
 3. Change `_PORTAL_ICON_FILENAME` to:\
     `/static/` + ( the `img_file_src` of `FAVICON` )
 


### PR DESCRIPTION
## Overview

Remind devs porting a project to update Portal favicon, if relevant.

## Related

- similar to 

## Changes

- **added** sub-section to porting doc

## Testing & UI

1. Open https://github.com/TACC/Core-CMS-Custom/blob/docs/portal-favicon-when-porting/docs/port-project.md#has-a-core-portal.
2. Read words.
3. Test links.