### PR TITLE
Task/WP 349 350 Business name change exten excep forms

### DIFF
--- a/apcd-cms/src/apps/exception/templates/exception_submission_form/exception_other_form.html
+++ b/apcd-cms/src/apps/exception/templates/exception_submission_form/exception_other_form.html
@@ -97,8 +97,8 @@
         <div class="field-errors" style="display: none"></div>
           <select name='business-name' required='required' class="choicefield" id='business-name'>
           {% for submitter in submitters %}
-          <option class="dropdown-text" value={{submitter.submitter_id}}>{{submitter.entity_name}} - Payor Code:
-            {{submitter.payor_code}}</option>
+          <option class="dropdown-text" value={{submitter.submitter_id}}>{{submitter.entity_name}}
+             - Payor Code: {{submitter.payor_code}}</option>
           {% endfor %} 
         </select>
 

--- a/apcd-cms/src/apps/exception/templates/exception_submission_form/exception_other_form.html
+++ b/apcd-cms/src/apps/exception/templates/exception_submission_form/exception_other_form.html
@@ -97,7 +97,8 @@
         <div class="field-errors" style="display: none"></div>
           <select name='business-name' required='required' class="choicefield" id='business-name'>
           {% for submitter in submitters %}
-            <option class="dropdown-text" value={{submitter.submitter_id}}>{{submitter.org_name}} - ID: {{submitter.submitter_id}}</option>
+          <option class="dropdown-text" value={{submitter.submitter_id}}>{{submitter.entity_name}} - Payor Code:
+            {{submitter.payor_code}}</option>
           {% endfor %} 
         </select>
 

--- a/apcd-cms/src/apps/exception/templates/exception_submission_form/exception_other_form.html
+++ b/apcd-cms/src/apps/exception/templates/exception_submission_form/exception_other_form.html
@@ -97,8 +97,7 @@
         <div class="field-errors" style="display: none"></div>
           <select name='business-name' required='required' class="choicefield" id='business-name'>
           {% for submitter in submitters %}
-          <option class="dropdown-text" value={{submitter.submitter_id}}>{{submitter.entity_name}}
-             - Payor Code: {{submitter.payor_code}}</option>
+          <option class="dropdown-text" value={{submitter.submitter_id}}>{{submitter.entity_name}} - Payor Code: {{submitter.payor_code}}</option>
           {% endfor %} 
         </select>
 

--- a/apcd-cms/src/apps/exception/templates/exception_submission_form/exception_other_form.html
+++ b/apcd-cms/src/apps/exception/templates/exception_submission_form/exception_other_form.html
@@ -97,7 +97,9 @@
         <div class="field-errors" style="display: none"></div>
           <select name='business-name' required='required' class="choicefield" id='business-name'>
           {% for submitter in submitters %}
-          <option class="dropdown-text" value={{submitter.submitter_id}}>{{submitter.entity_name}} - Payor Code: {{submitter.payor_code}}</option>
+          <option class="dropdown-text" value={{submitter.submitter_id}}>
+            {{submitter.entity_name}} - Payor Code: {{submitter.payor_code}}
+            </option>
           {% endfor %} 
         </select>
 

--- a/apcd-cms/src/apps/exception/templates/exception_submission_form/exception_threshold_form.html
+++ b/apcd-cms/src/apps/exception/templates/exception_submission_form/exception_threshold_form.html
@@ -33,6 +33,19 @@
             <hr/>
               <h4>Requested Threshold Reduction</h4>
               <div id="exception_block_1">
+                <div class="field-wrapper textinput required">
+                  <label for="business-name_1">
+                    Business Name<span class="asterisk">*</span>
+                  </label>
+                  <div class="field-errors" style="display: none"></div>
+                  <select name='business-name_1' required='required' class="choicefield" id='business-name_1'>
+                    {% for submitter in submitters %}
+                    <option class="dropdown-text" value={{submitter.submitter_id}}>{{submitter.entity_name}} - Payor Code:
+                      {{submitter.payor_code}}</option>
+                    {% endfor %}
+                  </select>
+    
+                </div>
               <div class="field-wrapper select required">
                 <div class="field-errors" style="display: none"></div>
   
@@ -155,19 +168,6 @@
                 I request an exception on behalf of:
               </label></div>
 
-            <div class="field-wrapper textinput required">
-              <label for="business-name">
-                Business Name<span class="asterisk">*</span>
-              </label>
-              <div class="field-errors" style="display: none"></div>
-              <select name='business-name' required='required' class="choicefield" id='business-name'>
-                {% for submitter in submitters %}
-                <option class="dropdown-text" value={{submitter.submitter_id}}>{{submitter.org_name}} - ID:
-                  {{submitter.submitter_id}}</option>
-                {% endfor %}
-              </select>
-
-            </div>
 
             <div class="field-wrapper checkbox required">
               <div class="field-errors" style="display: none"></div>
@@ -254,6 +254,18 @@
               let exceptionBlock = document.getElementById(`exception_block_${exceptions}`);
               document.getElementById(`exception_header_${exceptions}`).style.display = 'block';
               exceptionBlock.innerHTML = `
+              <div class="field-wrapper textinput required">
+              <label for="business-name_${exceptions}">
+                Business Name<span class="asterisk">*</span>
+              </label>
+              <div class="field-errors" style="display: none"></div>
+              <select name='business-name_${exceptions}' required='required' class="choicefield" id='business-name_${exceptions}'>
+                {% for submitter in submitters %}
+                <option class="dropdown-text" value={{submitter.submitter_id}}>{{submitter.entity_name}} - Payor Code:
+                  {{submitter.payor_code}}</option>
+                {% endfor %}
+              </select>
+            </div>
               <div class="field-wrapper select required">
               <div class="field-errors" style="display: none"></div>
 

--- a/apcd-cms/src/apps/exception/templates/exception_submission_form/exception_threshold_form.html
+++ b/apcd-cms/src/apps/exception/templates/exception_submission_form/exception_threshold_form.html
@@ -40,8 +40,9 @@
                   <div class="field-errors" style="display: none"></div>
                   <select name='business-name_1' required='required' class="choicefield" id='business-name_1'>
                     {% for submitter in submitters %}
-                    <option class="dropdown-text" value={{submitter.submitter_id}}>{{submitter.entity_name}} - Payor Code:
-                      {{submitter.payor_code}}</option>
+                    <option class="dropdown-text" value={{submitter.submitter_id}}>
+                      {{submitter.entity_name}} - Payor Code: {{submitter.payor_code}}
+                      </option>
                     {% endfor %}
                   </select>
     

--- a/apcd-cms/src/apps/exception/views.py
+++ b/apcd-cms/src/apps/exception/views.py
@@ -52,7 +52,7 @@ class ExceptionThresholdFormView(TemplateView):
                 "submitter_code": sub[1],
                 "payor_code": sub[2],
                 "user_name": sub[3],
-                "org_name": title_case(sub[4])
+                "entity_name": title_case(sub[4])
             }
 
         def _set_cdl(file_type):
@@ -77,12 +77,8 @@ class ExceptionThresholdFormView(TemplateView):
             errors = []
             submitters = request.session.get('submitters')
 
-            submitter = next(submitter for submitter in submitters if int(submitter[0]) == int(form['business-name']))
-            if _err_msg(submitter):
-                errors.append(_err_msg(submitter))
-
+            # To create counter of exception requests and corresponding fields
             max_iterations = 1
-            
             for i in range(2, 6):
                 if form.get('field-threshold-exception_{}'.format(i)):
                     max_iterations += 1
@@ -90,6 +86,9 @@ class ExceptionThresholdFormView(TemplateView):
                     break
 
             for iteration in range(max_iterations):
+                submitter = next(submitter for submitter in submitters if int(submitter[0]) == int(form['business-name_{}'.format(iteration + 1)]))
+                if _err_msg(submitter):
+                    errors.append(_err_msg(submitter))
                 except_response = apcd_database.create_threshold_exception(form, iteration + 1, submitter)
                 if _err_msg(except_response):
                     errors.append(_err_msg(except_response))
@@ -137,7 +136,7 @@ class ExceptionOtherFormView(TemplateView):
                 "submitter_code": sub[1],
                 "payor_code": sub[2],
                 "user_name": sub[3],
-                "org_name": title_case(sub[4])
+                "entity_name": title_case(sub[4])
             }
 
         context["submitters"] = []

--- a/apcd-cms/src/apps/extension/templates/extension_submission_form/extension_submission_form.html
+++ b/apcd-cms/src/apps/extension/templates/extension_submission_form/extension_submission_form.html
@@ -227,8 +227,9 @@
                 <div class="field-errors" style="display: none"></div>
                 <select name='business-name_${extension}' required='required' class="choicefield" id='business-name_${extension}'>
                   {% for submitter in submitters %}
-                  <option class="dropdown-text" value={{submitter.submitter_id}}>{{submitter.entity_name}} - Payor Code:
-                  {{submitter.payor_code}}</option>
+                  <option class="dropdown-text" value={{submitter.submitter_id}}>
+                    {{submitter.entity_name}} - Payor Code: {{submitter.payor_code}}
+                    </option>
                   {% endfor %}
                 </select>
                 </div>

--- a/apcd-cms/src/apps/extension/templates/extension_submission_form/extension_submission_form.html
+++ b/apcd-cms/src/apps/extension/templates/extension_submission_form/extension_submission_form.html
@@ -41,8 +41,8 @@
                 <div class="field-errors" style="display: none"></div>
                 <select name='business-name_1' required='required' class="choicefield" id='business-name_1'>
                   {% for submitter in submitters %}
-                  <option class="dropdown-text" value={{submitter.submitter_id}}>{{submitter.org_name}} - ID:
-                    {{submitter.submitter_id}}</option>
+                  <option class="dropdown-text" value={{submitter.submitter_id}}>{{submitter.entity_name}} - Payor Code:
+                    {{submitter.payor_code}}</option>
                   {% endfor %}
                 </select>
                 </div>
@@ -227,8 +227,8 @@
                 <div class="field-errors" style="display: none"></div>
                 <select name='business-name_${extension}' required='required' class="choicefield" id='business-name_${extension}'>
                   {% for submitter in submitters %}
-                  <option class="dropdown-text" value={{submitter.submitter_id}}>{{submitter.org_name}} - ID:
-                    {{submitter.submitter_id}} Payor Code: {{submitter.payor_code}}</option>
+                  <option class="dropdown-text" value={{submitter.submitter_id}}>{{submitter.entity_name}} - Payor Code:
+                  {{submitter.payor_code}}</option>
                   {% endfor %}
                 </select>
                 </div>

--- a/apcd-cms/src/apps/extension/views.py
+++ b/apcd-cms/src/apps/extension/views.py
@@ -31,7 +31,7 @@ class ExtensionFormView(TemplateView):
                 "submitter_code": sub[1],
                 "payor_code": sub[2],
                 "user_name": sub[3],
-                "org_name": title_case(sub[4])
+                "entity_name": title_case(sub[4])
             }
         context["submitters"] = []
 

--- a/apcd-cms/src/apps/utils/apcd_database.py
+++ b/apcd-cms/src/apps/utils/apcd_database.py
@@ -825,7 +825,7 @@ def create_threshold_exception(form, iteration, sub_data):
         ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
         """
         values = (
-            _clean_value(form["business-name"]),
+            _clean_value(form['business-name_{}'.format(iteration)]),
             sub_data[1],
             sub_data[2],
             sub_data[3],
@@ -1263,11 +1263,11 @@ def get_submitter_info(user):
                     submitters.submitter_code, 
                     submitters.payor_code, 
                     submitter_users.user_id, 
-                    submitters.org_name
+                    submitters.entity_name
                 FROM submitter_users
                 JOIN submitters
                     ON submitter_users.submitter_id = submitters.submitter_id and submitter_users.user_id = (%s)
-                ORDER BY submitters.org_name, submitter_users.submitter_id
+                ORDER BY submitters.entity_name, submitter_users.submitter_id
             """
         cur = conn.cursor()
         cur.execute(query, (user,))


### PR DESCRIPTION

## Overview

This PR changes the business name options on the exception and extension forms from org_name - submitter ID on submitter table to entity_name - payor code on submitter table.

Also now allows threshold exceptions to choose from different business names (entity - payor codes) associated with their user name.

## Related

- [WP-349](https://jira.tacc.utexas.edu/browse/WP-349)
- [WP-350](https://jira.tacc.utexas.edu/browse/WP-350)


## Changes

Exceptions
- Moved business name to each of the threshold exception blocks. Changed the drop down to prepopulated entity names - payor codes
- Changed create_threshold_extension insert so that it gets a business name for each block. 
- ThresholdExceptionView will associate each insert with a unique payor code, entity, submitter_id based on user's business name selection

Extensions
- Changed business names to entity name - payor codes

## Testing


Extensions
1. Go to [http://localhost:8000/submissions/extension-request/](http://localhost:8000/submissions/extension-request/)
2. Check that it populates with your associated entity name and payor code. Fill out form and go to http://localhost:8000/administration/list-extensions/ to make sure it successfully submits.
3.  On line 22 of extensions/views.py, change to the following code. 

- ` user = 'thbrown'`
4. Check that there are two options in the business name drop down.
5. Create two extension requests in two different blocks each with a different business name and submit successfully.
6. Go to [http://localhost:8000/administration/list-extensions/ ](http://localhost:8000/administration/list-extensions/ )and make sure the two different extensions submitted successfully with the associated data.

Exceptions
Extensions
1. Go to [http://localhost:8000/submissions/extension-request/](http://localhost:8000/submissions/extension-request/)
2. Check that it populates with your associated entity name and payor code. Fill out form and go to http://localhost:8000/administration/list-extensions/ to make sure it successfully submits.
3.  On line 36 of exceptions/views.py in the ExceptionThresholdFormView class, change to the following code. 

- ` user = 'thbrown'`
4. Check that there are two options in the business name drop down.
5. Create two extension requests in two different blocks each with a different business name and submit successfully.
6. Go to [http://localhost:8000/administration/list-exceptions/ ](http://localhost:8000/administration/list-exceptions/ )and make sure the two different extensions submitted successfully with the associated data.

## Notes

Joe updated the database to include the entity names on the submitters table. Make sure your containers are accessing these changes from the DB.
