### PR TITLE
bug/WP-495: Proxy date for 'None' posted_date on registrations using wrong data type

### DIFF
--- a/apcd-cms/src/apps/admin_regis_table/views.py
+++ b/apcd-cms/src/apps/admin_regis_table/views.py
@@ -7,7 +7,7 @@ from apps.utils.utils import table_filter
 from apps.utils.registrations_data_formatting import _set_registration
 from apps.components.paginator.paginator import paginator
 import logging
-from dateutil import parser
+from datetime import date as datetimeDate
 
 logger = logging.getLogger(__name__)
 
@@ -95,7 +95,7 @@ class RegistrationsTable(TemplateView):
 
         def getDate(row):
             date = row[1]
-            return date if date is not None else parser.parse('1-1-0001')  # put 'None' date entries all together at end of listing
+            return date if date is not None else datetimeDate(1,1,1)  # put 'None' date entries all together at end of listing w/ date 1-1-0001
 
         registrations_content = sorted(registrations_content, key=lambda row:getDate(row), reverse=True)  # sort registrations by newest to oldest
 


### PR DESCRIPTION
## Overview

…

## Related

- [WP-495](https://tacc-main.atlassian.net/browse/WP-495)
<!--
- requires https://github.com/TACC/Core-CMS/pull/117
-->…

## Changes
- Now using `datetime.date` method to sub in date 01-01-0001 for None date entries instead of dateutil's `parser.parse`
…

## Testing

1. Ensure your local instance for APCD is pointing to the 'apcd-psql-test' db in your local settings
2. Go to https://localhost:8000/administration/list-registration-requests
3. Confirm that the page loads successfully and that there is a record with name 'Tracy Test Busn' as the last record on the last page of the listing (this is the record with 'posted_date' as NULL)

## UI

…

<!--
## Notes

…
-->
