### PR TITLE
Bug/WP-483 - APCD fixes for extensions

### DIFF
--- a/apcd-cms/src/apps/extension/templates/extension_submission_form/extension_form_success.html
+++ b/apcd-cms/src/apps/extension/templates/extension_submission_form/extension_form_success.html
@@ -8,6 +8,6 @@
     <p>
         Your extension submission was successful.
     </p>
-    <a class="c-button c-button--primary" href="/submissions/extension-request/">Go Back to Extensions</a>
+    <a class="c-button c-button--primary" href="/workbench/dashboard">Go to Dashboard</a>
 </div>
 {% endblock %}

--- a/apcd-cms/src/apps/utils/apcd_database.py
+++ b/apcd-cms/src/apps/utils/apcd_database.py
@@ -1278,7 +1278,7 @@ def get_applicable_data_periods(submitter_id):
             sslmode='require',
         )
         cur = conn.cursor()
-        query = """ SELECT data_period_start FROM submitter_calendar WHERE submitter_id = (%s) AND cancelled = 'FALSE' AND granted_reprieve='FALSE' AND submission_id is Null """
+        query = """ SELECT distinct data_period_start FROM submitter_calendar WHERE submitter_id = (%s) AND cancelled = 'FALSE' AND granted_reprieve='FALSE' AND submission_id is Null """
         cur.execute(query, (submitter_id,))
         return cur.fetchall()
 


### PR DESCRIPTION
## Overview

Submitter calendar can accept duplicates by db design, but non functional in use cases. Business logic / queries need to adjust to that.
The key fields in submitter_calendar are submitter_id, data_period_start. 
Submitter_id is distinct for each submitter (org, payor_code). There is no other information in submitter_calendar to derive uniqueness. With the current db design, it is safe to assume the data_period_start should be unique per submitter_id.
If any of the business logic needs to change, that will require db design change.

## Related
[WP-483](https://tacc-main.atlassian.net/browse/WP-483)

## Changes

* For time period use distinct
* Change button text to go to dashboard

## Testing

1. Uploaded duplicate rows in test DB:

`select calendar_item_id, submitter_id, data_period_start, expected_submission_date from submitter_calendar;`

![Screenshot 2024-02-08 at 5 35 22 PM](https://github.com/TACC/Core-CMS-Custom/assets/2568355/481c3e2a-d29f-44ca-b783-181a081c31e0)


Screenshot with no duplicates in UI.   
![Screenshot 2024-02-08 at 5 30 08 PM](https://github.com/TACC/Core-CMS-Custom/assets/2568355/bcef1890-6432-44ae-977a-75c7301773ce)


2. Tested the exception and successful one shows 'go to dashboard'

![Screenshot 2024-02-08 at 5 30 48 PM](https://github.com/TACC/Core-CMS-Custom/assets/2568355/09b8859b-f4f5-4a3a-a378-8b6b62df65f8)

Also, navigation took to the dashboard

## UI

## Notes
