### PR TITLE
bug/WP-326: Threshold exception - validator doesn't match helper text on requested threshold

### DIFF
--- a/apcd-cms/src/apps/exception/templates/exception_submission_form/exception_threshold_form.html
+++ b/apcd-cms/src/apps/exception/templates/exception_submission_form/exception_threshold_form.html
@@ -380,6 +380,7 @@
           // exception block number
           function getHelpText(fieldSelection, file_type, exceptions) {
             helpText = document.getElementById(`help-text-threshold-requested_${exceptions}`);
+            thresholdInput = document.getElementById(`threshold-requested_${exceptions}`)
             $.ajax({
                 url: "{% url 'exception:get-cdls' %}",
                 type: 'GET',
@@ -388,9 +389,10 @@
                 },
                 success: function(response) {
                   let cdls = response;
-                  //To change help text for requested threshold percentage
+                  //To change input's max value & help text for requested threshold percentage
                     for (let i = 0; i < cdls.length; i++)
                       if (fieldSelection == cdls[i].field_list_code) {
+                          thresholdInput.max = cdls[i].threshold_value
                           helpText.innerHTML = "";
                           helpText.innerHTML = `Must be less than the ${cdls[i].threshold_value}% required.`
                       };


### PR DESCRIPTION
## Overview

…

## Related

- [WP-326](https://tacc-main.atlassian.net/browse/WP-326)
<!--
- requires https://github.com/TACC/Core-CMS/pull/117
-->…

## Changes
- To helper text script, added lines to point to and then update `max` prop on requested threshold input for each threshold exception block
…

## Testing

1. Go to https://localhost:8000/submissions/threshold-exception/
2. On the 'Requested Threshold Reduction' portion, choose options for File Type, Field Code, and Expiration Date
3. On the 'Requested Threshold Percentage' field, ensure you cannot submit the form with a value greater than that shown in the helper text below said field
4. Repeat for at least one other Threshold Exception block (via 'add Another Threshold Exception')
5. Complete form and submit, then go to https://localhost:8000/administration/list-exceptions/ and confirm your new exceptions show up and have the correct info from your submission

## UI

…

<!--
## Notes

…
-->
