### PR TITLE
task/WP-443 Convert Admin Submissions to React

### DIFF
--- a/apcd-cms/docker-compose.dev.yml
+++ b/apcd-cms/docker-compose.dev.yml
@@ -15,7 +15,7 @@ services:
       - ./src/taccsite_cms/settings_custom.py:/code/taccsite_cms/settings_custom.py
       - ./src/taccsite_cms/settings_local.py:/code/taccsite_cms/settings_local.py
       - ./src/taccsite_cms/secrets.py:/code/taccsite_cms/secrets.py
-      - ./src/client/dist/apcd-components.es.js:/code/taccsite_custom/apcd_cms/static/apcd-components.es.js
+      - ${PWD}/src/client/dist/:/code/taccsite_custom/apcd_cms/static/
     networks:
       - core_cms_net
 

--- a/apcd-cms/src/apps/admin_submissions/templates/list_admin_submissions.html
+++ b/apcd-cms/src/apps/admin_submissions/templates/list_admin_submissions.html
@@ -10,6 +10,13 @@
 <link rel="stylesheet" href="{% static 'admin_submissions/css/admin_table.css' %}">
 <link rel="stylesheet" href="{% static 'admin_regis_table/css/table.css' %}">
 
+{% block extra_js %}
+  <script type="module">
+    import { setupAdminSubmissions } from "{% static 'apcd-components.es.js' %}";
+    setupAdminSubmissions();
+  </script>
+{% endblock %}
+
 <div class="container">
   {% include "nav_cms_breadcrumbs.html" %}
 
@@ -37,34 +44,8 @@
       {% endif %}
     </div>
   </div>
-
-  <table id="submissionTable" class="submission-table">
-      <thead>
-          <tr>
-              {% for k in header %}
-              <th>{{k}}</th>
-              {% endfor %}
-          </tr>
-      </thead>
-      <tbody>
-          {% for r in page %}
-              <tr>
-                <td>{{r.received_timestamp}}</td>
-                <td>{{r.entity_name}}</td>
-                <td colspan="2">{{r.file_name}}</td>
-                <td>{{r.outcome}}</td>
-                <td>{{r.status}}</td>
-                <td>{{r.updated_at}}</td>
-                  <td>
-                    {% include "view_admin_submission_logs_modal.html" %}
-                    <a href='' data-toggle="modal" data-target="#viewAdminSubmissionLogsModal_{{r.submission_id}}" data-backdrop="static">View Logs</a>
-                  </td>
-              </tr>
-          {% endfor %}
-      </tbody>
-  </table>
-
-    {% include 'paginator.html' %}
+  <div id="react-root"></div>
+  {% include 'paginator.html' %}
 </div>
 <script>
   function filterTableByStatus() {

--- a/apcd-cms/src/apps/admin_submissions/templates/list_admin_submissions.html
+++ b/apcd-cms/src/apps/admin_submissions/templates/list_admin_submissions.html
@@ -24,67 +24,7 @@
   <hr />
   <p style="margin-bottom: 30px">All completed submissions by organizations</p>
   <hr />
-  <div class="filter-container">
-    <div class="filter-content">
-      <span><b>Filter by Status: </b></span>
-      <select id="statusFilter" class="status-filter" onchange="filterTableByStatus()">
-        {% for option in filter_options %}
-          <option class="dropdown-text" {% if option == selected_status %}selected{% endif %}>{{ option }}</option>
-        {% endfor %}
-      </select>
-      <span><b>Sort by: </b></span>
-      <select id="dateSort" class="status-filter" onchange="sortByDate()">
-        <option class="dropdown-text" {% if not selected_sort %}selected{% else %}hidden{% endif %} disabled> </option>
-        {% for option, display_text in sort_options.items %}
-          <option class="dropdown-text" value={{option}} {% if option == selected_sort %}selected{% endif %}>{{ display_text }}</option>
-        {% endfor %}
-      </select>
-      {% if selected_status or selected_sort %}
-        <button onclick="clearSelections()">Clear Options</button>
-      {% endif %}
-    </div>
-  </div>
   <div id="react-root"></div>
   {% include 'paginator.html' %}
 </div>
-<script>
-  function filterTableByStatus() {
-      var filterDropdown, filterValue, url_params, url, xhr;
-      filterDropdown = document.getElementById("statusFilter");
-      filterValue =  filterDropdown.value;
-      url_params = `?status=${filterValue}`;
-      {% if selected_sort %}
-          url_params = `?sort={{selected_sort}}&status=${filterValue}`;
-      {% endif %}
-      url = `/administration/list-submissions/${url_params}`;
-      xhr = new XMLHttpRequest();
-      xhr.open('GET', url);
-      xhr.send();
-      window.location.href = url;
-      window.location.load();
-  }
-  function sortByDate() {
-      var sortDropdown, sortValue, url_params, url, xhr;
-      sortDropdown = document.getElementById('dateSort');
-      sortValue =  sortDropdown.value;
-      url_params = `?sort=${sortValue}`;
-      {% if selected_status %}
-          url_params = `?sort=${sortValue}&status={{selected_status}}`;
-      {% endif %}
-      url = `/administration/list-submissions/${url_params}`;
-      xhr = new XMLHttpRequest();
-      xhr.open('GET', url);
-      xhr.send();
-      window.location.href = url;
-      window.location.load();
-  }
-  function clearSelections() {
-      var xhr;
-      xhr = new XMLHttpRequest();
-      xhr.open('GET', '/administration/list-submissions/')
-      xhr.send()
-      window.location.href = '/administration/list-submissions/';
-      window.location.load();
-  }
-</script>  
 {% endblock %}

--- a/apcd-cms/src/apps/admin_submissions/urls.py
+++ b/apcd-cms/src/apps/admin_submissions/urls.py
@@ -1,10 +1,12 @@
 from django.urls import path
+from django.views.generic import TemplateView
 from apps.admin_submissions.views import AdminSubmissionsTable
 
 app_name = 'administration'
 urlpatterns = [
-    path('list-submissions/', AdminSubmissionsTable.as_view(), name="admin_submissions"),
-    path(r'list-submissions/?status=(?P<status>)/', AdminSubmissionsTable.as_view(), name="admin_submissions"),
-    path(r'list-submissions/?sort=(?P<sort>)/', AdminSubmissionsTable.as_view(), name="admin_submissions"),
-    path(r'list-submissions/?sort=(?P<sort>)&filter=(?P<status>)/', AdminSubmissionsTable.as_view(), name="admin_submissions"),
+    path('list-submissions/', TemplateView.as_view(template_name='list_admin_submissions.html'), name="admin_submissions"),
+    path(r'list-submissions/api/', AdminSubmissionsTable.as_view(), name="admin_submissions_api"),
+    path(r'list-submissions/api/?status=(?P<status>)/', AdminSubmissionsTable.as_view(), name="admin_submissions_api"),
+    path(r'list-submissions/api/?sort=(?P<sort>)/', AdminSubmissionsTable.as_view(), name="admin_submissions_api"),
+    path(r'list-submissions/api/?sort=(?P<sort>)&filter=(?P<status>)/', AdminSubmissionsTable.as_view(), name="admin_submissions_api"),
 ]

--- a/apcd-cms/src/apps/admin_submissions/views.py
+++ b/apcd-cms/src/apps/admin_submissions/views.py
@@ -80,12 +80,14 @@ class AdminSubmissionsTable(TemplateView):
         page_info = paginator(self.request, submission_content, limit)
 
         context['page'] = [{
+            'submission_id': obj['submission_id'],
             'status': obj['status'],
             'entity_name': obj['entity_name'],
             'file_name': obj['file_name'],
             'outcome': obj['outcome'],
             'received_timestamp': obj['received_timestamp'],
-            'updated_at': obj['updated_at']
+            'updated_at': obj['updated_at'],
+            'view_modal_content': obj['view_modal_content'],
         } for obj in page_info['page']]
 
         context['page_num'] = page_num

--- a/apcd-cms/src/apps/admin_submissions/views.py
+++ b/apcd-cms/src/apps/admin_submissions/views.py
@@ -46,7 +46,7 @@ class AdminSubmissionsTable(TemplateView):
         except:
             page_num = 1
 
-        context['selected_status'] = None
+        context['selected_status'] = 'All'
         if status_filter is not None and status_filter != 'All':
             context['selected_status'] = status_filter
             queryStr += f'&status={status_filter}'
@@ -69,8 +69,12 @@ class AdminSubmissionsTable(TemplateView):
             } for t in (s['view_modal_content'] or [])]
 
         context['header'] = ['Received', 'Entity Organization', 'File Name', 'Outcome', 'Status', 'Last Updated', 'Actions']
-        context['filter_options'] = ['All', 'In Process', 'Complete']
-        context['sort_options'] = {'newDate': 'Newest Received', 'oldDate': 'Oldest Received'}
+        context['status_options'] = ['All', 'In Process', 'Complete']
+        context['sort_options'] = [
+            {'name': '', 'value': ''},
+            {'name': 'Newest Received', 'value': 'newDate'},
+            {'name': 'Oldest Received', 'value': 'oldDate'}
+        ]
 
         context['query_str'] = queryStr
         page_info = paginator(self.request, submission_content, limit)
@@ -83,6 +87,9 @@ class AdminSubmissionsTable(TemplateView):
             'received_timestamp': obj['received_timestamp'],
             'updated_at': obj['updated_at']
         } for obj in page_info['page']]
+
+        context['page_num'] = page_num
+        context['total_pages'] = page_info['page'].paginator.num_pages
 
         context['pagination_url_namespaces'] = 'admin_submission:admin_submissions'
         return context

--- a/apcd-cms/src/apps/utils/apcd_database.py
+++ b/apcd-cms/src/apps/utils/apcd_database.py
@@ -924,18 +924,23 @@ def get_all_submissions_and_logs():
                 'received_timestamp', submissions.received_timestamp,
                 'updated_at', submissions.updated_at,
                 'view_modal_content', (
-                    SELECT COALESCE(json_agg(json_build_object(
-                        'log_id', submission_logs.log_id,
-                        'submission_id', submission_logs.submission_id,
-                        'file_type', submission_logs.file_type,
-                        'validation_suite', submission_logs.validation_suite,
-                        'outcome', submission_logs.outcome,
-                        'file_type_name', (
-                            SELECT standard_codes.item_value FROM standard_codes
-                            WHERE UPPER(submission_logs.file_type) = UPPER(standard_codes.item_code) AND list_name='submission_file_type'
-                            LIMIT 1
-                        )
-                    )), '[]'::json)
+                    SELECT CASE
+                            WHEN COUNT(submission_logs.log_id) = 0 THEN '[]'::json
+                            ELSE json_agg(json_build_object(
+                                'log_id', submission_logs.log_id,
+                                'submission_id', submission_logs.submission_id,
+                                'file_type', submission_logs.file_type,
+                                'validation_suite', submission_logs.validation_suite,
+                                'outcome', submission_logs.outcome,
+                                'file_type_name', (
+                                    SELECT standard_codes.item_value 
+                                    FROM standard_codes
+                                    WHERE UPPER(submission_logs.file_type) = UPPER(standard_codes.item_code) 
+                                    AND list_name='submission_file_type'
+                                    LIMIT 1
+                                )
+                            ))
+                        END
                 )
             )
             FROM submissions

--- a/apcd-cms/src/client/package-lock.json
+++ b/apcd-cms/src/client/package-lock.json
@@ -15,6 +15,7 @@
         "react-dom": "^17.0.2",
         "react-query": "^3.34.15",
         "react-table": "^7.8.0",
+        "reactstrap": "^9.2.2",
         "typescript": "^4.4.3"
       },
       "devDependencies": {
@@ -3696,6 +3697,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
     "node_modules/@redux-saga/core": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@redux-saga/core/-/core-1.3.0.tgz",
@@ -5627,6 +5637,11 @@
       "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
       "dev": true
     },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
+    },
     "node_modules/cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -6029,8 +6044,7 @@
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -6276,6 +6290,15 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
     },
     "node_modules/dom-serializer": {
       "version": "1.4.1",
@@ -13932,10 +13955,29 @@
         "react": "17.0.2"
       }
     },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/react-popper": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
+      "integrity": "sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==",
+      "dependencies": {
+        "react-fast-compare": "^3.0.1",
+        "warning": "^4.0.2"
+      },
+      "peerDependencies": {
+        "@popperjs/core": "^2.0.0",
+        "react": "^16.8.0 || ^17 || ^18",
+        "react-dom": "^16.8.0 || ^17 || ^18"
+      }
     },
     "node_modules/react-query": {
       "version": "3.39.3",
@@ -14016,6 +14058,38 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/reactstrap": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/reactstrap/-/reactstrap-9.2.2.tgz",
+      "integrity": "sha512-4KroiGOdqZLAnMGzHjpErW3G7bLB+QbKzzMLIDXydPIV0y74lpdL7WtXHkLWAGInd97WCPNx4+R0NQDPyzIfhw==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@popperjs/core": "^2.6.0",
+        "classnames": "^2.2.3",
+        "prop-types": "^15.5.8",
+        "react-popper": "^2.2.4",
+        "react-transition-group": "^4.4.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
     },
     "node_modules/read-cache": {
       "version": "1.0.0",
@@ -15778,6 +15852,14 @@
       "dev": true,
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/weak-key": {

--- a/apcd-cms/src/client/package-lock.json
+++ b/apcd-cms/src/client/package-lock.json
@@ -48,7 +48,6 @@
         "react-test-renderer": "^17.0.2",
         "redux-mock-store": "^1.5.3",
         "redux-saga-test-plan": "^4.0.0-rc.3",
-        "rollup-plugin-visualizer": "^5.12.0",
         "sass": "^1.42.1",
         "stylelint": "^14.4.0",
         "stylelint-config-recommended": "^7.0.0",
@@ -6180,15 +6179,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/define-lazy-prop": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/define-properties": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
@@ -8588,21 +8578,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-docker": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-      "dev": true,
-      "bin": {
-        "is-docker": "cli.js"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -8870,18 +8845,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-wsl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-      "dev": true,
-      "dependencies": {
-        "is-docker": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/isarray": {
@@ -12175,23 +12138,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/open": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
-      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
-      "dev": true,
-      "dependencies": {
-        "define-lazy-prop": "^2.0.0",
-        "is-docker": "^2.1.1",
-        "is-wsl": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/optionator": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
@@ -14472,82 +14418,6 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/rollup-plugin-visualizer": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.12.0.tgz",
-      "integrity": "sha512-8/NU9jXcHRs7Nnj07PF2o4gjxmm9lXIrZ8r175bT9dK8qoLlvKTwRMArRCMgpMGlq8CTLugRvEmyMeMXIU2pNQ==",
-      "dev": true,
-      "dependencies": {
-        "open": "^8.4.0",
-        "picomatch": "^2.3.1",
-        "source-map": "^0.7.4",
-        "yargs": "^17.5.1"
-      },
-      "bin": {
-        "rollup-plugin-visualizer": "dist/bin/cli.js"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "rollup": "2.x || 3.x || 4.x"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/rollup-plugin-visualizer/node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/rollup-plugin-visualizer/node_modules/source-map": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/rollup-plugin-visualizer/node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/rollup-plugin-visualizer/node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/run-parallel": {

--- a/apcd-cms/src/client/package.json
+++ b/apcd-cms/src/client/package.json
@@ -10,6 +10,7 @@
     "react-dom": "^17.0.2",
     "react-query": "^3.34.15",
     "react-table": "^7.8.0",
+    "reactstrap": "^9.2.2",
     "typescript": "^4.4.3"
   },
   "scripts": {

--- a/apcd-cms/src/client/src/components/Admin/Submissions/AdminSubmissions.tsx
+++ b/apcd-cms/src/client/src/components/Admin/Submissions/AdminSubmissions.tsx
@@ -1,8 +1,22 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useSubmissions, SubmissionRow } from 'hooks/admin';
+import { ViewSubmissionLogsModal } from './ViewSubmissionLogsModal';
 
 export const AdminSubmissions: React.FC = () => {
-  const { data, isLoading, isError } = useSubmissions({});
+  const [status, setStatus] = useState<string>('');
+  const [sort, setSort] = useState<string>('');
+  const [page, setPage] = useState<number>(1);
+
+  const { data, isLoading, isError, refetch } = useSubmissions(
+    status,
+    sort,
+    page
+  );
+
+  useEffect(() => {
+    console.log('useEffect', status, sort, page);
+    refetch();
+  }, [status, sort, page]);
 
   if (isLoading) {
     return <div>Loading...</div>;
@@ -12,29 +26,81 @@ export const AdminSubmissions: React.FC = () => {
     return <div>Error loading data</div>;
   }
 
+  const clearSelections = () => {
+    setStatus('');
+    setSort('');
+    setPage(1);
+  };
+
   return (
-    <table id="submissionTable" className="submission-table">
-      <thead>
-        <tr>
-          {data?.header.map((columnName: string, index: number) => (
-            <th key={index}>{columnName}</th>
-          ))}
-        </tr>
-      </thead>
-      <tbody>
-        {data?.page.map((row: SubmissionRow, rowIndex: number) => (
-          <tr key={rowIndex}>
-            <td>{row.received_timestamp}</td>
-            <td>{row.entity_name}</td>
-            <td>{row.file_name}</td>
-            <td>{row.outcome}</td>
-            <td>{row.status}</td>
-            <td>{row.updated_at}</td>
-            <td>{row.submission_id}</td>
-            <td>{row.submitter_id}</td>
+    <>
+      <div className="filter-container">
+        <div className="filter-content">
+          <span>
+            <b>Filter by Status: </b>
+          </span>
+          <select
+            id="statusFilter"
+            className="status-filter"
+            value={status === '' ? data?.status_options[0] : status}
+            onChange={(e) => setStatus(e.target.value)}
+          >
+            {data?.status_options.map((option: string, index: number) => (
+              <option className="dropdown-text" key={index} value={option}>
+                {option}
+              </option>
+            ))}
+          </select>
+          <span>
+            <b>Sort by: </b>
+          </span>
+          <select
+            id="dateSort"
+            className="status-filter"
+            value={sort === '' ? data?.sort_options[0].value : sort}
+            onChange={(e) => setSort(e.target.value)}
+          >
+            {data?.sort_options.map((option: any, index: number) => (
+              <option
+                className="dropdown-text"
+                key={index}
+                value={option.value}
+              >
+                {option.name}
+              </option>
+            ))}
+          </select>
+          {data?.selected_status || data?.selected_sort ? (
+            <button onClick={clearSelections}>Clear Options</button>
+          ) : null}
+        </div>
+      </div>
+      <table id="submissionTable" className="submission-table">
+        <thead>
+          <tr>
+            {data?.header.map((columnName: string, index: number) => (
+              <th key={index}>{columnName}</th>
+            ))}
           </tr>
-        ))}
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          {data?.page.map((row: SubmissionRow, rowIndex: number) => (
+            <tr key={rowIndex}>
+              <td>{row.received_timestamp}</td>
+              <td>{row.entity_name}</td>
+              <td>{row.file_name}</td>
+              <td>{row.outcome}</td>
+              <td>{row.status}</td>
+              <td>{row.updated_at}</td>
+              <td>
+                <ViewSubmissionLogsModal
+                  submission_logs={row.view_modal_content}
+                />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </>
   );
 };

--- a/apcd-cms/src/client/src/components/Admin/Submissions/AdminSubmissions.tsx
+++ b/apcd-cms/src/client/src/components/Admin/Submissions/AdminSubmissions.tsx
@@ -1,0 +1,40 @@
+import React, { useEffect, useMemo } from 'react';
+import { useSubmissions, SubmissionRow } from 'hooks/admin';
+
+export const AdminSubmissions: React.FC = () => {
+  const { data, isLoading, isError } = useSubmissions({});
+
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+
+  if (isError) {
+    return <div>Error loading data</div>;
+  }
+
+  return (
+    <table id="submissionTable" className="submission-table">
+      <thead>
+        <tr>
+          {data?.header.map((columnName: string, index: number) => (
+            <th key={index}>{columnName}</th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {data?.page.map((row: SubmissionRow, rowIndex: number) => (
+          <tr key={rowIndex}>
+            <td>{row.received_timestamp}</td>
+            <td>{row.entity_name}</td>
+            <td>{row.file_name}</td>
+            <td>{row.outcome}</td>
+            <td>{row.status}</td>
+            <td>{row.updated_at}</td>
+            <td>{row.submission_id}</td>
+            <td>{row.submitter_id}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};

--- a/apcd-cms/src/client/src/components/Admin/Submissions/ViewSubmissionLogsModal.tsx
+++ b/apcd-cms/src/client/src/components/Admin/Submissions/ViewSubmissionLogsModal.tsx
@@ -1,0 +1,75 @@
+import { SubmissionLogsModalContent } from 'hooks/admin';
+import React, { useState } from 'react';
+import { Modal, ModalBody, ModalHeader } from 'reactstrap';
+import Button from 'core-components/Button';
+import styles from './Submissions.css';
+
+interface ViewSubmissionLogsModalProps {
+  submission_logs: SubmissionLogsModalContent[];
+}
+
+export const ViewSubmissionLogsModal: React.FC<
+  ViewSubmissionLogsModalProps
+> = ({ submission_logs }) => {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+
+  const toggle = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const closeBtn = (
+    <button className="close" onClick={toggle} type="button">
+      &times;
+    </button>
+  );
+
+  return (
+    <>
+      <Button type="link" onClick={() => toggle()}>
+        View Logs
+      </Button>
+      <Modal
+        isOpen={isOpen}
+        toggle={toggle}
+        size="lg"
+        className="modal-dialog-centered"
+      >
+        <ModalHeader toggle={toggle} close={closeBtn}>
+          <h5>View Logs</h5>
+        </ModalHeader>
+        <ModalBody>
+          <div>
+            <dl>
+              <h4>Logs</h4>
+              {submission_logs.length > 0 ? (
+                submission_logs.map((log, index) => (
+                  <div className="modal-section" key={index}>
+                    <dl className="c-data-list--is-vert c-data-list--is-wide">
+                      <dt className="c-data-list__key">Log ID</dt>
+                      <dd className="c-data-list__value">{log.log_id}</dd>
+                      <dt className="c-data-list__key">Entity Organization</dt>
+                      <dd className="c-data-list__value">{log.entity_name}</dd>
+                      <dt className="c-data-list__key">File Type</dt>
+                      <dd className="c-data-list__value">{log.file_type}</dd>
+                      <dt className="c-data-list__key">Validation Suite</dt>
+                      <dd className="c-data-list__value">
+                        {log.validation_suite}
+                      </dd>
+                      <dt className="c-data-list__key">Outcome</dt>
+                      <dd className="c-data-list__value">{log.outcome}</dd>
+                    </dl>
+                    <hr />
+                  </div>
+                ))
+              ) : (
+                <div className="modal-section">
+                  No logs found for this submission
+                </div>
+              )}
+            </dl>
+          </div>
+        </ModalBody>
+      </Modal>
+    </>
+  );
+};

--- a/apcd-cms/src/client/src/components/Admin/Submissions/index.ts
+++ b/apcd-cms/src/client/src/components/Admin/Submissions/index.ts
@@ -1,0 +1,3 @@
+import { AdminSubmissions } from "./AdminSubmissions";
+
+export { AdminSubmissions };

--- a/apcd-cms/src/client/src/components/library.tsx
+++ b/apcd-cms/src/client/src/components/library.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { AdminRegistrations } from './Admin/Registrations';
+import { AdminSubmissions } from './Admin/Submissions';
 import { QueryClient, QueryClientProvider } from 'react-query';
 
 const queryClient = new QueryClient();
@@ -15,4 +16,13 @@ function setupAdminRegistrations(): void {
   );
 }
 
-export { setupAdminRegistrations };
+function setupAdminSubmissions(): void {
+  ReactDOM.render(
+    <QueryClientProvider client={queryClient}>
+      <AdminSubmissions />
+    </QueryClientProvider>,
+    document.getElementById('react-root')
+  );
+}
+
+export { setupAdminRegistrations, setupAdminSubmissions };

--- a/apcd-cms/src/client/src/hooks/admin/index.ts
+++ b/apcd-cms/src/client/src/hooks/admin/index.ts
@@ -26,18 +26,29 @@ export type SubmissionRow = {
   outcome: string;
   received_timestamp: string;
   updated_at: string;
+  view_modal_content: SubmissionLogsModalContent[];
 }
 
 export type SubmissionResult = {
   header: string[];
   status_options: string[];
   filter_options: string[];
-  sort_options: string[];
+  sort_options: { name: string; value: string }[]
   selected_status: string;
   selected_sort: string;
   query_str: string;
   pagination_url_namespaces: string;
   page: SubmissionRow[];
+  page_num: number;
+  total_pages: number;
 };
+
+export type SubmissionLogsModalContent = {
+  log_id: string;
+  entity_name: string;
+  file_type: string;
+  validation_suite: string;
+  outcome: string;
+}
 
 export { useRegistrations, useSubmissions } from './useAdmin';

--- a/apcd-cms/src/client/src/hooks/admin/index.ts
+++ b/apcd-cms/src/client/src/hooks/admin/index.ts
@@ -17,4 +17,27 @@ export type RegistrationResult = {
   page: RegistrationRow[];
 };
 
-export { useRegistrations } from './useAdmin';
+export type SubmissionRow = {
+  submission_id: string;
+  submitter_id: string;
+  entity_name: string;
+  file_name: string;
+  status: string;
+  outcome: string;
+  received_timestamp: string;
+  updated_at: string;
+}
+
+export type SubmissionResult = {
+  header: string[];
+  status_options: string[];
+  filter_options: string[];
+  sort_options: string[];
+  selected_status: string;
+  selected_sort: string;
+  query_str: string;
+  pagination_url_namespaces: string;
+  page: SubmissionRow[];
+};
+
+export { useRegistrations, useSubmissions } from './useAdmin';

--- a/apcd-cms/src/client/src/hooks/admin/useAdmin.ts
+++ b/apcd-cms/src/client/src/hooks/admin/useAdmin.ts
@@ -31,8 +31,11 @@ const getSubmissions = async (params: any) => {
 };
 
 export const useSubmissions = (
-  params: any
+  status?: string,
+  sort?: string,
+  page?: number
 ): UseQueryResult<SubmissionResult> => {
+  const params: { status?: string; sort?: string, page?:number } = {status, sort, page};
   const query = useQuery(['submissions', params], () =>
     getSubmissions(params)
   ) as UseQueryResult<SubmissionResult>;

--- a/apcd-cms/src/client/src/hooks/admin/useAdmin.ts
+++ b/apcd-cms/src/client/src/hooks/admin/useAdmin.ts
@@ -1,6 +1,6 @@
 import { useQuery, UseQueryResult } from 'react-query';
 import { fetchUtil } from 'utils/fetchUtil';
-import { RegistrationResult } from '.';
+import { RegistrationResult, SubmissionResult } from '.';
 
 const getRegistrations = async (params: any) => {
   const url = `administration/list-registration-requests/api/`;
@@ -17,6 +17,25 @@ export const useRegistrations = (
   const query = useQuery(['registrations', params], () =>
     getRegistrations(params)
   ) as UseQueryResult<RegistrationResult>;
+
+  return { ...query };
+};
+
+const getSubmissions = async (params: any) => {
+  const url = `administration/list-submissions/api/`;
+  const response = await fetchUtil({
+    url,
+    params,
+  });
+  return response.response;
+};
+
+export const useSubmissions = (
+  params: any
+): UseQueryResult<SubmissionResult> => {
+  const query = useQuery(['submissions', params], () =>
+    getSubmissions(params)
+  ) as UseQueryResult<SubmissionResult>;
 
   return { ...query };
 };


### PR DESCRIPTION
## Overview

Converted the Admin Submissions page to a react component. Added `reactstrap` package to the project which allows us to use additional components. Added use of the reactstrap Modal component to handle modals. This is the same component that tup uses as well 

## Related

- [WP-443](https://tacc-main.atlassian.net/browse/WP-443)
- requires https://github.com/TACC/Core-CMS/pull/117

## Changes

- Added `AdminSubmissions.tsx` which contains logic for the main Admin Submissions page including Filter and Sort
- Added `ViewSubmissionsLogsModal.tsx` which uses reactstrap modal and displays the logs for a submission
- Fixed a bug in the sql query for submissions which should now return an empty array of logs if none exist

## Testing

1. Run `npm run install` and `npm run build` in the client directory 
2. Start the server with the command `make start` in the root apcd-cms directory
3. Go to [http://localhost:8000/administration/list-submissions/](http://localhost:8000/administration/list-submissions/) and ensure page functionality works as intended

## UI

<img width="1281" alt="Screen Shot 2024-06-12 at 2 59 27 PM" src="https://github.com/TACC/Core-CMS-Custom/assets/23081932/864c26b9-fd24-4239-9087-be3d55637dc1">

<img width="991" alt="Screen Shot 2024-06-12 at 3 00 07 PM" src="https://github.com/TACC/Core-CMS-Custom/assets/23081932/37a158a1-a93a-435a-aa73-fe0e8f81b4a0">

## Notes

- Could not get custom css working properly, so the modal looks a little off at the moment. Need to look further into how to get custom css modules to work correctly
