### PR TITLE
Task/wp 372 admin except extend entity name

### DIFF
--- a/apcd-cms/src/apps/admin_exception/static/admin_exception/css/table.css
+++ b/apcd-cms/src/apps/admin_exception/static/admin_exception/css/table.css
@@ -7,7 +7,7 @@
     /* To label the cells */
     /* RFE: Add `data-label` to each cell so we can use `attr(data-label)` */
     .exception-table td:nth-of-type(1):before { content: "Created"; }
-    .exception-table td:nth-of-type(2):before { content: "Organization"; }
+    .exception-table td:nth-of-type(2):before { content: "Entity"; }
     .exception-table td:nth-of-type(3):before { content: "Requestor Name"; }
     .exception-table td:nth-of-type(4):before { content: "Exception Type"; }
     .exception-table td:nth-of-type(5):before { content: "Outcome"; }

--- a/apcd-cms/src/apps/admin_exception/static/admin_exception/css/table.css
+++ b/apcd-cms/src/apps/admin_exception/static/admin_exception/css/table.css
@@ -1,16 +1,13 @@
-.modal-cell {
-    padding-left: 0px;
-}
 /* SEE: https://css-tricks.com/responsive-data-tables/ */
 @media (max-width: 767px) {
 
     /* To label the cells */
     /* RFE: Add `data-label` to each cell so we can use `attr(data-label)` */
     .exception-table td:nth-of-type(1):before { content: "Created"; }
-    .exception-table td:nth-of-type(2):before { content: "Entity"; }
+    .exception-table td:nth-of-type(2):before { content: "Entity Organization"; }
     .exception-table td:nth-of-type(3):before { content: "Requestor Name"; }
     .exception-table td:nth-of-type(4):before { content: "Exception Type"; }
     .exception-table td:nth-of-type(5):before { content: "Outcome"; }
     .exception-table td:nth-of-type(6):before { content: "Status"; }
-    .exception-table td:nth-of-type(7):before { content: "Actions"; }
+    .exception-table td:nth-of-type(7):before {content:"Actions";}
 }

--- a/apcd-cms/src/apps/admin_exception/templates/edit_exception_modal.html
+++ b/apcd-cms/src/apps/admin_exception/templates/edit_exception_modal.html
@@ -7,7 +7,7 @@
     <!-- Modal content-->
     <div class="modal-content">
       <div class="modal-header">
-        <h4 class="modal-title">Edit Exception ID: {{r.exception_id}} for {{r.org_name}}</h4>
+        <h4 class="modal-title">Edit Exception ID {{r.exception_id}} for {{r.entity_name}}</h4>
         <button type="button" class="close" data-dismiss="modal">
           <span aria-hidden="true">&#xe912;</span>
         </button>
@@ -94,8 +94,8 @@
                   <dl class="c-data-list--is-vert c-data-list--is-wide">
                     <dt class="c-data-list__key">Created</dt>
                     <dd class="c-data-list__value">{{r.created_at}}</dd>
-                    <dt class="c-data-list__key">Organization</dt>
-                    <dd class="c-data-list__value">{{r.org_name}}</dd>
+                    <dt class="c-data-list__key">Entity</dt>
+                    <dd class="c-data-list__value">{{r.entity_name}}</dd>
                     <dt class="c-data-list__key">Requestor</dt>
                     <dd class="c-data-list__value">{{r.requestor_name}}</dd>
                     <dt class="c-data-list__key">Requestor Email</dt>

--- a/apcd-cms/src/apps/admin_exception/templates/edit_exception_modal.html
+++ b/apcd-cms/src/apps/admin_exception/templates/edit_exception_modal.html
@@ -94,7 +94,7 @@
                   <dl class="c-data-list--is-vert c-data-list--is-wide">
                     <dt class="c-data-list__key">Created</dt>
                     <dd class="c-data-list__value">{{r.created_at}}</dd>
-                    <dt class="c-data-list__key">Entity</dt>
+                    <dt class="c-data-list__key">Entity Organization</dt>
                     <dd class="c-data-list__value">{{r.entity_name}}</dd>
                     <dt class="c-data-list__key">Requestor</dt>
                     <dd class="c-data-list__value">{{r.requestor_name}}</dd>

--- a/apcd-cms/src/apps/admin_exception/templates/list_admin_exception.html
+++ b/apcd-cms/src/apps/admin_exception/templates/list_admin_exception.html
@@ -44,7 +44,7 @@
               <tr>
                 <!-- So when page is shrunk, rows match with the former columns -->
                 <td class="created">{{r.created_at}}</td>
-                <td class="org_name">{{r.org_name}}</td>
+                <td class="entity_name">{{r.entity_name}}</td>
                 <td class="requestor_name">{{r.requestor_name}}</td>
                 <td class="exception_type">{{r.request_type}}</td>
                 <td class="outcome">{{r.outcome}}</td>

--- a/apcd-cms/src/apps/admin_exception/templates/view_admin_exception_modal.html
+++ b/apcd-cms/src/apps/admin_exception/templates/view_admin_exception_modal.html
@@ -21,7 +21,7 @@
                       <dt class="c-data-list__key">Created</dt>
                       <dd class="c-data-list__value">{{r.created_at}}</dd>
                       <dt class="c-data-list__key">Organization</dt>
-                      <dd class="c-data-list__value">{{r.org_name}}</dd>
+                      <dd class="c-data-list__value">{{r.entity_name}}</dd>
                       <dt class="c-data-list__key">Requestor</dt>
                       <dd class="c-data-list__value">{{r.requestor_name}}</dd>
                       <dt class="c-data-list__key">Requestor Email</dt>

--- a/apcd-cms/src/apps/admin_exception/templates/view_admin_exception_modal.html
+++ b/apcd-cms/src/apps/admin_exception/templates/view_admin_exception_modal.html
@@ -20,7 +20,7 @@
                     <dl class="c-data-list--is-vert c-data-list--is-wide">
                       <dt class="c-data-list__key">Created</dt>
                       <dd class="c-data-list__value">{{r.created_at}}</dd>
-                      <dt class="c-data-list__key">Organization</dt>
+                      <dt class="c-data-list__key">Entity Organization</dt>
                       <dd class="c-data-list__value">{{r.entity_name}}</dd>
                       <dt class="c-data-list__key">Requestor</dt>
                       <dd class="c-data-list__value">{{r.requestor_name}}</dd>

--- a/apcd-cms/src/apps/admin_exception/views.py
+++ b/apcd-cms/src/apps/admin_exception/views.py
@@ -89,7 +89,7 @@ class AdminExceptionsTable(TemplateView):
                 'data_file_name': exception[22]
             }
 
-        context['header'] = ['Created', 'Entity', 'Requestor Name', 'Exception Type', 'Outcome', 'Status', 'Actions']
+        context['header'] = ['Created', 'Entity Organization', 'Requestor Name', 'Exception Type', 'Outcome', 'Status', 'Actions']
         context['status_options'] = ['All']
         context['org_options'] = ['All']
         context['outcome_options'] = []

--- a/apcd-cms/src/apps/admin_exception/views.py
+++ b/apcd-cms/src/apps/admin_exception/views.py
@@ -85,11 +85,11 @@ class AdminExceptionsTable(TemplateView):
                 'approved_expiration_date': exception[18],
                 'status': title_case(exception[19])if exception[3] else None,
                 'notes': exception[20],
-                'org_name': exception[21],
+                'entity_name': exception[21],
                 'data_file_name': exception[22]
             }
 
-        context['header'] = ['Created', 'Organization', 'Requestor Name', 'Exception Type', 'Outcome', 'Status', 'Actions']
+        context['header'] = ['Created', 'Entity', 'Requestor Name', 'Exception Type', 'Outcome', 'Status', 'Actions']
         context['status_options'] = ['All']
         context['org_options'] = ['All']
         context['outcome_options'] = []
@@ -109,11 +109,11 @@ class AdminExceptionsTable(TemplateView):
             exception_table_entries.append(_set_exceptions(exception))
             # to be able to access any exception in a template using exceptions var in the future
             context['exceptions'].append(_set_exceptions(exception))
-            org_name = title_case(exception[21])
+            entity_name = title_case(exception[21])
             status = title_case(exception[19])
             outcome = title_case(exception[5])
-            if org_name not in context['org_options']:
-                context['org_options'].append(org_name)
+            if entity_name not in context['org_options']:
+                context['org_options'].append(entity_name)
                 # to make sure All is first in the dropdown filter options after sorting alphabetically
                 context['org_options'] = sorted(context['org_options'], key=lambda x: (x != 'All', x))
             if status not in context['status_options']:
@@ -136,7 +136,7 @@ class AdminExceptionsTable(TemplateView):
         if org_filter is not None and org_filter != 'All':
             context['selected_org'] = org_filter
             queryStr += f'&org={org_filter}'
-            exception_table_entries = table_filter(org_filter.replace("(", "").replace(")",""), exception_table_entries, 'org_name')
+            exception_table_entries = table_filter(org_filter.replace("(", "").replace(")",""), exception_table_entries, 'entity_name')
 
         context['query_str'] = queryStr
         context.update(paginator(self.request, exception_table_entries))

--- a/apcd-cms/src/apps/admin_extension/static/admin_extension/css/table.css
+++ b/apcd-cms/src/apps/admin_extension/static/admin_extension/css/table.css
@@ -6,7 +6,7 @@
     /* To label the cells */
     /* RFE: Add `data-label` to each cell so we can use `attr(data-label)` */
     .extension-table td:nth-of-type(1):before { content: "Created"; }
-    .extension-table td:nth-of-type(2):before { content: "Organization"; }
+    .extension-table td:nth-of-type(2):before { content: "Entity"; }
     .extension-table td:nth-of-type(3):before { content: "Requestor Name"; }
     .extension-table td:nth-of-type(4):before { content: "Extension Type"; }
     .extension-table td:nth-of-type(5):before { content: "Outcome"; }

--- a/apcd-cms/src/apps/admin_extension/static/admin_extension/css/table.css
+++ b/apcd-cms/src/apps/admin_extension/static/admin_extension/css/table.css
@@ -1,12 +1,9 @@
-.modal-cell {
-    padding-left: 0px;
-}
 /* SEE: https://css-tricks.com/responsive-data-tables/ */
 @media (max-width: 767px) {
     /* To label the cells */
     /* RFE: Add `data-label` to each cell so we can use `attr(data-label)` */
     .extension-table td:nth-of-type(1):before { content: "Created"; }
-    .extension-table td:nth-of-type(2):before { content: "Entity"; }
+    .extension-table td:nth-of-type(2):before { content: "Entity Organization"; }
     .extension-table td:nth-of-type(3):before { content: "Requestor Name"; }
     .extension-table td:nth-of-type(4):before { content: "Extension Type"; }
     .extension-table td:nth-of-type(5):before { content: "Outcome"; }

--- a/apcd-cms/src/apps/admin_extension/templates/edit_extension_modal.html
+++ b/apcd-cms/src/apps/admin_extension/templates/edit_extension_modal.html
@@ -92,8 +92,8 @@
                   <dl class="c-data-list--is-vert c-data-list--is-wide">
                       <dt class="c-data-list__key">Created</dt>
                       <dd class="c-data-list__value">{{r.created_at}}</dd>
-                      <dt class="c-data-list__key">Organization</dt>
-                      <dd class="c-data-list__value">{{r.org_name}}</dd>
+                      <dt class="c-data-list__key">Entity</dt>
+                      <dd class="c-data-list__value">{{r.entity_name}}</dd>
                       <dt class="c-data-list__key">Requestor</dt>
                       <dd class="c-data-list__value">{{r.requestor_name}}</dd>
                       <dt class="c-data-list__key">Requestor Email</dt>

--- a/apcd-cms/src/apps/admin_extension/templates/edit_extension_modal.html
+++ b/apcd-cms/src/apps/admin_extension/templates/edit_extension_modal.html
@@ -7,7 +7,7 @@
     <!-- Modal content-->
     <div class="modal-content">
       <div class="modal-header">
-        <h4 class="modal-title">Edit Extension ID: {{r.extension_id}} for {{r.org_name}}</h4>
+        <h4 class="modal-title">Edit Extension ID {{r.extension_id}} for {{r.entity_name}}</h4>
         <button type="button" class="close" data-dismiss="modal">
           <span aria-hidden="true">&#xe912;</span>
         </button>

--- a/apcd-cms/src/apps/admin_extension/templates/edit_extension_modal.html
+++ b/apcd-cms/src/apps/admin_extension/templates/edit_extension_modal.html
@@ -92,7 +92,7 @@
                   <dl class="c-data-list--is-vert c-data-list--is-wide">
                       <dt class="c-data-list__key">Created</dt>
                       <dd class="c-data-list__value">{{r.created_at}}</dd>
-                      <dt class="c-data-list__key">Entity</dt>
+                      <dt class="c-data-list__key">Entity Organization</dt>
                       <dd class="c-data-list__value">{{r.entity_name}}</dd>
                       <dt class="c-data-list__key">Requestor</dt>
                       <dd class="c-data-list__value">{{r.requestor_name}}</dd>

--- a/apcd-cms/src/apps/admin_extension/templates/list_admin_extension.html
+++ b/apcd-cms/src/apps/admin_extension/templates/list_admin_extension.html
@@ -43,7 +43,7 @@
         {% for r in page %}
               <tr>
                 <td class="created">{{r.created_at}}</td>
-                <td class="org_name">{{r.org_name}} - {{r.submitter_id}}</td>
+                <td class="org_name">{{r.entity_name}}</td>
                 <td class="requestor_name">{{r.requestor_name}}</td>
                 <td class="extension_type">{{r.extension_type}}</td>
                 <td class="outcome">{{r.outcome}}</td>

--- a/apcd-cms/src/apps/admin_extension/templates/list_admin_extension.html
+++ b/apcd-cms/src/apps/admin_extension/templates/list_admin_extension.html
@@ -43,7 +43,7 @@
         {% for r in page %}
               <tr>
                 <td class="created">{{r.created_at}}</td>
-                <td class="org_name">{{r.entity_name}}</td>
+                <td class="entity_name">{{r.entity_name}}</td>
                 <td class="requestor_name">{{r.requestor_name}}</td>
                 <td class="extension_type">{{r.extension_type}}</td>
                 <td class="outcome">{{r.outcome}}</td>

--- a/apcd-cms/src/apps/admin_extension/templates/view_admin_extension_modal.html
+++ b/apcd-cms/src/apps/admin_extension/templates/view_admin_extension_modal.html
@@ -20,7 +20,7 @@
                     <dl class="c-data-list--is-vert c-data-list--is-wide">
                         <dt class="c-data-list__key">Created</dt>
                         <dd class="c-data-list__value">{{r.created_at}}</dd>
-                        <dt class="c-data-list__key">Entity</dt>
+                        <dt class="c-data-list__key">Entity Organization</dt>
                         <dd class="c-data-list__value">{{r.entity_name}}</dd>
                         <dt class="c-data-list__key">Requestor</dt>
                         <dd class="c-data-list__value">{{r.requestor_name}}</dd>

--- a/apcd-cms/src/apps/admin_extension/templates/view_admin_extension_modal.html
+++ b/apcd-cms/src/apps/admin_extension/templates/view_admin_extension_modal.html
@@ -7,7 +7,7 @@
       <!-- Modal content-->
       <div class="modal-content">
         <div class="modal-header">
-          <h4 class="modal-title">Extension Details ID: {{r.extension_id}} for {{r.org_name}}</h4>
+          <h4 class="modal-title">Extension Details ID {{r.extension_id}} for {{r.entity_name}}</h4>
           <button type="button" class="close" data-dismiss="modal">
             <span aria-hidden="true">&#xe912;</span>
           </button>

--- a/apcd-cms/src/apps/admin_extension/templates/view_admin_extension_modal.html
+++ b/apcd-cms/src/apps/admin_extension/templates/view_admin_extension_modal.html
@@ -20,8 +20,8 @@
                     <dl class="c-data-list--is-vert c-data-list--is-wide">
                         <dt class="c-data-list__key">Created</dt>
                         <dd class="c-data-list__value">{{r.created_at}}</dd>
-                        <dt class="c-data-list__key">Organization</dt>
-                        <dd class="c-data-list__value">{{r.org_name}}</dd>
+                        <dt class="c-data-list__key">Entity</dt>
+                        <dd class="c-data-list__value">{{r.entity_name}}</dd>
                         <dt class="c-data-list__key">Requestor</dt>
                         <dd class="c-data-list__value">{{r.requestor_name}}</dd>
                         <dt class="c-data-list__key">Requestor Email</dt>

--- a/apcd-cms/src/apps/admin_extension/views.py
+++ b/apcd-cms/src/apps/admin_extension/views.py
@@ -78,7 +78,7 @@ class AdminExtensionsTable(TemplateView):
                 'requestor_email': extension[15],
                 'explanation_justification': extension[16],
                 'notes': extension[17],
-                'org_name': extension[18]
+                'entity_name': extension[18]
             }
         context['header'] = ['Created', 'Organization', 'Requestor Name', 'Extension Type', 'Outcome', 'Status', 'Approved Expiration', 'Actions']
         context['status_options'] = ['All']

--- a/apcd-cms/src/apps/admin_extension/views.py
+++ b/apcd-cms/src/apps/admin_extension/views.py
@@ -80,7 +80,7 @@ class AdminExtensionsTable(TemplateView):
                 'notes': extension[17],
                 'entity_name': extension[18]
             }
-        context['header'] = ['Created', 'Organization', 'Requestor Name', 'Extension Type', 'Outcome', 'Status', 'Approved Expiration', 'Actions']
+        context['header'] = ['Created', 'Entity', 'Requestor Name', 'Extension Type', 'Outcome', 'Status', 'Approved Expiration', 'Actions']
         context['status_options'] = ['All']
         context['org_options'] = ['All']
         context['outcome_options'] = []
@@ -103,11 +103,11 @@ class AdminExtensionsTable(TemplateView):
             extension_table_entries.append(_set_extensions(extension))
             # to be able to access any extension in a template
             context['extensions'].append(_set_extensions(extension))
-            org_name = title_case(extension[18])
+            entity_name = title_case(extension[18])
             status = title_case(extension[7])
             outcome = title_case(extension[8])
-            if org_name not in context['org_options']:
-                context['org_options'].append(org_name)
+            if entity_name not in context['org_options']:
+                context['org_options'].append(entity_name)
                 context['org_options'] = sorted(context['org_options'], key=lambda x: (x != 'All', x))
             if status not in context['status_options']:
                 context['status_options'].append(status)
@@ -130,7 +130,7 @@ class AdminExtensionsTable(TemplateView):
         if org_filter is not None and org_filter != 'All':
             context['selected_org'] = org_filter
             queryStr += f'&org={org_filter}'
-            extension_table_entries = table_filter(org_filter.replace("(", "").replace(")",""), extension_table_entries, 'org_name')
+            extension_table_entries = table_filter(org_filter.replace("(", "").replace(")",""), extension_table_entries, 'entity_name')
 
         context['query_str'] = queryStr
         context.update(paginator(self.request, extension_table_entries))

--- a/apcd-cms/src/apps/admin_extension/views.py
+++ b/apcd-cms/src/apps/admin_extension/views.py
@@ -80,7 +80,7 @@ class AdminExtensionsTable(TemplateView):
                 'notes': extension[17],
                 'entity_name': extension[18]
             }
-        context['header'] = ['Created', 'Entity', 'Requestor Name', 'Extension Type', 'Outcome', 'Status', 'Approved Expiration', 'Actions']
+        context['header'] = ['Created', 'Entity Organization', 'Requestor Name', 'Extension Type', 'Outcome', 'Status', 'Approved Expiration', 'Actions']
         context['status_options'] = ['All']
         context['org_options'] = ['All']
         context['outcome_options'] = []

--- a/apcd-cms/src/apps/utils/apcd_database.py
+++ b/apcd-cms/src/apps/utils/apcd_database.py
@@ -1372,7 +1372,7 @@ def get_all_extensions():
                 extensions.requestor_email,
                 extensions.explanation_justification,
                 extensions.notes,
-                submitters.org_name
+                submitters.entity_name
             FROM extensions
             JOIN submitters
                 ON extensions.submitter_id = submitters.submitter_id
@@ -1423,7 +1423,7 @@ def get_all_exceptions():
                 exceptions.approved_expiration_date,
                 exceptions.status,
                 exceptions.notes,
-                submitters.org_name,
+                submitters.entity_name,
                 standard_codes.item_value
             FROM exceptions
             JOIN submitters


### PR DESCRIPTION
## Overview

Updated Exception and Extension Admin tables so that it displays the extension and exception id's entity_name rather than org_name from the submitters table. 

I left the parameter for filtering by entity as org for brevity's sake in the URL. Let me know if it makes more sense to change to org. Or we can can check with Tracy and UTH.

## Related

- [WP-123](https://jira.tacc.utexas.edu/browse/WP-372)


## Changes

apcd_database.py:
- Changed get_all_exceptions and get_all_extensions queries to get entity name rather than org name

views.py:
- Changed the AdminExceptionTable and AdminExtensionTable class views so it sets the entity name from the DB response to "entity_name".
- Changed the AdminExceptionTable and AdminExtensionTable class views so it sets the header to Entity rather than Organization
- Appends entity_name from DB to org_options for the org_filter. Let these as org so the URL with query params were not as long
- Filter table by entity_name if org_filter is selected

Templates and Static:

- Changed styles so that when window is small, it changes columns to rows with Entity rather than Organization as the header
- Removed {{r.org_name}} and replaced with {{r.entity_name}}


## Testing

1. Go to [http://localhost:8000/administration/list-extensions/](http://localhost:8000/administration/list-extensions/)
2. Check that table matches UI below pulling entity_name rather than org_name
3. Check that filters still work as expected
4. Click view and edit actions to make sure entity_name is showing rather than org_name
5. Submit an edit and make sure it works
6. Go to [http://localhost:8000/administration/list-exceptions](http://localhost:8000/administration/list-exceptions)
7. Repeat steps 2-5

## UI
Exceptions Table
![Screenshot 2023-11-02 at 3 00 00 PM](https://github.com/TACC/Core-CMS-Custom/assets/96220951/63392f55-ee3d-4de3-a012-525882832b3d)

Extensions Table
![Screenshot 2023-11-02 at 4 04 26 PM](https://github.com/TACC/Core-CMS-Custom/assets/96220951/1841207d-083e-446a-a407-a228418cc919)

…

<!--
## Notes

…
-->
