### PR TITLE
Task/WP-132 upgrade django version in A2CPS and MISE

### DIFF
--- a/a2cps_cms/Dockerfile
+++ b/a2cps_cms/Dockerfile
@@ -1,5 +1,5 @@
-# TACC/Core-CMS#v3.12.0-beta.2
-FROM taccwma/core-cms:55db2ed
+# TACC/Core-CMS#v4.5.0
+FROM taccwma/core-cms:5473db7
 
 WORKDIR /code
 

--- a/matcssi_cms/Dockerfile
+++ b/matcssi_cms/Dockerfile
@@ -1,5 +1,5 @@
-# TACC/Core-CMS#v3.12.0-beta.3
-FROM taccwma/core-cms:aba079b
+# TACC/Core-CMS#v4.5.0
+FROM taccwma/core-cms:5473db7
 
 WORKDIR /code
 


### PR DESCRIPTION
## Overview
Moving portal to latest version of CMS to upgrade django. The current version of django in A2CPS and MISE is 3.x.

## Related
[WP-132](https://jira.tacc.utexas.edu/browse/WP-132) requires https://github.com/TACC/Core-CMS/releases/tag/v4.5.0

## Changes
Upgrade to 4.5.0

## Testing

Will do testing once a version is deployed to pprd sites.

## UI

