### PR TITLE
task/WP-345--entities-changes-uth---proposed-query-fix

### DIFF
--- a/apcd-cms/src/apps/submitter_renewals_listing/views.py
+++ b/apcd-cms/src/apps/submitter_renewals_listing/views.py
@@ -18,6 +18,12 @@ class SubmittersTable(RegistrationsTable):
             data = json.loads(submitter_code)
             submitter_code = data['submitter_code']
             registrations_content = get_registrations(submitter_code=submitter_code)
+            registrations_entities = []
+            registrations_contacts = []
+            for reg in registrations_content:
+                reg_id = int(reg[0])
+                registrations_entities.append(get_registration_entities(reg_id=reg_id))  # get entities and contacts for reg id's
+                registrations_contacts.append(get_registration_contacts(reg_id=reg_id))  # we have already verified are associated w/ given submitter code
             registrations_entities = get_registration_entities(submitter_code=submitter_code)
             registrations_contacts = get_registration_contacts(submitter_code=submitter_code)            
             context = self.get_context_data(registrations_content, registrations_entities, registrations_contacts, *args,**kwargs)

--- a/apcd-cms/src/apps/utils/apcd_database.py
+++ b/apcd-cms/src/apps/utils/apcd_database.py
@@ -309,8 +309,7 @@ def get_registration_entities(reg_id=None, submitter_code=None):
                 registration_entities.file_dc
                 FROM registration_entities 
                 {f"WHERE registration_id = {str(reg_id)}" if reg_id is not None else ''}
-                {f"LEFT JOIN submitters on registration_entities.registration_id = submitters.registration_id WHERE submitter_code = '{str(submitter_code)}'" if submitter_code is not None else ''}"""
-
+                {f"LEFT JOIN registration_submitters on registration_entities.registration_id = registration_submitters.registration_id LEFT JOIN submitters on registration_entities.registration_id = submitters.registration_id WHERE submitter_code = '{str(submitter_code)}'" if submitter_code is not None else ''}"""
         cur = conn.cursor()
         cur.execute(query)
         return cur.fetchall()
@@ -522,7 +521,7 @@ def get_registration_contacts(reg_id=None, submitter_code=None):
                 registration_contacts.contact_email
                 FROM registration_contacts 
                 {f"WHERE registration_id = {str(reg_id)}" if reg_id is not None else ''}
-                {f"LEFT JOIN submitters on registration_contacts.registration_id = submitters.registration_id WHERE submitter_code = '{str(submitter_code)}'" if submitter_code is not None else ''}"""
+                {f"LEFT JOIN registration_submitters on registration_contacts.registration_id = registration_submitters.registration_id LEFT JOIN submitters on registration_contacts.registration_id = submitters.registration_id WHERE submitter_code = '{str(submitter_code)}'" if submitter_code is not None else ''}"""
         cur = conn.cursor()
         cur.execute(query)
         return cur.fetchall()

--- a/apcd-cms/src/apps/utils/apcd_database.py
+++ b/apcd-cms/src/apps/utils/apcd_database.py
@@ -308,8 +308,7 @@ def get_registration_entities(reg_id=None, submitter_code=None):
                 registration_entities.file_pc,
                 registration_entities.file_dc
                 FROM registration_entities 
-                {f"WHERE registration_id = {str(reg_id)}" if reg_id is not None else ''}
-                {f"LEFT JOIN registration_submitters on registration_entities.registration_id = registration_submitters.registration_id LEFT JOIN submitters on registration_entities.registration_id = submitters.registration_id WHERE submitter_code = '{str(submitter_code)}'" if submitter_code is not None else ''}"""
+                {f"WHERE registration_id = {str(reg_id)}" if reg_id is not None else ''}"""
         cur = conn.cursor()
         cur.execute(query)
         return cur.fetchall()
@@ -520,8 +519,7 @@ def get_registration_contacts(reg_id=None, submitter_code=None):
                 registration_contacts.contact_phone,
                 registration_contacts.contact_email
                 FROM registration_contacts 
-                {f"WHERE registration_id = {str(reg_id)}" if reg_id is not None else ''}
-                {f"LEFT JOIN registration_submitters on registration_contacts.registration_id = registration_submitters.registration_id LEFT JOIN submitters on registration_contacts.registration_id = submitters.registration_id WHERE submitter_code = '{str(submitter_code)}'" if submitter_code is not None else ''}"""
+                {f"WHERE registration_id = {str(reg_id)}" if reg_id is not None else ''}"""
         cur = conn.cursor()
         cur.execute(query)
         return cur.fetchall()


### PR DESCRIPTION
## Overview

Adjust entities and contacts queries so view displays appropriate contacts and entities for a registration id when passed to the prepopulated form, listing view modal, and submitter listing table 


## Related

- [WP-345](https://jira.tacc.utexas.edu/browse/WP-345)

## Changes

- For each registration, pass in the reg_id to get the entities and contacts associated to that registration
- Then, pass in submitter_code to get all registrations for a submitter_admin submitter_code to display on the submitter admin page

## Testing
_Most of this review will involve looking at the code and database if you have access to ensure the pages and queries are pulling the correct things._

1. Branch off [task/WP-345--entities-changes-uth  #245](https://github.com/TACC/Core-CMS-Custom/tree/task/WP-345--entities-changes-uth) and checkout this branch 
**_If #245 has been merged into main already, skip this step_**
2. Go to [http://localhost:8000/register/list-registration-requests/](http://localhost:8000/register/list-registration-requests/)
3. Check that entities and contacts are showing up in the view modal
4. Check that the same entities and contacts show up when you click on the renew action in the drop down.
5. The form should be pre-populated for each entity except for the Coverage Estimates section

## UI


