### PR TITLE
task/WP-345: Entities changes UTH & task/WP-376: Add 'Year' column to registration admin listing

### DIFF
--- a/apcd-cms/src/apps/admin_regis_table/static/admin_regis_table/css/table.css
+++ b/apcd-cms/src/apps/admin_regis_table/static/admin_regis_table/css/table.css
@@ -7,8 +7,9 @@
     /* To label the cells */
     /* RFE: Add `data-label` to each cell so we can use `attr(data-label)` */
     .registration-table td:nth-of-type(1):before { content: "Business Name"; }
-    .registration-table td:nth-of-type(2):before { content: "Type"; }
-    .registration-table td:nth-of-type(3):before { content: "Location"; }
-    .registration-table td:nth-of-type(4):before { content: "Registration Status"; }
-    .registration-table td:nth-of-type(5):before { content: "Actions"; }
+    .registration-table td:nth-of-type(2):before { content: "Year"; }
+    .registration-table td:nth-of-type(3):before { content: "Type"; }
+    .registration-table td:nth-of-type(4):before { content: "Location"; }
+    .registration-table td:nth-of-type(5):before { content: "Registration Status"; }
+    .registration-table td:nth-of-type(6):before { content: "Actions"; }
 }

--- a/apcd-cms/src/apps/admin_regis_table/templates/list_registrations.html
+++ b/apcd-cms/src/apps/admin_regis_table/templates/list_registrations.html
@@ -45,6 +45,7 @@
           {% for r in page %}
               <tr>
                   <td>{{r.biz_name}}</td>
+                  <td>{{r.year}}</td>
                   <td>{{r.type}}</td>
                   <td>{{r.location}}</td>
                   <td>{{r.reg_status}}</td>

--- a/apcd-cms/src/apps/admin_regis_table/views.py
+++ b/apcd-cms/src/apps/admin_regis_table/views.py
@@ -84,7 +84,7 @@ class RegistrationsTable(TemplateView):
     def get_context_data(self, registrations_content, registrations_entities, registrations_contacts, *args, **kwargs):
         context = super(RegistrationsTable, self).get_context_data(*args, **kwargs)
 
-        context['header'] = ['Business Name', 'Type', 'Location', 'Registration Status', 'Actions']
+        context['header'] = ['Business Name', 'Year', 'Type', 'Location', 'Registration Status', 'Actions']
         context['status_options'] = ['All', 'Received', 'Processing', 'Complete']
         context['org_options'] = ['All']
 

--- a/apcd-cms/src/apps/registrations/static/registrations/css/submission_form.css
+++ b/apcd-cms/src/apps/registrations/static/registrations/css/submission_form.css
@@ -10,7 +10,7 @@ input[name^="zip_code"] {
     box-sizing: content-box;
 }
 select[name^="state"] {
-    --length: 2ch;
+    --length: 2.5ch;
     --ui-buffer: 2.5ch; /* to make room for dropdown arrows */
 
     width: calc( var(--length) + var(--ui-buffer) );

--- a/apcd-cms/src/apps/registrations/templates/submission_form/registration_form_body.html
+++ b/apcd-cms/src/apps/registrations/templates/submission_form/registration_form_body.html
@@ -416,14 +416,13 @@
                     </label>
 
                     <input
-                        type="number"
+                        type="text"
                         name="total_covered_lives_{{ent_no}}_{{r.reg_id}}"
                         required
                         class="integerfield"
                         id="total_covered_lives_{{ent_no}}_{{r.reg_id}}"
                         inputmode="numeric"
-                        min="1"
-                        step="1"
+                        pattern="^[1-9]+[0-9]*$"
                         value="{% if not renew %}{{ entity.no_covered }}{% endif %}"
                     />
                     </div>
@@ -436,13 +435,13 @@
                     </label>
 
                     <input
-                        type="number"
+                        type="text"
                         name="claims_encounters_volume_{{ent_no}}_{{r.reg_id}}"
                         required
                         class="integerfield"
                         id="claims_encounters_volume_{{ent_no}}_{{r.reg_id}}"
                         inputmode="numeric"
-                        min="1"
+                        pattern="^[1-9]+[0-9]*$"
                         value="{% if not renew %}{{ entity.claim_and_enc_vol }}{% endif %}"
                     />
                     </div>
@@ -456,14 +455,13 @@
 
                     <span class="s-affixed-input-wrapper__prefix">$</span>
                     <input
-                        type="number"
+                        type="text"
                         name="total_claims_value_{{ent_no}}_{{r.reg_id}}"
                         required
                         class="integerfield"
                         id="total_claims_value_{{ent_no}}_{{r.reg_id}}"
                         inputmode="numeric"
-                        step="0.01"
-                        min="0.01"
+                        pattern="^(?=.*[1-9])[0-9]*[.]?[0-9]{1,2}$"
                         value="{% if not renew %}{{ entity.claim_val }}{% endif %}"
                     />
                     </div>
@@ -708,14 +706,13 @@
                 </label>
 
                 <input
-                type="number"
+                type="text"
                 name="total_covered_lives_1"
                 required
                 class="integerfield"
                 id="total_covered_lives_1"
                 inputmode="numeric"
-                min="1"
-                step="1"
+                pattern="^[1-9]+[0-9]*$"
                 />
             </div>
 
@@ -727,13 +724,13 @@
                 </label>
 
                 <input
-                type="number"
+                type="text"
                 name="claims_encounters_volume_1"
                 required
                 class="integerfield"
                 id="claims_encounters_volume_1"
                 inputmode="numeric"
-                min="1"
+                pattern="^[1-9]+[0-9]*$"
                 />
             </div>
 
@@ -746,14 +743,13 @@
 
                 <span class="s-affixed-input-wrapper__prefix">$</span>
                 <input
-                type="number"
+                type="text"
                 name="total_claims_value_1"
                 required
                 class="integerfield"
                 id="total_claims_value_1"
                 inputmode="numeric"
-                step="0.01"
-                min="0.01"
+                pattern="^(?=.*[1-9])[0-9]*[.]?[0-9]{1,2}$"
                 />
             </div>
             {# Additional entities rendered here... #}

--- a/apcd-cms/src/apps/registrations/templates/submission_form/registration_form_body.html
+++ b/apcd-cms/src/apps/registrations/templates/submission_form/registration_form_body.html
@@ -25,7 +25,7 @@
                 class="radioselect"
                 required
                 id="on-behalf-of_0"                      
-                {% if r.view_modal_content.for_self %}
+                {% if r.view_modal_content.for_self or r is None or r|length == 0 %}
                     checked
                 {% endif %}
                 />
@@ -41,7 +41,7 @@
                 class="radioselect"
                 required
                 id="on-behalf-of_1"
-                {% if not r.view_modal_content.for_self and r is not None %}
+                {% if not r.view_modal_content.for_self and r is not None and r|length != 0 %}
                     checked
                 {% endif %}
                 />
@@ -145,14 +145,14 @@
             class="choicefield"
             id="state{% if r %}_{{r.reg_id}}{% endif%}"
         >
-            <option hidden value=" " selected> </option>
             {% if r.view_modal_content %}
                 {% for state in r.view_modal_content.us_state_list %}
                 <option data-display-value='{{ state|slice:":2"}}' value="{{ state }}" {% if r.view_modal_content.state == state|slice:":2" %}selected{% endif %}>
-                    {{ state }}
+                    {% if r.view_modal_content.state == state|slice:":2" %}{{ state|slice:":2" }}{% else %}{{ state }}{% endif %}
                 </option>
                 {% endfor %}
             {% else %}
+            <option hidden value=" " selected> </option>
             <option data-display-value="AL" value="AL - Alabama">AL - Alabama</option>
             <option data-display-value="AK" value="AK - Alaska">AK - Alaska</option>
             <option data-display-value="AS" value="AS - American Samoa">AS - American Samoa</option>
@@ -392,7 +392,6 @@
                                     type="checkbox"
                                     name="types_of_files_{{ file_type|lower }}_{{ent_no}}_{{r.reg_id}}"
                                     id="types_of_files_{{ file_type|lower }}_{{ent_no}}_{{r.reg_id}}"
-                                    {% if file_type is not 'Provider' %}required{% endif %}
                                     {% if file_type_selected %}checked{% endif %}
                                     />{{ file_type }}</label
                                 >

--- a/apcd-cms/src/apps/registrations/templates/submission_form/registration_form_body.html
+++ b/apcd-cms/src/apps/registrations/templates/submission_form/registration_form_body.html
@@ -143,71 +143,72 @@
             name="state"
             required="required"
             class="choicefield"
-            id="state"
+            id="state{% if r %}_{{r.reg_id}}{% endif%}"
         >
+            <option hidden value=" " selected> </option>
             {% if r.view_modal_content %}
                 {% for state in r.view_modal_content.us_state_list %}
-                <option value="{{ state }}" {% if r.view_modal_content.state == state|slice:":2" %}selected{% endif %}>
+                <option data-display-value='{{ state|slice:":2"}}' value="{{ state }}" {% if r.view_modal_content.state == state|slice:":2" %}selected{% endif %}>
                     {{ state }}
                 </option>
                 {% endfor %}
             {% else %}
-            <option value="AL - Alabama">AL - Alabama</option>
-            <option value="AK - Alaska">AK - Alaska</option>
-            <option value="AS - American Samoa">AS - American Samoa</option>
-            <option value="AZ - Arizona">AZ - Arizona</option>
-            <option value="AR - Arkansas">AR - Arkansas</option>
-            <option value="CA - California">CA - California</option>
-            <option value="CO - Colorado">CO - Colorado</option>
-            <option value="CT - Connecticut">CT - Connecticut</option>
-            <option value="DE - Delaware">DE - Delaware</option>
-            <option value="DC - District of Columbia">DC - District of Columbia</option>
-            <option value="FL - Florida">FL - Florida</option>
-            <option value="GA - Georgia">GA - Georgia</option>
-            <option value="GU - Guam">GU - Guam</option>
-            <option value="HI - Hawaii">HI - Hawaii</option>
-            <option value="ID - Idaho">ID - Idaho</option>
-            <option value="IL - Illinois">IL - Illinois</option>
-            <option value="IN - Indiana">IN - Indiana</option>
-            <option value="IA - Iowa">IA - Iowa</option>
-            <option value="KS - Kansas">KS - Kansas</option>
-            <option value="KY - Kentucky">KY - Kentucky</option>
-            <option value="LA - Louisiana">LA - Louisiana</option>
-            <option value="ME - Maine">ME - Maine</option>
-            <option value="MD - Maryland">MD - Maryland</option>
-            <option value="MA - Massachusetts">MA - Massachusetts</option>
-            <option value="MI - Michigan">MI - Michigan</option>
-            <option value="MN - Minnesota">MN - Minnesota</option>
-            <option value="MS - Mississippi">MS - Mississippi</option>
-            <option value="MO - Missouri">MO - Missouri</option>
-            <option value="MT - Montana">MT - Montana</option>
-            <option value="NE - Nebraska">NE - Nebraska</option>
-            <option value="NV - Nevada">NV - Nevada</option>
-            <option value="NH - New hampshire">NH - New hampshire</option>
-            <option value="NJ - New jersey">NJ - New jersey</option>
-            <option value="NM - New mexico">NM - New mexico</option>
-            <option value="NY - New york">NY - New york</option>
-            <option value="NC - North carolina">NC - North carolina</option>
-            <option value="ND - North dakota">ND - North dakota</option>
-            <option value="MP - Northern Mariana Islands">MP - Northern Mariana Islands</option>
-            <option value="OH - Ohio">OH - Ohio</option>
-            <option value="OK - Oklahoma">OK - Oklahoma</option>
-            <option value="OR - Oregon">OR - Oregon</option>
-            <option value="PA - Pennsylvania">PA - Pennsylvania</option>
-            <option value="PR - Puerto rico">PR - Puerto rico</option>
-            <option value="RI - Rhode island">RI - Rhode island</option>
-            <option value="SC - South Carolina">SC - South Carolina</option>
-            <option value="SD - South Dakota">SD - South Dakota</option>
-            <option value="TN - Tennessee">TN - Tennessee</option>
-            <option value="TX - Texas">TX - Texas</option>
-            <option value="UT - Utah">UT - Utah</option>
-            <option value="VT - Vermont">VT - Vermont</option>
-            <option value="VA - Virginia">VA - Virginia</option>
-            <option value="VI - Virgin Islands">VI - Virgin Islands</option>
-            <option value="WA - Washington">WA - Washington</option>
-            <option value="WV - West Virginia">WV - West Virginia</option>
-            <option value="WI - Wisconsin">WI - Wisconsin</option>
-            <option value="WY - Wyoming">WY - Wyoming</option>
+            <option data-display-value="AL" value="AL - Alabama">AL - Alabama</option>
+            <option data-display-value="AK" value="AK - Alaska">AK - Alaska</option>
+            <option data-display-value="AS" value="AS - American Samoa">AS - American Samoa</option>
+            <option data-display-value="AZ" value="AZ - Arizona">AZ - Arizona</option>
+            <option data-display-value="AR" value="AR - Arkansas">AR - Arkansas</option>
+            <option data-display-value="CA" value="CA - California">CA - California</option>
+            <option data-display-value="CO" value="CO - Colorado">CO - Colorado</option>
+            <option data-display-value="CT" value="CT - Connecticut">CT - Connecticut</option>
+            <option data-display-value="DE" value="DE - Delaware">DE - Delaware</option>
+            <option data-display-value="DC" value="DC - District of Columbia">DC - District of Columbia</option>
+            <option data-display-value="FL" value="FL - Florida">FL - Florida</option>
+            <option data-display-value="GA" value="GA - Georgia">GA - Georgia</option>
+            <option data-display-value="GU" value="GU - Guam">GU - Guam</option>
+            <option data-display-value="HI" value="HI - Hawaii">HI - Hawaii</option>
+            <option data-display-value="ID" value="ID - Idaho">ID - Idaho</option>
+            <option data-display-value="IL" value="IL - Illinois">IL - Illinois</option>
+            <option data-display-value="IN" value="IN - Indiana">IN - Indiana</option>
+            <option data-display-value="IA" value="IA - Iowa">IA - Iowa</option>
+            <option data-display-value="KS" value="KS - Kansas">KS - Kansas</option>
+            <option data-display-value="KY" value="KY - Kentucky">KY - Kentucky</option>
+            <option data-display-value="LA" value="LA - Louisiana">LA - Louisiana</option>
+            <option data-display-value="ME" value="ME - Maine">ME - Maine</option>
+            <option data-display-value="MD" value="MD - Maryland">MD - Maryland</option>
+            <option data-display-value="MA" value="MA - Massachusetts">MA - Massachusetts</option>
+            <option data-display-value="MI" value="MI - Michigan">MI - Michigan</option>
+            <option data-display-value="MN" value="MN - Minnesota">MN - Minnesota</option>
+            <option data-display-value="MS" value="MS - Mississippi">MS - Mississippi</option>
+            <option data-display-value="MO" value="MO - Missouri">MO - Missouri</option>
+            <option data-display-value="MT" value="MT - Montana">MT - Montana</option>
+            <option data-display-value="NE" value="NE - Nebraska">NE - Nebraska</option>
+            <option data-display-value="NV" value="NV - Nevada">NV - Nevada</option>
+            <option data-display-value="NH" value="NH - New hampshire">NH - New hampshire</option>
+            <option data-display-value="NJ" value="NJ - New Jersey">NJ - New Jersey</option>
+            <option data-display-value="NM" value="NM - New Mexico">NM - New Mexico</option>
+            <option data-display-value="NY" value="NY - New York">NY - New York</option>
+            <option data-display-value="NC" value="NC - North Carolina">NC - North Carolina</option>
+            <option data-display-value="ND" value="ND - North Dakota">ND - North Dakota</option>
+            <option data-display-value="MP" value="MP - Northern Mariana Islands">MP - Northern Mariana Islands</option>
+            <option data-display-value="OH" value="OH - Ohio">OH - Ohio</option>
+            <option data-display-value="OK" value="OK - Oklahoma">OK - Oklahoma</option>
+            <option data-display-value="OR" value="OR - Oregon">OR - Oregon</option>
+            <option data-display-value="PA" value="PA - Pennsylvania">PA - Pennsylvania</option>
+            <option data-display-value="PR" value="PR - Puerto Rico">PR - Puerto Rico</option>
+            <option data-display-value="RI" value="RI - Rhode Island">RI - Rhode Island</option>
+            <option data-display-value="SC" value="SC - South Carolina">SC - South Carolina</option>
+            <option data-display-value="SD" value="SD - South Dakota">SD - South Dakota</option>
+            <option data-display-value="TN" value="TN - Tennessee">TN - Tennessee</option>
+            <option data-display-value="TX" value="TX - Texas">TX - Texas</option>
+            <option data-display-value="UT" value="UT - Utah">UT - Utah</option>
+            <option data-display-value="VT" value="VT - Vermont">VT - Vermont</option>
+            <option data-display-value="VA" value="VA - Virginia">VA - Virginia</option>
+            <option data-display-value="VI" value="VI - Virgin Islands">VI - Virgin Islands</option>
+            <option data-display-value="WA" value="WA - Washington">WA - Washington</option>
+            <option data-display-value="WV" value="WV - West Virginia">WV - West Virginia</option>
+            <option data-display-value="WI" value="WI - Wisconsin">WI - Wisconsin</option>
+            <option data-display-value="WY" value="WY - Wyoming">WY - Wyoming</option>
             {% endif %}
         </select>
         </div>

--- a/apcd-cms/src/apps/registrations/templates/submission_form/registration_form_body.html
+++ b/apcd-cms/src/apps/registrations/templates/submission_form/registration_form_body.html
@@ -363,7 +363,7 @@
                         Types of Files
                     </label>
                     <div class="help-text">
-                        Eligibility/Enrollment files are mandatory. Select additional file types to be submitted.
+                        Eligibility/Enrollment files are mandatory. At least one claims file type (Medical, Pharmacy, and Dental) must be selected.
                     </div>
                     </div>
 
@@ -391,6 +391,7 @@
                                     type="checkbox"
                                     name="types_of_files_{{ file_type|lower }}_{{ent_no}}_{{r.reg_id}}"
                                     id="types_of_files_{{ file_type|lower }}_{{ent_no}}_{{r.reg_id}}"
+                                    {% if file_type is not 'Provider' %}required{% endif %}
                                     {% if file_type_selected %}checked{% endif %}
                                     />{{ file_type }}</label
                                 >
@@ -629,7 +630,7 @@
                 Types of Files<span class="asterisk">*</span>
             </label>
             <div class="help-text">
-                Eligibility/Enrollment files are mandatory. Select additional file types to be submitted.
+                Eligibility/Enrollment files are mandatory. At least one claims file type (Medical, Pharmacy, and Dental) must be selected.
             </div>
             </div>
 
@@ -664,6 +665,7 @@
                             type="checkbox"
                             name="types_of_files_medical_1"
                             id="types_of_files_medical_1"
+                            required
                             />Medical</label
                         >
                     </li>
@@ -673,6 +675,7 @@
                             type="checkbox"
                             name="types_of_files_pharmacy_1"
                             id="types_of_files_pharmacy_1"
+                            required
                             />Pharmacy</label
                         >
                     </li>
@@ -682,6 +685,7 @@
                             type="checkbox"
                             name="types_of_files_dental_1"
                             id="types_of_files_dental_1"
+                            required
                             />Dental</label
                         >
                     </li>

--- a/apcd-cms/src/apps/registrations/templates/submission_form/registration_form_body.html
+++ b/apcd-cms/src/apps/registrations/templates/submission_form/registration_form_body.html
@@ -152,7 +152,7 @@
                 </option>
                 {% endfor %}
             {% else %}
-            <option hidden value=" " selected> </option>
+            <option hidden selected> </option>
             <option data-display-value="AL" value="AL - Alabama">AL - Alabama</option>
             <option data-display-value="AK" value="AK - Alaska">AK - Alaska</option>
             <option data-display-value="AS" value="AS - American Samoa">AS - American Samoa</option>

--- a/apcd-cms/src/apps/registrations/templates/submission_form/registration_form_scripts.html
+++ b/apcd-cms/src/apps/registrations/templates/submission_form/registration_form_scripts.html
@@ -35,22 +35,16 @@
       }
     </script>  
     <script id="form-entity_plan_type-required">
-      function entityPlanTypeValidation(ent_no, reg_id) {
-        const planGroup = Array.from(
-          document.querySelectorAll(`
-          input[name=types_of_plans_commercial_${ent_no}${ reg_id ? `_${reg_id}`: ''}],
-          input[name=types_of_plans_medicare_${ent_no}${ reg_id ? `_${reg_id}`: ''}],
-          input[name=types_of_plans_medicaid_${ent_no}${ reg_id ? `_${reg_id}`: ''}]`)
-        );
-        planGroup.forEach(i => i.addEventListener('invalid', function (event) {
+      function checkboxGroupValidation(checkboxGroup, customValidityMessage) {
+        checkboxGroup.forEach(i => i.addEventListener('invalid', function (event) {
           if (!event.target.checked) {
-            event.target.setCustomValidity('Please select at least one plan type.');
+            event.target.setCustomValidity(customValidityMessage);
           }
         }));
-        planGroup.forEach(i => i.addEventListener('click', function (event) {
-          planGroup.forEach(j => {
+        checkboxGroup.forEach(i => i.addEventListener('click', function (event) {
+          checkboxGroup.forEach(j => {
             j.required = true;
-            if (planGroup.some(input => input.checked)) { // if box checked, no other inputs in this group are required
+            if (checkboxGroup.some(input => input.checked)) { // if box checked, no other inputs in this group are required
               j.setCustomValidity('');
               j.required = false;
             }
@@ -88,27 +82,41 @@
         {% else %}
           null
         {% endif %};
+      let reg_id_substr = reg_id ? `_${reg_id}`: '';
 
       for (let ent_no = 1; ent_no < entities + 1; ent_no +=1) {
         entityIdGroupValidation(ent_no, reg_id); // add validation for entities already on form at page load
-        entityPlanTypeValidation(ent_no, reg_id);
+        let planTypeBoxes = Array.from(
+          document.querySelectorAll(`
+          input[name=types_of_plans_commercial_${ent_no}${reg_id_substr}],
+          input[name=types_of_plans_medicare_${ent_no}${reg_id_substr}],
+          input[name=types_of_plans_medicaid_${ent_no}${reg_id_substr}]`)
+        );
+        let claimFileTypeBoxes = Array.from(
+          document.querySelectorAll(`
+          input[name=types_of_files_medical_${entities}${reg_id_substr}],
+          input[name=types_of_files_pharmacy_${entities}${reg_id_substr}],
+          input[name=types_of_files_dental_${entities}${reg_id_substr}]`)
+        );
+        checkboxGroupValidation(planTypeBoxes, 'Please select at least one plan type.');
+        checkboxGroupValidation(claimFileTypeBoxes, 'Please select at least one claims file type (see above).');
       };
       btnStatus();
 
       addEntityBtn.addEventListener("click", () => {
         if (entities < 5) entities += 1;
-        let entityBlock = document.getElementById(`entity_block_${entities}{% if r %}_{{r.reg_id}}{% endif %}`);
-        document.getElementById(`entity_header_${entities}{% if r %}_{{r.reg_id}}{% endif %}`).style.display = 'block';
+        let entityBlock = document.getElementById(`entity_block_${entities}${reg_id_substr}`);
+        document.getElementById(`entity_header_${entities}${reg_id_substr}`).style.display = 'block';
         entityBlock.innerHTML = `
         <div class="field-wrapper textinput required">
           <div class="field-errors" style="display: none"></div>
-          <label for="entity_name_${entities}{% if r %}_{{r.reg_id}}{% endif %}"> Name<span class="asterisk">*</span> </label>
+          <label for="entity_name_${entities}${reg_id_substr}"> Name<span class="asterisk">*</span> </label>
           <input
             type="text"
-            name="entity_name_${entities}{% if r %}_{{r.reg_id}}{% endif %}"
+            name="entity_name_${entities}${reg_id_substr}"
             required
             class="textinput"
-            id="entity_name_${entities}{% if r %}_{{r.reg_id}}{% endif %}"
+            id="entity_name_${entities}${reg_id_substr}"
           />
           <div id="help-text-entity_name_${entities}" class="help-text">
           </div>
@@ -125,13 +133,13 @@
         <div class="o-grid o-grid--col-auto-count">
           <div class="field-wrapper textinput">
             <div class="field-errors" style="display: none"></div>
-            <label for="fein_${entities}{% if r %}_{{r.reg_id}}{% endif %}"> FEIN<sup>2</sup> </label>
+            <label for="fein_${entities}${reg_id_substr}"> FEIN<sup>2</sup> </label>
             <input
               type="text"
-              name="fein_${entities}{% if r %}_{{r.reg_id}}{% endif %}"
+              name="fein_${entities}${reg_id_substr}"
               placeholder="12-3456789"
               class="textinput"
-              id="fein_${entities}{% if r %}_{{r.reg_id}}{% endif %}"
+              id="fein_${entities}${reg_id_substr}"
               inputmode="numeric"
               minlength="10"
               maxlength="10"
@@ -144,13 +152,13 @@
           </div>
           <div class="field-wrapper textinput">
             <div class="field-errors" style="display: none"></div>
-            <label for="license_number_${entities}{% if r %}_{{r.reg_id}}{% endif %}"> License Number </label>
+            <label for="license_number_${entities}${reg_id_substr}"> License Number </label>
             <input
               type="number"
-              name="license_number_${entities}{% if r %}_{{r.reg_id}}{% endif %}"
+              name="license_number_${entities}${reg_id_substr}"
               placeholder="1234567890"
               class="integerfield"
-              id="license_number_${entities}{% if r %}_{{r.reg_id}}{% endif %}"
+              id="license_number_${entities}${reg_id_substr}"
               inputmode="numeric"
               min="0"
               max="2147483648"
@@ -162,13 +170,13 @@
           </div>
           <div class="field-wrapper textinput">
             <div class="field-errors" style="display: none"></div>
-            <label for="naic_company_code_${entities}{% if r %}_{{r.reg_id}}{% endif %}"> NAIC<sup>3</sup> Company Code </label>
+            <label for="naic_company_code_${entities}${reg_id_substr}"> NAIC<sup>3</sup> Company Code </label>
             <input
               type="number"
-              name="naic_company_code_${entities}{% if r %}_{{r.reg_id}}{% endif %}"
+              name="naic_company_code_${entities}${reg_id_substr}"
               placeholder="12345"
               class="integerfield"
-              id="naic_company_code_${entities}{% if r %}_{{r.reg_id}}{% endif %}"
+              id="naic_company_code_${entities}${reg_id_substr}"
               inputmode="numeric"
               min="0"
               max="2147483648"
@@ -191,31 +199,31 @@
 
             <ul id="types_of_plans" class="checkboxselectmultiple">
                 <li>
-                    <label for="types_of_plans_commercial_${entities}{% if r %}_{{r.reg_id}}{% endif %}"
+                    <label for="types_of_plans_commercial_${entities}${reg_id_substr}"
                     ><input
                         type="checkbox"
-                        name="types_of_plans_commercial_${entities}{% if r %}_{{r.reg_id}}{% endif %}"
-                        id="types_of_plans_commercial_${entities}{% if r %}_{{r.reg_id}}{% endif %}"
+                        name="types_of_plans_commercial_${entities}${reg_id_substr}"
+                        id="types_of_plans_commercial_${entities}${reg_id_substr}"
                         required
                     />Commercial</label
                     >
                 </li>
                 <li>
-                    <label for="types_of_plans_medicare_${entities}{% if r %}_{{r.reg_id}}{% endif %}"
+                    <label for="types_of_plans_medicare_${entities}${reg_id_substr}"
                         ><input
                         type="checkbox"
-                        name="types_of_plans_medicare_${entities}{% if r %}_{{r.reg_id}}{% endif %}"
-                        id="types_of_plans_medicare_${entities}{% if r %}_{{r.reg_id}}{% endif %}"
+                        name="types_of_plans_medicare_${entities}${reg_id_substr}"
+                        id="types_of_plans_medicare_${entities}${reg_id_substr}"
                         required
                         />Medicare</label
                     >
                 </li>
                 <li>
-                    <label for="types_of_plans_medicaid_${entities}{% if r %}_{{r.reg_id}}{% endif %}"
+                    <label for="types_of_plans_medicaid_${entities}${reg_id_substr}"
                         ><input
                         type="checkbox"
-                        name="types_of_plans_medicaid_${entities}{% if r %}_{{r.reg_id}}{% endif %}"
-                        id="types_of_plans_medicaid_${entities}{% if r %}_{{r.reg_id}}{% endif %}"
+                        name="types_of_plans_medicaid_${entities}${reg_id_substr}"
+                        id="types_of_plans_medicaid_${entities}${reg_id_substr}"
                         required
                         />Medicaid</label
                     >
@@ -228,7 +236,7 @@
             Types of Files
         </label>
         <div class="help-text">
-            Eligibility/Enrollment files are mandatory. Select additional file types to be submitted.
+            Eligibility/Enrollment files are mandatory. At least one claims file type (Medical, Pharmacy, and Dental) must be selected.
         </div>
         </div>
 
@@ -237,50 +245,53 @@
 
             <ul id="types_of_files" class="checkboxselectmultiple">
                 <li>
-                    <label for="types_of_files_eligibility_enrollment_${entities}{% if r %}_{{r.reg_id}}{% endif %}"
+                    <label for="types_of_files_eligibility_enrollment_${entities}${reg_id_substr}"
                     ><input
                         type="checkbox"
-                        name="types_of_files_eligibility_enrollment_${entities}{% if r %}_{{r.reg_id}}{% endif %}"
+                        name="types_of_files_eligibility_enrollment_${entities}${reg_id_substr}"
                         required
-                        id="types_of_files_eligibility_enrollment_${entities}{% if r %}_{{r.reg_id}}{% endif %}"
+                        id="types_of_files_eligibility_enrollment_${entities}${reg_id_substr}"
                         checked=""
                         disabled
                     />Eligibility/Enrollment*</label
                     >
                 </li>
                 <li>
-                    <label for="types_of_files_provider_${entities}{% if r %}_{{r.reg_id}}{% endif %}"
+                    <label for="types_of_files_provider_${entities}${reg_id_substr}"
                         ><input
                         type="checkbox"
-                        name="types_of_files_provider_${entities}{% if r %}_{{r.reg_id}}{% endif %}"
-                        id="types_of_files_provider_${entities}{% if r %}_{{r.reg_id}}{% endif %}"
+                        name="types_of_files_provider_${entities}${reg_id_substr}"
+                        id="types_of_files_provider_${entities}${reg_id_substr}"
                         />Provider</label
                     >
                 </li>
                 <li>
-                    <label for="types_of_files_medical_${entities}{% if r %}_{{r.reg_id}}{% endif %}"
+                    <label for="types_of_files_medical_${entities}${reg_id_substr}"
                         ><input
                         type="checkbox"
-                        name="types_of_files_medical_${entities}{% if r %}_{{r.reg_id}}{% endif %}"
-                        id="types_of_files_medical_${entities}{% if r %}_{{r.reg_id}}{% endif %}"
+                        name="types_of_files_medical_${entities}${reg_id_substr}"
+                        id="types_of_files_medical_${entities}${reg_id_substr}"
+                        required
                         />Medical</label
                     >
                 </li>
                 <li>
-                    <label for="types_of_files_pharmacy_${entities}{% if r %}_{{r.reg_id}}{% endif %}"
+                    <label for="types_of_files_pharmacy_${entities}${reg_id_substr}"
                         ><input
                         type="checkbox"
-                        name="types_of_files_pharmacy_${entities}{% if r %}_{{r.reg_id}}{% endif %}"
-                        id="types_of_files_pharmacy_${entities}{% if r %}_{{r.reg_id}}{% endif %}"
+                        name="types_of_files_pharmacy_${entities}${reg_id_substr}"
+                        id="types_of_files_pharmacy_${entities}${reg_id_substr}"
+                        required
                         />Pharmacy</label
                     >
                 </li>
                 <li>
-                    <label for="types_of_files_dental_${entities}{% if r %}_{{r.reg_id}}{% endif %}"
+                    <label for="types_of_files_dental_${entities}${reg_id_substr}"
                         ><input
                         type="checkbox"
-                        name="types_of_files_dental_${entities}{% if r %}_{{r.reg_id}}{% endif %}"
-                        id="types_of_files_dental_${entities}{% if r %}_{{r.reg_id}}{% endif %}"
+                        name="types_of_files_dental_${entities}${reg_id_substr}"
+                        id="types_of_files_dental_${entities}${reg_id_substr}"
+                        required
                         />Dental</label
                     >
                 </li>
@@ -293,15 +304,15 @@
         </h6>
         <div class="field-wrapper numberinput required">
           <div class="field-errors" style="display: none"></div>
-          <label for="total_covered_lives_${entities}{% if r %}_{{r.reg_id}}{% endif %}">
+          <label for="total_covered_lives_${entities}${reg_id_substr}">
             Total Covered Lives<span class="asterisk">*</span>
           </label>
           <input
             type="number"
-            name="total_covered_lives_${entities}{% if r %}_{{r.reg_id}}{% endif %}"
+            name="total_covered_lives_${entities}${reg_id_substr}"
             required
             class="integerfield"
-            id="total_covered_lives_${entities}{% if r %}_{{r.reg_id}}{% endif %}"
+            id="total_covered_lives_${entities}${reg_id_substr}"
             inputmode="numeric"
             min="1"
             step="1"
@@ -311,15 +322,15 @@
         </div>
         <div class="field-wrapper numberinput required">
           <div class="field-errors" style="display: none"></div>
-          <label for="claims_encounters_volume_${entities}{% if r %}_{{r.reg_id}}{% endif %}">
+          <label for="claims_encounters_volume_${entities}${reg_id_substr}">
             Claims and Encounters Volume<span class="asterisk">*</span>
           </label>
           <input
             type="number"
-            name="claims_encounters_volume_${entities}{% if r %}_{{r.reg_id}}{% endif %}"
+            name="claims_encounters_volume_${entities}${reg_id_substr}"
             required
             class="integerfield"
-            id="claims_encounters_volume_${entities}{% if r %}_{{r.reg_id}}{% endif %}"
+            id="claims_encounters_volume_${entities}${reg_id_substr}"
             inputmode="numeric"
             min="1"
           />
@@ -328,16 +339,16 @@
         </div>
         <div class="field-wrapper numberinput required s-affixed-input-wrapper s-affixed-input-wrapper--prefix">
           <div class="field-errors" style="display: none"></div>
-          <label for="total_claims_value_${entities}{% if r %}_{{r.reg_id}}{% endif %}">
+          <label for="total_claims_value_${entities}${reg_id_substr}">
             Total Claims Value (USD<sup>4</sup>)<span class="asterisk">*</span>
           </label>
           <span class="s-affixed-input-wrapper__prefix">$</span>
           <input
             type="number"
-            name="total_claims_value_${entities}{% if r %}_{{r.reg_id}}{% endif %}"
+            name="total_claims_value_${entities}${reg_id_substr}"
             required
             class="integerfield"
-            id="total_claims_value_${entities}{% if r %}_{{r.reg_id}}{% endif %}"
+            id="total_claims_value_${entities}${reg_id_substr}"
             inputmode="numeric"
             step="0.01"
             min="0.01"
@@ -353,17 +364,30 @@
         {% endif %}
         `;
         entityIdGroupValidation(entities, reg_id); // add entity input validation for new entities on form
-        entityPlanTypeValidation(entities, reg_id);
+        let planTypeBoxes = Array.from(
+          document.querySelectorAll(`
+          input[name=types_of_plans_commercial_${entities}${reg_id_substr}],
+          input[name=types_of_plans_medicare_${entities}${reg_id_substr}],
+          input[name=types_of_plans_medicaid_${entities}${reg_id_substr}`)
+        );
+        let claimFileTypeBoxes = Array.from(
+          document.querySelectorAll(`
+          input[name=types_of_files_medical_${entities}${reg_id_substr}],
+          input[name=types_of_files_pharmacy_${entities}${reg_id_substr}],
+          input[name=types_of_files_dental_${entities}${reg_id_substr}]`)
+        );
+        checkboxGroupValidation(planTypeBoxes, 'Please select at least one plan type.');
+        checkboxGroupValidation(claimFileTypeBoxes, 'Please select at least one claims file type (see above).');
 
-        const addEntityNameInput = document.querySelectorAll(`input[name=entity_name_${entities}{% if r %}_{{r.reg_id}}{% endif %}]`);
+        const addEntityNameInput = document.querySelectorAll(`input[name=entity_name_${entities}${reg_id_substr}]`);
         noEmptyInputs(addEntityNameInput);
 
         btnStatus();
       });
 
       dropEntityBtn.addEventListener("click", () => {
-        document.getElementById(`entity_header_${entities}{% if r %}_{{r.reg_id}}{% endif %}`).style.display = 'none';
-        let entityBlock = document.getElementById(`entity_block_${entities}{% if r %}_{{r.reg_id}}{% endif %}`);
+        document.getElementById(`entity_header_${entities}${reg_id_substr}`).style.display = 'none';
+        let entityBlock = document.getElementById(`entity_block_${entities}${reg_id_substr}`);
         entityBlock.innerHTML = '';
         if (entities > 1) entities -= 1;
         btnStatus();
@@ -394,44 +418,51 @@
         {% else %}
             1
         {% endif %};
+      let reg_id = 
+        {% if r %}
+          Number(`{{r.reg_id}}`)
+        {% else %}
+          null
+        {% endif %};
+      let reg_id_substr = reg_id ? `_${reg_id}`: '';
       btnStatus();
 
       addContactBtn.addEventListener("click", () => {
         if (contacts < 5) contacts += 1;
-        let contactBlock = document.getElementById(`contact_block_${contacts}{% if r %}_{{r.reg_id}}{% endif %}`);
-        document.getElementById(`contact_header_${contacts}{% if r %}_{{r.reg_id}}{% endif %}`).style.display = 'block';
+        let contactBlock = document.getElementById(`contact_block_${contacts}${reg_id_substr}`);
+        document.getElementById(`contact_header_${contacts}${reg_id_substr}`).style.display = 'block';
         contactBlock.innerHTML = `
             <div class="field-wrapper textinput required">
               <div class="field-errors" style="display: none"></div>
-              <label for="contact_type_${contacts}{% if r %}_{{r.reg_id}}{% endif %}"> Role<span class="asterisk">*</span> </label>
+              <label for="contact_type_${contacts}${reg_id_substr}"> Role<span class="asterisk">*</span> </label>
               <input
                 type="text"
-                name="contact_type_${contacts}{% if r %}_{{r.reg_id}}{% endif %}"
+                name="contact_type_${contacts}${reg_id_substr}"
                 required
                 class="textinput"
-                id="contact_type_${contacts}{% if r %}_{{r.reg_id}}{% endif %}"
+                id="contact_type_${contacts}${reg_id_substr}"
               />
             </div>
             <div class="field-wrapper textinput required">
               <div class="field-errors" style="display: none"></div>
-              <label for="contact_name_${contacts}{% if r %}_{{r.reg_id}}{% endif %}"> Name<span class="asterisk">*</span> </label>
+              <label for="contact_name_${contacts}${reg_id_substr}"> Name<span class="asterisk">*</span> </label>
               <input
                 type="text"
-                name="contact_name_${contacts}{% if r %}_{{r.reg_id}}{% endif %}"
+                name="contact_name_${contacts}${reg_id_substr}"
                 required
                 class="textinput"
-                id="contact_name_${contacts}{% if r %}_{{r.reg_id}}{% endif %}"
+                id="contact_name_${contacts}${reg_id_substr}"
               />
             </div>
             <div class="field-wrapper telephoneinput required">
               <div class="field-errors" style="display: none"></div>
-              <label for="contact_phone_${contacts}{% if r %}_{{r.reg_id}}{% endif %}"> Phone<span class="asterisk">*</span> </label>
+              <label for="contact_phone_${contacts}${reg_id_substr}"> Phone<span class="asterisk">*</span> </label>
               <input
                 type="tel"
-                name="contact_phone_${contacts}{% if r %}_{{r.reg_id}}{% endif %}"
+                name="contact_phone_${contacts}${reg_id_substr}"
                 required
                 class="telephoneinput"
-                id="contact_phone_${contacts}{% if r %}_{{r.reg_id}}{% endif %}"
+                id="contact_phone_${contacts}${reg_id_substr}"
                 inputmode="tel"
                 pattern="^(\\+0?1\\s)?\\(?\\d{3}\\)?[\\s.\\-]\\d{3}[\\s.\\-]\\d{4}$"
               />
@@ -457,36 +488,36 @@
             </div>
             <div class="field-wrapper emailinput required">
               <div class="field-errors" style="display: none"></div>
-              <label for="contact_email_${contacts}{% if r %}_{{r.reg_id}}{% endif %}"> Email<span class="asterisk">*</span> </label>
+              <label for="contact_email_${contacts}${reg_id_substr}"> Email<span class="asterisk">*</span> </label>
               <input
                 type="email"
-                name="contact_email_${contacts}{% if r %}_{{r.reg_id}}{% endif %}"
+                name="contact_email_${contacts}${reg_id_substr}"
                 autocomplete="email"
                 required
                 class="emailinput"
                 pattern="^[A-Za-z0-9._%+\\-]+@[A-Za-z0-9.\\-]+\.[a-z]{2,4}$"
-                id="contact_email_${contacts}{% if r %}_{{r.reg_id}}{% endif %}"
+                id="contact_email_${contacts}${reg_id_substr}"
               />
             </div>
             <div class="field-wrapper checkboxinput">
               <div class="field-errors" style="display: none"></div>
               <input
                 type="checkbox"
-                name="contact_notifications_${contacts}{% if r %}_{{r.reg_id}}{% endif %}"
+                name="contact_notifications_${contacts}${reg_id_substr}"
                 class="booleanfield"
                 id="contact_notifications_${contacts}"
               />
-              <label for="contact_notifications_${contacts}{% if r %}_{{r.reg_id}}{% endif %}">
+              <label for="contact_notifications_${contacts}${reg_id_substr}">
                 Select to receive system notifications
               </label>
-              <div id="help-text-contact_notifications_${contacts}{% if r %}_{{r.reg_id}}{% endif %}" class="help-text">
+              <div id="help-text-contact_notifications_${contacts}${reg_id_substr}" class="help-text">
               </div>
             </div>
         `;
 
         const addContactTextInputs = document.querySelectorAll(`
-          input[name=contact_type_${contacts}{% if r %}_{{r.reg_id}}{% endif %}],
-          input[name=contact_name_${contacts}{% if r %}_{{r.reg_id}}{% endif %}]
+          input[name=contact_type_${contacts}${reg_id_substr}],
+          input[name=contact_name_${contacts}${reg_id_substr}]
         `);
         noEmptyInputs(addContactTextInputs);
 
@@ -494,8 +525,8 @@
       });
 
       dropContactBtn.addEventListener("click", () => {
-        document.getElementById(`contact_header_${contacts}{% if r %}_{{r.reg_id}}{% endif %}`).style.display = 'none';
-        let contactBlock = document.getElementById(`contact_block_${contacts}{% if r %}_{{r.reg_id}}{% endif %}`);
+        document.getElementById(`contact_header_${contacts}${reg_id_substr}`).style.display = 'none';
+        let contactBlock = document.getElementById(`contact_block_${contacts}${reg_id_substr}`);
         contactBlock.innerHTML = '';
         if (contacts > 1) contacts -= 1;
         btnStatus();

--- a/apcd-cms/src/apps/registrations/templates/submission_form/registration_form_scripts.html
+++ b/apcd-cms/src/apps/registrations/templates/submission_form/registration_form_scripts.html
@@ -94,9 +94,9 @@
         );
         let claimFileTypeBoxes = Array.from(
           document.querySelectorAll(`
-          input[name=types_of_files_medical_${entities}${reg_id_substr}],
-          input[name=types_of_files_pharmacy_${entities}${reg_id_substr}],
-          input[name=types_of_files_dental_${entities}${reg_id_substr}]`)
+          input[name=types_of_files_medical_${ent_no}${reg_id_substr}],
+          input[name=types_of_files_pharmacy_${ent_no}${reg_id_substr}],
+          input[name=types_of_files_dental_${ent_no}${reg_id_substr}]`)
         );
         checkboxGroupValidation(planTypeBoxes, 'Please select at least one plan type.');
         checkboxGroupValidation(claimFileTypeBoxes, 'Please select at least one claims file type (see above).');

--- a/apcd-cms/src/apps/registrations/templates/submission_form/registration_form_scripts.html
+++ b/apcd-cms/src/apps/registrations/templates/submission_form/registration_form_scripts.html
@@ -530,4 +530,31 @@
         btnStatus();
       });
     </script>
+    <script>
+      function stateOptionText (stateSelectDropdown, action) {
+        var selectedState, selectedStateValue, selectedStateDisplayVal;
+        selectedState = stateSelectDropdown.selectedOptions[0];
+        selectedStateValue = selectedState.value;
+        selectedStateDisplayVal = selectedState.getAttribute("data-display-value");
+        if (action === 'reset') {
+          selectedState.innerHTML = selectedStateValue;
+        }
+        else if (action === 'select') {
+          selectedState.innerHTML = selectedStateDisplayVal; /* sets dropdown to display state abbreviation only */
+        }
+      }
+      var regStrEnd, stateSelectDropdowns;
+      regStrEnd = 
+            {% if r %}
+              "_{{r.reg_id}}"
+            {% else %}
+              ""
+            {% endif %}
+      ;
+      stateSelectDropdowns = document.querySelectorAll(`select[id=state${regStrEnd}]`);
+      stateSelectDropdowns.forEach(selector => {
+        selector.addEventListener('input', (event) => stateOptionText(event.target, 'select')),
+        selector.addEventListener('focus', (event) => stateOptionText(event.target, 'reset')) /* assumes user will click away before interacting again */
+      });
+  </script>
 </aside>

--- a/apcd-cms/src/apps/registrations/templates/submission_form/registration_form_scripts.html
+++ b/apcd-cms/src/apps/registrations/templates/submission_form/registration_form_scripts.html
@@ -530,7 +530,7 @@
         btnStatus();
       });
     </script>
-    <script>
+    <script id="state-dropdown-text-handler">
       function stateOptionText (stateSelectDropdown, action) {
         var selectedState, selectedStateValue, selectedStateDisplayVal;
         selectedState = stateSelectDropdown.selectedOptions[0];

--- a/apcd-cms/src/apps/registrations/templates/submission_form/registration_form_scripts.html
+++ b/apcd-cms/src/apps/registrations/templates/submission_form/registration_form_scripts.html
@@ -308,14 +308,13 @@
             Total Covered Lives<span class="asterisk">*</span>
           </label>
           <input
-            type="number"
+            type="text"
             name="total_covered_lives_${entities}${reg_id_substr}"
             required
             class="integerfield"
             id="total_covered_lives_${entities}${reg_id_substr}"
             inputmode="numeric"
-            min="1"
-            step="1"
+            pattern="^[1-9]+[0-9]*$"
           />
           <div id="help-text-total_covered_lives_${entities}" class="help-text">
           </div>
@@ -326,13 +325,13 @@
             Claims and Encounters Volume<span class="asterisk">*</span>
           </label>
           <input
-            type="number"
+            type="text"
             name="claims_encounters_volume_${entities}${reg_id_substr}"
             required
             class="integerfield"
             id="claims_encounters_volume_${entities}${reg_id_substr}"
             inputmode="numeric"
-            min="1"
+            pattern="^[1-9]+[0-9]*$"
           />
           <div id="help-text-claims_encounters_volume_${entities}" class="help-text">
           </div>
@@ -344,14 +343,13 @@
           </label>
           <span class="s-affixed-input-wrapper__prefix">$</span>
           <input
-            type="number"
+            type="text"
             name="total_claims_value_${entities}${reg_id_substr}"
             required
             class="integerfield"
             id="total_claims_value_${entities}${reg_id_substr}"
             inputmode="numeric"
-            step="0.01"
-            min="0.01"
+            pattern="^(?=.*[1-9])[0-9]*[.]?[0-9]{1,2}$"
           />
           <div id="help-text-total_claims_value_${entities}" class="help-text">
           </div>

--- a/apcd-cms/src/apps/registrations/views.py
+++ b/apcd-cms/src/apps/registrations/views.py
@@ -47,8 +47,10 @@ class SubmissionFormView(View):
     def post(self, request):
         form = request.POST.copy()
         old_reg_id = None
+        renewal = False
         if 'reg_id' in form:
             old_reg_id = form['reg_id']
+            renewal = True
         errors = []
 
         if (request.user.is_authenticated):
@@ -59,7 +61,7 @@ class SubmissionFormView(View):
         else:
             return HttpResponseRedirect('/')
 
-        reg_resp = apcd_database.create_registration(form)
+        reg_resp = apcd_database.create_registration(form, renewal=renewal)
         if not _err_msg(reg_resp) and type(reg_resp) == int:
             for iteration in range(1,6):
                 contact_resp = apcd_database.create_registration_contact(form, reg_resp, iteration, old_reg_id=old_reg_id)

--- a/apcd-cms/src/apps/submitter_renewals_listing/templates/list_submitter_registrations.html
+++ b/apcd-cms/src/apps/submitter_renewals_listing/templates/list_submitter_registrations.html
@@ -5,7 +5,7 @@
 
 <link rel="stylesheet" href="{% static 'apcd-cms/css/table.css' %}">
 <link rel="stylesheet" href="{% static 'apcd-cms/css/modal.css' %}">
-<link rel="stylesheet" href="{% static 'submitter_renewals_listing/css/table.css' %}">
+<link rel="stylesheet" href="{% static 'admin_regis_table/css/table.css' %}">
 
 <div class="container">
   {% include "nav_cms_breadcrumbs.html" %}

--- a/apcd-cms/src/apps/submitter_renewals_listing/views.py
+++ b/apcd-cms/src/apps/submitter_renewals_listing/views.py
@@ -18,6 +18,12 @@ class SubmittersTable(RegistrationsTable):
             data = json.loads(submitter_code)
             submitter_code = data['submitter_code']
             registrations_content = get_registrations(submitter_code=submitter_code)
+            registrations_entities = []
+            registrations_contacts = []
+            for reg in registrations_content:
+                reg_id = int(reg[0])
+                registrations_entities.append(get_registration_entities(reg_id=reg_id))  # get entities and contacts for reg id's
+                registrations_contacts.append(get_registration_contacts(reg_id=reg_id))  # we have already verified are associated w/ given submitter code
             registrations_entities = get_registration_entities(submitter_code=submitter_code)
             registrations_contacts = get_registration_contacts(submitter_code=submitter_code)            
             context = self.get_context_data(registrations_content, registrations_entities, registrations_contacts, *args,**kwargs)

--- a/apcd-cms/src/apps/utils/apcd_database.py
+++ b/apcd-cms/src/apps/utils/apcd_database.py
@@ -308,9 +308,7 @@ def get_registration_entities(reg_id=None, submitter_code=None):
                 registration_entities.file_pc,
                 registration_entities.file_dc
                 FROM registration_entities 
-                {f"WHERE registration_id = {str(reg_id)}" if reg_id is not None else ''}
-                {f"LEFT JOIN submitters on registration_entities.registration_id = submitters.registration_id WHERE submitter_code = '{str(submitter_code)}'" if submitter_code is not None else ''}"""
-
+                {f"WHERE registration_id = {str(reg_id)}" if reg_id is not None else ''}"""
         cur = conn.cursor()
         cur.execute(query)
         return cur.fetchall()
@@ -521,8 +519,7 @@ def get_registration_contacts(reg_id=None, submitter_code=None):
                 registration_contacts.contact_phone,
                 registration_contacts.contact_email
                 FROM registration_contacts 
-                {f"WHERE registration_id = {str(reg_id)}" if reg_id is not None else ''}
-                {f"LEFT JOIN submitters on registration_contacts.registration_id = submitters.registration_id WHERE submitter_code = '{str(submitter_code)}'" if submitter_code is not None else ''}"""
+                {f"WHERE registration_id = {str(reg_id)}" if reg_id is not None else ''}"""
         cur = conn.cursor()
         cur.execute(query)
         return cur.fetchall()

--- a/apcd-cms/src/apps/utils/apcd_database.py
+++ b/apcd-cms/src/apps/utils/apcd_database.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 import psycopg2
-from datetime import datetime
+from datetime import datetime, date
 import re
 import logging
 
@@ -153,7 +153,7 @@ def get_registrations(reg_id=None, submitter_code=None):
                 registrations.state,
                 registrations.zip,
                 registrations.registration_year
-                FROM registrations 
+                FROM registrations
                 {f"WHERE registration_id = {str(reg_id)}" if reg_id is not None else ''}
                 {f"LEFT JOIN submitters on registrations.registration_id = submitters.registration_id WHERE submitter_code = '{str(submitter_code)}' ORDER BY registrations.registration_id" if submitter_code is not None else ''}"""
         cur = conn.cursor()
@@ -170,7 +170,7 @@ def get_registrations(reg_id=None, submitter_code=None):
             conn.close()
 
 
-def create_registration(form):
+def create_registration(form, renewal=False):
     cur = None
     conn = None
     try:
@@ -194,8 +194,9 @@ def create_registration(form):
             mail_address,
             city,
             state,
-            zip
-        ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+            zip,
+            registration_year
+        ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
         RETURNING registration_id"""
         values = (
             datetime.now(),
@@ -208,7 +209,8 @@ def create_registration(form):
             _clean_value(form['mailing-address']),
             _clean_value(form['city']),
             form['state'][:2],
-            form['zip_code']
+            form['zip_code'],
+            "{}".format(datetime.now().year + (1 if renewal else 0))
         )
         cur.execute(operation, values)
         conn.commit()


### PR DESCRIPTION
## Overview
Addresses requested changes to entities on the registration form + adds 'Year' column to admin registration listing
…

## Related

- [WP-345](https://jira.tacc.utexas.edu/browse/WP-345)
- [WP-376](https://jira.tacc.utexas.edu/browse/WP-376)
<!--
- requires https://github.com/TACC/Core-CMS/pull/117
-->…

## Changes
**WP-345**
- For file type checkboxes, now at least one of three (Medical, Pharmacy, Dental) must be selected to continue to submit form
- Entity coverage estimate fields are now text fields which only accept ints or float (where needed) by regex patterns
- Slightly increased state box to accommodate larger state abbreviations + added JS listeners to swap between state abbr. and full name, depending on user interaction on drop down

**WP-376**
- Added 'Year' column to admin list registrations table
- Consolidated styling for registrations listings to one CSS file + changed renewal listing to grab styles from there instead
- Added `registration_year` to database query for creating new registrations
   - * For renewals, this year is indexed up by 1 to account for renewals for the next registration period
…

## Testing

1. Go to https://localhost:8000/register/request-to-submit
2. Test the form as normal, and confirm that:
    - On the State drop down, the default value should now be blank
    - On selecting a choice in the drop down, only the corresponding state abbreviation shows up in the box
    - Click away from the drop down and then click back and confirm that the option you selected displays both the 
       abbreviation and full state name, as before selection
    - On the entities, on any number of entity entries, that you cannot submit the form unless one of Medical, Pharmacy, and 
       Dental boxes is selected
    - On the Coverages Estimates section, that any input other than ints on the first two fields and two-decimal-point floats 
      (dollars + cents) on the final field raises an error (str input is allowed but not accepted on submit)
    - After successful submission, go to https://localhost:8000/administration/list-registration-requests and confirm the 
       record shows on the listing with the current year on the table, and all the info on View/Edit record is accurate
    - On the Edit Record action, confirm the same tests as above on the registration form
3. Go to https://localhost:8000/register/list-registration-requests and first confirm table looks the same as before, then initiate a registration renewal
4. On the renewal, fill in the necessary info and submit. On successful submission, navigate back to the administration registration listings and confirm the renewal record shows up with the year as 2024

## UI

…

<!--
## Notes

…
-->
