### PR TITLE
hotfix: fix 500 error of "taggit_autosuggest-list"

### DIFF
--- a/ecep_cms/src/taccsite_cms/urls_custom.py
+++ b/ecep_cms/src/taccsite_cms/urls_custom.py
@@ -1,6 +1,6 @@
-from django.conf.urls import include, url
+from django.urls import include, re_path
 
 custom_urls = [
     # Support `taggit_autosuggest` (from `djangocms-blog`)
-    url(r'^taggit_autosuggest/', include('taggit_autosuggest.urls')),
+    re_path(r'^taggit_autosuggest/', include('taggit_autosuggest.urls')),
 ]


### PR DESCRIPTION
## Overview / Changes

[Use `re_path`, not `url`, since Django 4.](https://docs.djangoproject.com/en/3.2/ref/urls/#url)

<details><summary>the error that this fixes</summary>

```
django.urls.exceptions.NoReverseMatch: Reverse for 'taggit_autosuggest-list' not found. 'taggit_autosuggest-list' is not a valid view function or pattern name.
```

</details>

## Related

- [RT #27486](https://tickets.tacc.utexas.edu/Ticket/Display.html?id=27486)

## Testing

Try to edit a blog article on ECEP site with this fix deployed.

## UI

| before | after |
| - | - |
| <img width="1006" alt="before" src="https://github.com/TACC/Core-CMS-Custom/assets/62723358/a3409b52-cfab-43e0-8e39-652a23b51d4e"> | <img width="1006" alt="after" src="https://github.com/TACC/Core-CMS-Custom/assets/62723358/696228d5-75de-4f5c-bf19-ff068aad58a1"> |
