### PR TITLE
task/wp-373-admin-submitter-entity-name

### DIFF
--- a/apcd-cms/src/apps/admin_submissions/templates/list_admin_submissions.html
+++ b/apcd-cms/src/apps/admin_submissions/templates/list_admin_submissions.html
@@ -50,7 +50,7 @@
           {% for r in page %}
               <tr>
                 <td>{{r.received_timestamp}}</td>
-                <td>{{r.org_name}}</td>
+                <td>{{r.entity_name}}</td>
                 <td colspan="2">{{r.file_name}}</td>
                 <td>{{r.outcome}}</td>
                 <td>{{r.status}}</td>

--- a/apcd-cms/src/apps/admin_submissions/templates/view_admin_submission_logs_modal.html
+++ b/apcd-cms/src/apps/admin_submissions/templates/view_admin_submission_logs_modal.html
@@ -23,8 +23,8 @@
                   <dl class="c-data-list--is-vert c-data-list--is-wide">
                       <dt class="c-data-list__key">Log ID</dt>
                       <dd class="c-data-list__value">{{log.log_id}}</dd>
-                      <dt class="c-data-list__key">Organization</dt>
-                      <dd class="c-data-list__value">{{r.org_name}}</dd>                       
+                      <dt class="c-data-list__key">Entity Organization</dt>
+                      <dd class="c-data-list__value">{{r.entity_name}}</dd>                       
                       <dt class="c-data-list__key">File Type</dt>                
                       <dd class="c-data-list__value">{{log.file_type_name}}</dd>
                       <dt class="c-data-list__key">Validation Suite</dt>                

--- a/apcd-cms/src/apps/admin_submissions/views.py
+++ b/apcd-cms/src/apps/admin_submissions/views.py
@@ -55,6 +55,7 @@ class AdminSubmissionsTable(TemplateView):
         # on the current page using offset and limit
         for s in submission_content[offset:offset + limit]:
             s['status'] = title_case(s['status'])
+            s['entity_name'] = title_case(s['entity_name'])
             s['outcome'] = title_case(s['outcome'])
             s['received_timestamp'] = parser.parse(s['received_timestamp']) if s['received_timestamp'] else None
             s['updated_at'] = parser.parse(s['updated_at']) if s['updated_at'] else None
@@ -63,7 +64,7 @@ class AdminSubmissionsTable(TemplateView):
                 'outcome': title_case(t['outcome'])
             } for t in (s['view_modal_content'] or [])]
 
-        context['header'] = ['Received', 'Organization', 'File Name', ' ', 'Outcome', 'Status', 'Last Updated', 'Actions']
+        context['header'] = ['Received', 'Entity Organization', 'File Name', ' ', 'Outcome', 'Status', 'Last Updated', 'Actions']
         context['filter_options'] = ['All', 'In Process', 'Complete']
         context['sort_options'] = {'newDate': 'Newest Received', 'oldDate': 'Oldest Received'}
 


### PR DESCRIPTION
## Overview

Add entity name to submittions table in admin tab

## Related

- [WP-373](https://jira.tacc.utexas.edu/browse/WP-373)


## Changes

- Changed query to pull and group by entity name rather than apcd_id and org_name
- Changed table to say entity organization and display entity in table
- Changed modal to pull entity name

## Testing

1. Go to [http://localhost:8000/administration/list-submissions/](http://localhost:8000/administration/list-submissions/)
2. Make sure that entity name populates in the table and in the modal 

## UI

![Screenshot 2023-11-07 at 10 33 12 AM](https://github.com/TACC/Core-CMS-Custom/assets/96220951/4c90c6bd-c6ba-49ff-b977-383dd0e8966c)

![Screenshot 2023-11-07 at 10 33 26 AM](https://github.com/TACC/Core-CMS-Custom/assets/96220951/bc789a84-db8c-4a66-a76e-d46ce1fab30c)

