### PR TITLE
Bug/WP-484: Remove text from threshold form

### DIFF
--- a/apcd-cms/src/apps/exception/templates/exception_submission_form/exception_threshold_form.html
+++ b/apcd-cms/src/apps/exception/templates/exception_submission_form/exception_threshold_form.html
@@ -165,10 +165,6 @@
                   id="requestor-email" pattern="^[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[a-z]{2,4}$" />
               </div>
             </div>
-            <div class="field-wrapper textinput required"><label>
-                I request an exception on behalf of:
-              </label></div>
-
 
             <div class="field-wrapper checkbox required">
               <div class="field-errors" style="display: none"></div>


### PR DESCRIPTION
## Overview
Exception request form - remove incomplete statement.
There is extra text "I accept on the behalf of.." which is not relevant for exception threshold form.
…

## Related
[WP-484](https://tacc-main.atlassian.net/browse/WP-484)

## Changes

Delete text from form.

## Testing

1. Threshold exception form
![Screenshot 2024-02-07 at 6 10 28 PM](https://github.com/TACC/Core-CMS-Custom/assets/2568355/b729a295-e333-48af-ae52-09e5cbf40cfa)


2. Other exception form (unchanged)
![Screenshot 2024-02-07 at 6 10 56 PM](https://github.com/TACC/Core-CMS-Custom/assets/2568355/d69a4f79-32c2-4df0-989c-70a25934a978)

## UI
## Notes
