### PR TITLE
WP-494: handle null entity_names when using exception and extensions in admin view

### DIFF
--- a/apcd-cms/src/apps/admin_exception/views.py
+++ b/apcd-cms/src/apps/admin_exception/views.py
@@ -116,6 +116,8 @@ class AdminExceptionsTable(TemplateView):
                 context['org_options'].append(entity_name)
                 # to make sure All is first in the dropdown filter options after sorting alphabetically
                 context['org_options'] = sorted(context['org_options'], key=lambda x: (x != 'All', x))
+                # Remove empty strings
+                context['org_options'] = [option for option in context['org_options'] if option != '']
             if status not in context['status_options']:
                 if status != None:
                     context['status_options'].append(status)

--- a/apcd-cms/src/apps/admin_extension/views.py
+++ b/apcd-cms/src/apps/admin_extension/views.py
@@ -109,6 +109,8 @@ class AdminExtensionsTable(TemplateView):
             if entity_name not in context['org_options']:
                 context['org_options'].append(entity_name)
                 context['org_options'] = sorted(context['org_options'], key=lambda x: (x != 'All', x))
+                # Remove empty strings
+                context['org_options'] = [option for option in context['org_options'] if option != '']
             if status not in context['status_options']:
                 context['status_options'].append(status)
                 context['status_options'] = sorted(context['status_options'], key=lambda x: (x != 'All', x))

--- a/apcd-cms/src/apps/utils/apcd_database.py
+++ b/apcd-cms/src/apps/utils/apcd_database.py
@@ -1349,7 +1349,7 @@ def get_all_extensions():
                 extensions.requestor_email,
                 extensions.explanation_justification,
                 extensions.notes,
-                COALESCE(submitters.entity_name, '') as entity_name
+                COALESCE(NULLIF(submitters.entity_name, ''), '') as entity_name
             FROM extensions
             JOIN submitters
                 ON extensions.submitter_id = submitters.submitter_id
@@ -1400,7 +1400,7 @@ def get_all_exceptions():
                 exceptions.approved_expiration_date,
                 exceptions.status,
                 exceptions.notes,
-                COALESCE(submitters.entity_name, '') as entity_name,
+                COALESCE(NULLIF(submitters.entity_name, ''), '') as entity_name,
                 standard_codes.item_value
             FROM exceptions
             JOIN submitters

--- a/apcd-cms/src/apps/utils/apcd_database.py
+++ b/apcd-cms/src/apps/utils/apcd_database.py
@@ -1349,7 +1349,7 @@ def get_all_extensions():
                 extensions.requestor_email,
                 extensions.explanation_justification,
                 extensions.notes,
-                submitters.entity_name
+                COALESCE(submitters.entity_name, '') as entity_name
             FROM extensions
             JOIN submitters
                 ON extensions.submitter_id = submitters.submitter_id
@@ -1400,7 +1400,7 @@ def get_all_exceptions():
                 exceptions.approved_expiration_date,
                 exceptions.status,
                 exceptions.notes,
-                submitters.entity_name,
+                COALESCE(submitters.entity_name, '') as entity_name,
                 standard_codes.item_value
             FROM exceptions
             JOIN submitters


### PR DESCRIPTION

## Overview
There is bad data in db with empty entity name in submitters table. This is leading to 500 errors in UI.

## Related

- [WP-494](https://tacc-main.atlassian.net/browse/WP-494)

## Changes
* Fix DB queries so any business logic using the data is not broken - check for both null and empty
* Do not allow empty strings in dropdown.

## Testing

* Entity name empty strings show up in UI table listing
* Drop down listing filter out empty entity name.

1. Admin exception listing - the listing happens with empty entity_name
![Screenshot 2024-02-15 at 12 15 25 PM](https://github.com/TACC/Core-CMS-Custom/assets/2568355/6b7834ec-ad58-40b9-9af8-dc58281c5386)

2. Admin extension listing - the listing happens with empty entity_name
![Screenshot 2024-02-15 at 12 15 11 PM](https://github.com/TACC/Core-CMS-Custom/assets/2568355/9cbeb1c3-6d60-429e-87fb-e57bd7bba67d)

## UI
