### PR TITLE
task/WP-347: Restrict registration renewal access

### DIFF
--- a/apcd-cms/src/apps/registrations/views.py
+++ b/apcd-cms/src/apps/registrations/views.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.http import HttpResponse, HttpResponseRedirect
 from django.template import loader
 from django.views.generic import View
+from django.shortcuts import redirect
 from requests.auth import HTTPBasicAuth
 import logging
 import rt
@@ -28,9 +29,7 @@ class SubmissionFormView(View):
             try:
                 response = get_submitter_code(request.user)
                 submitter_code = json.loads(response.content)['submitter_code']
-                logger.error(submitter_code)
                 submitter_registrations = apcd_database.get_registrations(submitter_code=submitter_code)
-                logger.error(submitter_registrations)
                 registration_content = [registration for registration in submitter_registrations if registration[0] == int(reg_id)][0]
                 registration_entities = apcd_database.get_registration_entities(reg_id=reg_id)
                 registration_contacts = apcd_database.get_registration_contacts(reg_id=reg_id)
@@ -38,6 +37,7 @@ class SubmissionFormView(View):
                 formatted_reg_data = _set_registration(registration_content, registration_entities, registration_contacts)
             except Exception as exception:
                 logger.error(exception)
+                return redirect('/register/request-to-submit/')
         if (request.user.is_authenticated and has_apcd_group(request.user)):
             template = loader.get_template('submission_form/submission_form.html')
             return HttpResponse(template.render({'r': formatted_reg_data, 'renew': renew}, request))

--- a/apcd-cms/src/apps/submitter_renewals_listing/templates/list_submitter_registrations.html
+++ b/apcd-cms/src/apps/submitter_renewals_listing/templates/list_submitter_registrations.html
@@ -114,11 +114,12 @@
       $(`#${modal_id}`).modal({backdrop: "static"}); /* modal appears manually */
       actionsDropdown.selectedIndex = 0; /* resets dropdown to display 'Select Action' again */
       if (selectedOption == "renewRegistration") {
-        var xhr;
+        var xhr, url;
+        url = `/register/request-to-submit/?reg_id=${reg_id}`
         xhr = new XMLHttpRequest();
-        xhr.open('GET', `/register/request-to-submit/?reg_id=${reg_id}`)
+        xhr.open('GET', url)
         xhr.send()
-        window.location.href = `/register/request-to-submit/?reg_id=${reg_id}`;
+        window.location.href = url;
         window.location.load();
       }
     }

--- a/apcd-cms/src/apps/submitter_renewals_listing/views.py
+++ b/apcd-cms/src/apps/submitter_renewals_listing/views.py
@@ -1,5 +1,4 @@
 from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
-from django.views.generic.base import TemplateView
 from django.template import loader
 from apps.utils.apcd_database import get_registrations, get_registration_contacts, get_submitter_info, get_registration_entities
 from apps.utils.apcd_groups import is_submitter_admin
@@ -40,9 +39,10 @@ class SubmittersTable(RegistrationsTable):
         context['header'] = ['Business Name', 'Year', 'Type', 'Location', 'Registration Status', 'Actions']
         context['pagination_url_namespaces'] = 'register:submitter_regis_table'
         return context
-    
+
+
 def get_submitter_code(request):
     submitter = get_submitter_info(str(request))
     for i in submitter:
-        submitter_code =  i[1]
-    return JsonResponse(({'submitter_code' : submitter_code } if submitter_code else ""), safe=False)
+        submitter_code = i[1]
+    return JsonResponse(({'submitter_code' : submitter_code} if submitter_code else ""), safe=False)


### PR DESCRIPTION
## Overview
With passing reg_id as a url parameter to the registration form to initiate a renewal, need to check both user role and reg_id validity for said user before a renewal can be initiated on the form.

## Related

- [WP-347](https://jira.tacc.utexas.edu/browse/WP-347)
<!--
- requires https://github.com/TACC/Core-CMS/pull/117
-->…

## Changes
- If `reg_id` parameter is in GET request for the registration form, now also checks if a user if either a submitter admin or an APCD admin
- Then grabs user's submitter code and checks if queried `reg_id` is within submitter code's registrations before loading registration's data to the form
- If any of the above tests are not passed, instead loads registration form with no pre-loaded data
- Some code clean-up + linting found while working on main task 
…

## Testing

1. Go to http://localhost:8000/admin and:
    - Go to click users and your username
    - Remove submitter_admin from your groups and leave only APCD_ADMIN
    - Click save
    - Bring down your containers and bring them back up
2. Go to https://localhost:8000/register/request-to-submit/?reg_id=1 and confirm the page pre-loads with the registration data (no entities or contacts expected for this record)
3. Now try hitting https://localhost:8000/register/request-to-submit/?reg_id=5 and confirm the form loads, but with no data pre-loaded
4. Repeat step 1, but leave your role as only SUBMITTER_ADMIN and then repeat steps 2 and 3 and confirm the same
5. Repeat step 1, but leave your role as SUBMITTER_USER only and repeat steps 2 and 3; confirm that, in either case, the form does not pre-load with the data

## UI

…

<!--
## Notes

…
-->
