### PR TITLE
docs(.github): PR template should ref. tacc-main not jira

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@
 ## Related
 
 <!--
-- [FP-123](https://jira.tacc.utexas.edu/browse/FP-123)
+- [WP-123](https://tacc-main.atlassian.net/browse/WP-123)
 - requires https://github.com/TACC/Core-CMS/pull/117
 -->…
 


### PR DESCRIPTION
## Overview

PR template is suggesting old (thus broken) links be created. This fixes those URLs.

## Related

- noticed in #270