### PR TITLE
docs(upgrade): move opt. changes to future version

### DIFF
--- a/docs/upgrade-project.md
+++ b/docs/upgrade-project.md
@@ -4,8 +4,10 @@
 
 - [Core-CMS v3.11 to v3.12](#core-cms-v311-to-v312)
     1. [Rename Project](#rename-project)
-    2. [Update Settings](#update-settings)
-    3. [Move Images](#move-images)
+
+- [Core-CMS v4 Future Changes](#core-cms-v4-future-changes)
+    1. [Update Settings](#update-settings)
+    2. [Move Images](#move-images)
 
 ## [Core CMS] v3.11 to v3.12
 
@@ -52,6 +54,9 @@ Verify project name is compatible with Django 3.2.
     > **Note**
     > [Core CMS] already defines the `static` directory for each project.
 
+
+## [Core-CMS] v4 Future Changes
+
 ### Update Settings
 
 Remove unnecessary settings.
@@ -79,6 +84,7 @@ Verify project name is compatible with Django 3.2.
 
 2. Rename **all** references to the previous image paths e.g.
     - in `settings_custom.py`
+
 
 <!-- Link Aliases -->
 


### PR DESCRIPTION
## Overview

In upgrade doc, move optional changes to future CMS version upgrade.

<details><summary>Background</summary>

1. CMS's are being upgraded to v4.
2. The new upgrade document instructs two non-required changes.
3. I should not try to "force" these "upgrades".

</details>

## Related

- fixes #177

## Changes

- **moved** content within a document to a new section

## Testing

Skipped.

## UI

N/A