### PR TITLE
task/WP-452: Upgrade Netsage CMS to Django 4.2+

### DIFF
--- a/netsage_cms/Dockerfile
+++ b/netsage_cms/Dockerfile
@@ -1,5 +1,5 @@
 # v3.12.0-beta.3
-FROM taccwma/core-cms:aba079b
+FROM taccwma/core-cms:v4.8.0
 
 WORKDIR /code
 

--- a/netsage_cms/Dockerfile
+++ b/netsage_cms/Dockerfile
@@ -1,4 +1,3 @@
-# v3.12.0-beta.3
 FROM taccwma/core-cms:v4.8.0
 
 WORKDIR /code


### PR DESCRIPTION
## Overview

…

## Related

<!--
- [WP-452](https://tacc-main.atlassian.net/browse/WP-452)
- [WP-132](https://tacc-main.atlassian.net/browse/WP-132)
- requires https://github.com/TACC/Core-CMS/pull/117
-->…

## Changes
- Updated core-cms image to v4.8.0
…

## Testing

1. Deployed to [NetSage PPRD](https://pprd.netsage.tacc.utexas.edu/)

## UI

…

<!--
## Notes

…
-->
