### PR TITLE
WP-522: Fix incorrect path for STATICFILE_DIRS

### DIFF
--- a/apcd-cms/src/taccsite_cms/custom_app_settings.py
+++ b/apcd-cms/src/taccsite_cms/custom_app_settings.py
@@ -1,4 +1,4 @@
 CUSTOM_APPS = ['apps.admin_regis_table', 'apps.apcd_login', 'apps.registrations', 'apps.submissions', 'apps.exception', 'apps.admin_submissions', 'apps.admin_extension', 'apps.admin_exception', 'apps.extension', 'apps.submitter_renewals_listing', 'apps.view_users', 'apps.components.paginator', 'apps.utils']
 CUSTOM_MIDDLEWARE = []
-STATICFILES_DIRS = ('taccsite_custom/apcd-cms', 'apps/admin_regis_table', 'apps/submissions', 'apps/exception', 'apps/extension', 'apps/submitter_renewals_listing', 'apps/view_users', 'apps/components/paginator', 'apps/utils')
+STATICFILES_DIRS = ('taccsite_custom/apcd_cms', 'apps/admin_regis_table', 'apps/submissions', 'apps/exception', 'apps/extension', 'apps/submitter_renewals_listing', 'apps/view_users', 'apps/components/paginator', 'apps/utils')
 


### PR DESCRIPTION
## Overview
The static file specification in settings is wrong leading to [build errors](https://jenkins01.tacc.utexas.edu/view/WMA%20CEP/job/Core_Portal_Deploy/3859/consoleFull) like this:
```
?: (staticfiles.W004) The directory 'taccsite_custom/apcd-cms' in the STATICFILES_DIRS setting does not exist.
```
## Related

- [WP-522](https://tacc-main.atlassian.net/browse/WP-522)

## Changes

Fix the path specified in config

## Testing

1. Run build

## UI

…

<!--
## Notes

…
-->
