### PR TITLE
bug/WP-327: Broken email regex

### DIFF
--- a/apcd-cms/src/apps/exception/templates/exception_submission_form/exception_other_form.html
+++ b/apcd-cms/src/apps/exception/templates/exception_submission_form/exception_other_form.html
@@ -83,7 +83,7 @@
           <div class="field-errors" style="display: none"></div>
 
           <input type="email" name="requestor-email" required class="emailinput" autocomplete="email"
-            id="requestor-email" pattern="^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[a-z]{2,4}$"/>
+            id="requestor-email" pattern="^[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[a-z]{2,4}$"/>
         </div>
       </div>
       <div class="field-wrapper textinput required"><label>

--- a/apcd-cms/src/apps/exception/templates/exception_submission_form/exception_threshold_form.html
+++ b/apcd-cms/src/apps/exception/templates/exception_submission_form/exception_threshold_form.html
@@ -162,7 +162,7 @@
                 <div class="field-errors" style="display: none"></div>
 
                 <input type="email" name="requestor-email" required class="emailinput" autocomplete="email"
-                  id="requestor-email" pattern="^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[a-z]{2,4}$" />
+                  id="requestor-email" pattern="^[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[a-z]{2,4}$" />
               </div>
             </div>
             <div class="field-wrapper textinput required"><label>

--- a/apcd-cms/src/apps/extension/templates/extension_submission_form/extension_submission_form.html
+++ b/apcd-cms/src/apps/extension/templates/extension_submission_form/extension_submission_form.html
@@ -159,7 +159,7 @@
                 <div class="field-errors" style="display: none"></div>
 
                 <input type="email" name="requestor-email" required class="emailinput" autocomplete="email"
-                  id="requestor-email" pattern="^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[a-z]{2,4}$" />
+                  id="requestor-email" pattern="^[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[a-z]{2,4}$" />
               </div>
             </div>
 

--- a/apcd-cms/src/apps/view_users/templates/view_user_edit_modal.html
+++ b/apcd-cms/src/apps/view_users/templates/view_user_edit_modal.html
@@ -27,8 +27,8 @@
                     </label>
         
                       <div class="field-errors" style="display: none"></div>
-                        <textarea name="user_name" cols="40" rows="1" class="textinput" type="text" id="name"
-                          minlength="2" maxlength="200">{{r.user_name}}</textarea>
+                        <input name="user_name" class="textinput" type="text" id="name"
+                          value='{{r.user_name}}' required></textarea>
 
                       </div>
                       <div class="field-wrapper text required">
@@ -37,8 +37,9 @@
                         </label>
             
                           <div class="field-errors" style="display: none"></div>
-                            <textarea name="user_email" cols="40" rows="1" class="textinput" type="text" id="email"
-                              minlength="2" maxlength="200">{{r.user_email}}</textarea>
+                            <input name="user_email" class="textinput" type="email" id="email"
+                              pattern="^[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[a-z]{2,4}$" value='{{r.user_email}}' required
+                              >
 
                           </div>
                 


### PR DESCRIPTION
## Overview
Follow-on task to fix broken regex on multiple forms' email validation
…

## Related

- [WP-327](https://jira.tacc.utexas.edu/browse/WP-327)
- [WP-330](https://jira.tacc.utexas.edu/browse/WP-330)
<!--
- requires https://github.com/TACC/Core-CMS/pull/117
-->…

## Changes
- On exception threshold + other as well as extension forms, escaped the `-` within the regex character fields on the email inputs to resolve broken regex pattern
- On view user edit modal, converted username + email fields to text input to allow regex validation, and included regex pattern used for email on other forms for this field
…

## Testing

1. Go to http://localhost:8000/submissions/extension-request/
2. Fill out form, and test email field to ensure pattern of "[some input]@[someinput].[some input]" is enforced
3. Check dev console and confirm no errors about regex characters is showing
4. Repeat steps 2 + 3 for the following forms
    - http://localhost:8000/submissions/other-exception/
    - http://localhost:8000/submissions/threshold-exception/
    - http://localhost:8000/administration/view-users/ (click 'Edit Record' on any record on listing, email field in modal)

## UI

…

<!--
## Notes

…
-->
