### PR TITLE
List Admin Exceptions React Conversion

### DIFF
--- a/apcd-cms/src/apps/admin_exception/templates/list_admin_exception.html
+++ b/apcd-cms/src/apps/admin_exception/templates/list_admin_exception.html
@@ -1,8 +1,9 @@
-{% extends "standard.html" %}
+{% extends "apcd_cms/templates/standard.html" %}
 {% load static %}
 
 {% block content %}
 <link rel="stylesheet" href="{% static 'apcd-cms/css/table.css' %}">
+<link rel="stylesheet" href="{% static 'apcd-cms/css/modal.css' %}">
 <link rel="stylesheet" href="{% static 'admin_exception/css/table.css' %}">
 <div class="container">
   {% include "nav_cms_breadcrumbs.html" %}
@@ -11,104 +12,11 @@
   <hr />
   <p style="margin-bottom: 30px">All submitted exception requests</p>
   <hr/>
-  <div class="filter-container">
-    <div class="filter-content">
-      <span><b>Filter by Status: </b></span>
-      <select id="statusFilter" class="status-filter" onchange="filterTableByStatus()">
-        {% for option in status_options %}
-          <option class="dropdown-text" {% if option == selected_status %}selected{% endif %}>{{ option }}</option>
-        {% endfor %}
-      </select>
-      <span><b>Filter by Organization: </b></span>
-      <select id="organizationFilter" class="status-filter org-filter" onchange="sortByOrg()">
-        <!-- Value set here so dropdown is not blank but set to All-->
-        {% for option in org_options %}
-          <option class="dropdown-text" {% if option == selected_org %}selected{% endif %}>{{ option }}</option>
-        {% endfor %}
-      </select>
-      {% if selected_status or selected_org %}
-          <button onclick="clearSelections()">Clear Options</button>
-      {% endif %}
-    </div>
-  </div>
-  <table id="exception-table" class="exception-table">
-      <thead>
-          <tr>
-              {% for k in header %}
-              <th>{{k}}</th>
-              {% endfor %}
-          </tr>
-      </thead>
-      <tbody>
-          {% for r in page %}
-              <tr>
-                <!-- So when page is shrunk, rows match with the former columns -->
-                <td class="created">{{r.created_at}}</td>
-                <td class="entity_name">{{r.entity_name}}</td>
-                <td class="requestor_name">{{r.requestor_name}}</td>
-                <td class="exception_type">{{r.request_type}}</td>
-                <td class="outcome">{{r.outcome}}</td>
-                <td class="status">{{r.status}}</td>
-                  <td class="modal-cell">
-                    {% include "view_admin_exception_modal.html" %}
-                    {% include "edit_exception_modal.html" %}                   
-                    <select id='actionsDropdown_{{r.exception_id}}' onchange="openAction('{{r.exception_id}}')">
-                      <div class="filter-container">
-                        <div class="filter-content">
-                          <option value="">Select Action</option>
-                          <option value="viewAdminExceptions">View Record</option>
-                          <option value="editException">Edit Record</option>
-                        </div>
-                      </div>
-                    </select>
-                </td>
-            </tr>
-          {% endfor %}
-      </tbody>
-  </table>
+  <div id="admin-exceptions-root"></div>
   {% include 'paginator.html' %}
 </div>
 <script>
-  
-    function filterTableByStatus() {
-      var dropdown, statusFilter, xhr, url_params, url;
-      dropdown = document.getElementById("statusFilter");
-      statusFilter =  dropdown.value;
-      url_params = `?status=${statusFilter}`;
-      {% if selected_org %}
-              url_params = `?status=${statusFilter}&org={{selected_org}}`;
-          {% endif %}
-      url = `/administration/list-exceptions/${url_params}`;
-      xhr = new XMLHttpRequest();
-      xhr.open('GET', url);
-      xhr.send();
-      window.location.href = url;
-      window.location.load();
-    }
 
-      function sortByOrg() {
-          var orgDropdown, orgValue, url_params, url, xhr;
-          orgDropdown = document.getElementById('organizationFilter');
-          orgValue =  orgDropdown.value;
-          url_params = `?org=${orgValue}`;
-          {% if selected_status %}
-              url_params = `?status={{selected_status}}&org=${orgValue}`;
-          {% endif %}
-          url = `/administration/list-exceptions/${url_params}`;
-          xhr = new XMLHttpRequest();
-          xhr.open('GET', url);
-          xhr.send();
-          window.location.href = url;
-          window.location.load();
-      }
-      function clearSelections() {
-          var xhr;
-          xhr = new XMLHttpRequest();
-          xhr.open('GET', '/administration/list-exceptions/')
-          xhr.send()
-          window.location.href = '/administration/list-exceptions/';
-          window.location.load();
-      }
       function openAction(exception_id) {
       var actionsDropdown, selectedOption, modal_id;
       actionsDropdown = document.getElementById(`actionsDropdown_${exception_id}`);

--- a/apcd-cms/src/apps/admin_exception/urls.py
+++ b/apcd-cms/src/apps/admin_exception/urls.py
@@ -1,10 +1,17 @@
 from django.urls import path
+from django.views.generic import TemplateView
 from apps.admin_exception.views import AdminExceptionsTable
 
 app_name = 'admin_exception'
 urlpatterns = [
-    path('list-exceptions/', AdminExceptionsTable.as_view(), name="list_exceptions"),
+    path('list-exceptions/', TemplateView.as_view(template_name='list_admin_exception.html'), name="list_exceptions"),
     path('list-exceptions/<str:status>', AdminExceptionsTable.as_view(), name='status'),
     path('list-exceptions/<str:org>', AdminExceptionsTable.as_view(), name='org'),
-    path('list-exceptions/<str:status><str:org>', AdminExceptionsTable.as_view(), name='status_org')
+    path('list-exceptions/<str:status><str:org>', AdminExceptionsTable.as_view(), name='status_org'),
+    path(r'list-exceptions/api/', AdminExceptionsTable.as_view(), name='admin_exceptions_table_api'),
+    path(r'list-exceptions/api/?status=(?P<status>)/', AdminExceptionsTable.as_view(),
+         name='admin_exceptions_table_api'),
+    path(r'list-exceptions/api/?org=(?P<org>)/', AdminExceptionsTable.as_view(), name='admin_exceptions_table_api'),
+    path(r'list-exceptions/api/?status=(?P<status>)&org=(?P<org>)/', AdminExceptionsTable.as_view(),
+         name='admin_exceptions_table_api')
 ]

--- a/apcd-cms/src/client/src/components/Admin/Exceptions/AdminExceptions.tsx
+++ b/apcd-cms/src/client/src/components/Admin/Exceptions/AdminExceptions.tsx
@@ -1,0 +1,126 @@
+import React, { useState, useEffect, useMemo } from 'react';
+import { useExceptions, ExceptionRow } from 'hooks/admin';
+
+export const AdminExceptions: React.FC = () => {
+  const [status, setStatus] = useState('All');
+  const [org, setOrg] = useState('All');
+  const [page, setPage] = useState(1);
+  const { data, isLoading, isError, refetch } = useExceptions(
+          status,
+          org,
+          page
+        );
+
+  useEffect(() => {
+    refetch();
+  }, [status, org, page, refetch]);
+
+  const clearSelections = () => {
+    setStatus('');
+    setOrg('');
+    setPage(1);
+  };
+
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+
+  if (isError) {
+    return <div>Error loading data</div>;
+  }
+
+  const openAction = (
+    event: React.ChangeEvent<HTMLSelectElement>,
+    exception_id: string
+  ) => {
+    // const actionsDropdown = event.target;
+    // const selectedOption = actionsDropdown.value;
+    // setSelectedRegistration(
+    //   data?.page.find((x) => x.reg_id === reg_id) ?? null
+    // );
+    // if (selectedOption == 'viewRegistration') {
+    //   setIsViewModalOpen(true);
+    // }
+    // actionsDropdown.selectedIndex = 0;
+  };
+
+  return (
+    <div>
+    <div className="filter-container">
+        <div className="filter-content">
+          {/* Filter */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+            <span>
+              <b>Filter by Status: </b>
+            </span>
+            <select
+              id="statusFilter"
+              className="status-filter"
+              defaultValue={data?.selected_status} // Use defaultValue to set the initial selected value
+              onChange={(e) => setStatus(e.target.value)}
+            >
+              {data?.status_options.map((status, index) => (
+                <option className="dropdown-text" key={index} value={status}>
+                  {status}
+                </option>
+              ))}
+            </select>
+
+            {/* Filter by Organization */}
+            <span>
+              <b>Filter by Organization: </b>
+            </span>
+            <select
+              id="organizationFilter"
+              className="status-filter org-filter"
+              defaultValue={data?.selected_org} // Use defaultValue to set the initial selected value
+              onChange={(e) => setOrg(e.target.value)}
+            >
+              {data?.org_options.map((org, index) => (
+                <option className="dropdown-text" key={index} value={org}>
+                  {org}
+                </option>
+              ))}
+            </select>
+            {data?.selected_status || data?.selected_org ? (
+              <button onClick={clearSelections}>Clear Options</button>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    <table id="exceptionTable" className="exception-table">
+      <thead>
+        <tr>
+          {data?.header.map((columnName: string, index: number) => (
+            <th key={index}>{columnName}</th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {data?.page.map((row: ExceptionRow, rowIndex: number) => (
+          <tr key={rowIndex}>
+            <td>{row.created_at}</td>
+            <td>{row.entity_name}</td>
+            <td>{row.requestor_name}</td>
+            <td>{row.requestor_type}</td>
+            <td>{row.outcome}</td>
+            <td>{row.status}</td>
+            <td className="modal-cell">
+                <select
+                  id={`actionsDropdown_${row.exception_id}`}
+                  defaultValue=""
+                  className="status-filter"
+                  onChange={(e) => openAction(e, row.exception_id)}
+                >
+                  <option value="">Select Action</option>
+                  <option value="viewAdminExceptions">View Record</option>
+                  <option value="editException">Edit Record</option>
+                </select>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+    </div>
+  );
+};

--- a/apcd-cms/src/client/src/components/Admin/Exceptions/index.ts
+++ b/apcd-cms/src/client/src/components/Admin/Exceptions/index.ts
@@ -1,0 +1,4 @@
+// index.ts
+import { AdminExceptions } from './AdminExceptions';
+
+export { AdminExceptions };

--- a/apcd-cms/src/client/src/hooks/admin/index.ts
+++ b/apcd-cms/src/client/src/hooks/admin/index.ts
@@ -70,4 +70,24 @@ export type SubmissionLogsModalContent = {
   outcome: string;
 }
 
-export { useRegistrations, useSubmissions, useUsers } from './useAdmin';
+export type ExceptionRow = {
+  created_at: string;
+  entity_name: string;
+  requestor_name: string;
+  requestor_type: string;
+  outcome: string;
+  status: string;
+  exception_id: string;
+};
+
+export type ExceptionResult = {
+  header: string[];
+  status_options: string[];
+  org_options: string[];
+  selected_status: string;
+  selected_org: string;
+  query_str: string;
+  pagination_url_namespaces: string;
+  page: ExceptionRow[];
+};
+export { useRegistrations, useSubmissions, useUsers, useExceptions } from './useAdmin';

--- a/apcd-cms/src/client/src/hooks/admin/useAdmin.ts
+++ b/apcd-cms/src/client/src/hooks/admin/useAdmin.ts
@@ -1,6 +1,6 @@
 import { useQuery, UseQueryResult } from 'react-query';
 import { fetchUtil } from 'utils/fetchUtil';
-import { RegistrationResult, UserResult, SubmissionResult } from '.';
+import { RegistrationResult, UserResult, SubmissionResult, ExceptionResult } from '.';
 
 const getRegistrations = async (params: any) => {
   const url = `/administration/list-registration-requests/api/`;
@@ -44,6 +44,32 @@ export const useSubmissions = (
   const query = useQuery(['submissions', params], () =>
     getSubmissions(params)
   ) as UseQueryResult<SubmissionResult>;
+
+  return { ...query };
+};
+
+const getExceptions = async (params: any) => {
+  const url = `administration/list-exceptions/api/`;
+  const response = await fetchUtil({
+    url,
+    params,
+  });
+  return response.response;
+};
+
+export const useExceptions = (
+  status?: string,
+  org?: string,
+  page?: number
+): UseQueryResult<ExceptionResult> => {
+  const params: { status?: string; org?: string; page?: number } = {
+    status,
+    org,
+    page,
+  };
+  const query = useQuery(['exceptions', params], () =>
+    getExceptions(params)
+  ) as UseQueryResult<ExceptionResult>;
 
   return { ...query };
 };

--- a/apcd-cms/src/client/src/main.tsx
+++ b/apcd-cms/src/client/src/main.tsx
@@ -5,6 +5,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { AdminRegistrations } from './components/Admin/Registrations';
 import { ViewUsers } from './components/Admin/ViewUsers';
 import { AdminSubmissions } from './components/Admin/Submissions';
+import { AdminExceptions } from './components/Admin/Exceptions';
 import { QueryClient, QueryClientProvider } from 'react-query';
 
 const queryClient = new QueryClient();
@@ -28,6 +29,7 @@ const componentMap: { [key: string]: React.ComponentType } = {
   'list-registrations-root': AdminRegistrations,
   'view-users-root': ViewUsers,
   'list-admin-submissions': AdminSubmissions,
+  'admin-exceptions-root': AdminExceptions,
   // Add new components with html id in the list above.
 };
 


### PR DESCRIPTION
## Overview

First pass at updating Admin List Exceptions page to React. No API work has been done yet and is still lacking dropdown functionality.


## Related

[WP-441](https://tacc-main.atlassian.net/browse/WP-441)

## Changes

Listing page converted to React component.

## Testing

1. Go to http://localhost:8000/administration/list-exceptions/ and make sure its listing exceptions information.


## UI


![Screenshot 2024-07-31 at 3 22 35 PM](https://github.com/user-attachments/assets/a217422f-f399-4d83-98a9-8933d7547157)


## Notes
The modal windows related to the "Actions" dropdown in the exceptions rows are not been implemented in this PR.

