### PR TITLE
hotfix/wp-375-extension-entity-name-add-button

### DIFF
--- a/apcd-cms/src/apps/extension/templates/extension_submission_form/extension_submission_error.html
+++ b/apcd-cms/src/apps/extension/templates/extension_submission_form/extension_submission_error.html
@@ -12,7 +12,7 @@
     <p class="c-message c-message--error">
         An error occurred during your extension request submission. For help, <a href="/workbench/dashboard">submit a ticket</a>.
     </p>
-    <button class="c-button c-button--primary" href="/submissions/extension-request/" type="link">Go Back to Extensions</button>
+    <a class="c-button c-button--primary" href="/submissions/extension-request/">Go Back to Extensions</a>
 </div>
 
 {% endblock %}

--- a/apcd-cms/src/apps/extension/templates/extension_submission_form/extension_submission_form.html
+++ b/apcd-cms/src/apps/extension/templates/extension_submission_form/extension_submission_form.html
@@ -269,7 +269,7 @@
             <div class="field-errors" style="display: none"></div>
             <select name='business-name_${extensions}' required='required' class="choicefield" id='business-name_${extensions}'>
               {% for submitter in submitters %}
-              <option class="dropdown-text" value={{submitter.submitter_id}}>{{submitter.entity_name}} - 
+              <option class="dropdown-text" value={{submitter.submitter_id}}>{{submitter.entity_name}} - Payor Code:
                 {{submitter.payor_code}}</option>
               {% endfor %}
             </select>

--- a/apcd-cms/src/apps/extension/templates/extension_submission_form/extension_submission_form.html
+++ b/apcd-cms/src/apps/extension/templates/extension_submission_form/extension_submission_form.html
@@ -269,7 +269,7 @@
             <div class="field-errors" style="display: none"></div>
             <select name='business-name_${extensions}' required='required' class="choicefield" id='business-name_${extensions}'>
               {% for submitter in submitters %}
-              <option class="dropdown-text" value={{submitter.submitter_id}}>{{submitter.org_name}} - 
+              <option class="dropdown-text" value={{submitter.submitter_id}}>{{submitter.entity_name}} - 
                 {{submitter.payor_code}}</option>
               {% endfor %}
             </select>

--- a/apcd-cms/src/apps/extension/templates/extension_submission_form/extension_submission_form.html
+++ b/apcd-cms/src/apps/extension/templates/extension_submission_form/extension_submission_form.html
@@ -379,7 +379,6 @@
       $('[id^="applicable-data-period"]').change(function() {
           let appDataValue = $(this).val();
           appDataValue = formatAppPeriod(appDataValue)
-          console.log(appDataValue)
         // Gets applicable data period                
           let extensionsNum = $(this).attr('id').slice(-1);
           let expectedDate = $(`current-expected-date_${extensions}`).val();


### PR DESCRIPTION
## Overview

Entity name missing from extension form add buttons

## Related


- [WP-375](https://jira.tacc.utexas.edu/browse/WP-375)


## Changes
Added entity_name var into template rather than org_name

## Testing

1. Go to [http://localhost:8000/submissions/extension-request/](http://localhost:8000/submissions/extension-request/)
2. Click Add Extension button
3. Make sure drop down populates with an entity name 


