### PR TITLE
bug/WP-340: Fix for add/remove entity buttons on edit registration

### DIFF
--- a/apcd-cms/src/apps/registrations/templates/submission_form/registration_form_scripts.html
+++ b/apcd-cms/src/apps/registrations/templates/submission_form/registration_form_scripts.html
@@ -345,12 +345,12 @@
           <div id="help-text-total_claims_value_${entities}" class="help-text">
           </div>
         </div>
-        ${ entities === 5 ?
-            {% if not r %}
+        {% if not r %}
+        ${( entities === 5 ?
              `<p class="c-message c-message--type-info c-message--scope-inline">If you need to associate more than 5 entities with your registration, <a href="/workbench/dashboard" target="_blank">submit a ticket</a> with your additional entries and your registration ID (displayed after submitting this form).</p>`
-            {% endif %}
           : ''
-        }
+        )}
+        {% endif %}
         `;
         entityIdGroupValidation(entities, reg_id); // add entity input validation for new entities on form
         entityPlanTypeValidation(entities, reg_id);


### PR DESCRIPTION
## Overview
Fixes bug where add/remove buttons for entities were not responding when editing a registration on Admin List Registrations page
…

## Related

- [WP-340](https://jira.tacc.utexas.edu/browse/WP-340)
<!--
- requires https://github.com/TACC/Core-CMS/pull/117
-->…

## Changes
- Moved a html templating {% if %} statement outside of its previously-surrounding JSX string literal `${}` to resolve bug with compact if-else (`? :`)
…

## Testing

1. Go to http://localhost:8000/administration/list-registration-requests/
2. On any record, select 'Edit Record' from the Actions drop down
3. Try both adding and removing entities from the record with the corresponding buttons and confirm said buttons are responding
4. Bonus: try submitting the form with an additional/removed entity and confirm the submission is successful and, upon reload, the same record now reflects the submitted change

## UI

…

<!--
## Notes

…
-->
