### PR TITLE
fix: WP-602 `docker compose` with and without dash

### DIFF
--- a/demdata_cms/Makefile
+++ b/demdata_cms/Makefile
@@ -2,13 +2,14 @@ DOCKERHUB_REPO := $(shell cat ./docker_repo.var)
 DOCKER_TAG ?= $(shell git rev-parse --short HEAD)
 DOCKER_IMAGE := $(DOCKERHUB_REPO):$(DOCKER_TAG)
 DOCKER_IMAGE_LATEST := $(DOCKERHUB_REPO):latest
+DOCKER_COMPOSE_CMD := $(shell if command -v docker-compose > /dev/null; then echo "docker-compose"; else echo "docker compose"; fi)
 
 # `DOCKER_IMAGE_BRANCH` tag is the git tag for the commit if it exists, else the branch on which the commit exists
 DOCKER_IMAGE_BRANCH := $(DOCKERHUB_REPO):$(shell git describe --exact-match --tags 2> /dev/null || git symbolic-ref --short HEAD)
 
 #.PHONY: build
 build:
-	docker-compose -f docker-compose.dev.yml build
+	$(DOCKER_COMPOSE_CMD) -f docker-compose.dev.yml build
 
 .PHONY: build-full
 build-full:
@@ -27,12 +28,12 @@ publish-latest:
 
 .PHONY: start
 start:
-	docker-compose -f docker-compose.dev.yml up
+	$(DOCKER_COMPOSE_CMD) -f docker-compose.dev.yml up
 
 .PHONY: stop
 stop:
-	docker-compose -f docker-compose.dev.yml down
+	$(DOCKER_COMPOSE_CMD) -f docker-compose.dev.yml down
 
 .PHONY: stop-full
 stop-v:
-	docker-compose -f docker-compose.dev.yml down -v
+	$(DOCKER_COMPOSE_CMD) -f docker-compose.dev.yml down -v

--- a/ecep_cms/Makefile
+++ b/ecep_cms/Makefile
@@ -2,13 +2,14 @@ DOCKERHUB_REPO := $(shell cat ./docker_repo.var)
 DOCKER_TAG ?= $(shell git rev-parse --short HEAD)
 DOCKER_IMAGE := $(DOCKERHUB_REPO):$(DOCKER_TAG)
 DOCKER_IMAGE_LATEST := $(DOCKERHUB_REPO):latest
+DOCKER_COMPOSE_CMD := $(shell if command -v docker-compose > /dev/null; then echo "docker-compose"; else echo "docker compose"; fi)
 
 # `DOCKER_IMAGE_BRANCH` tag is the git tag for the commit if it exists, else the branch on which the commit exists
 DOCKER_IMAGE_BRANCH := $(DOCKERHUB_REPO):$(shell git describe --exact-match --tags 2> /dev/null || git symbolic-ref --short HEAD)
 
 #.PHONY: build
 build:
-	docker-compose -f docker-compose.dev.yml build
+	$(DOCKER_COMPOSE_CMD) -f docker-compose.dev.yml build
 
 .PHONY: build-full
 build-full:
@@ -27,12 +28,12 @@ publish-latest:
 
 .PHONY: start
 start:
-	docker-compose -f docker-compose.dev.yml up
+	$(DOCKER_COMPOSE_CMD) -f docker-compose.dev.yml up
 
 .PHONY: stop
 stop:
-	docker-compose -f docker-compose.dev.yml down
+	$(DOCKER_COMPOSE_CMD) -f docker-compose.dev.yml down
 
 .PHONY: stop-full
 stop-v:
-	docker-compose -f docker-compose.dev.yml down -v
+	$(DOCKER_COMPOSE_CMD) -f docker-compose.dev.yml down -v

--- a/example_cms/Makefile
+++ b/example_cms/Makefile
@@ -2,13 +2,14 @@ DOCKERHUB_REPO := $(shell cat ./docker_repo.var)
 DOCKER_TAG ?= $(shell git rev-parse --short HEAD)
 DOCKER_IMAGE := $(DOCKERHUB_REPO):$(DOCKER_TAG)
 DOCKER_IMAGE_LATEST := $(DOCKERHUB_REPO):latest
+DOCKER_COMPOSE_CMD := $(shell if command -v docker-compose > /dev/null; then echo "docker-compose"; else echo "docker compose"; fi)
 
 # `DOCKER_IMAGE_BRANCH` tag is the git tag for the commit if it exists, else the branch on which the commit exists
 DOCKER_IMAGE_BRANCH := $(DOCKERHUB_REPO):$(shell git describe --exact-match --tags 2> /dev/null || git symbolic-ref --short HEAD)
 
 #.PHONY: build
 build:
-	docker-compose -f docker-compose.dev.yml build
+	$(DOCKER_COMPOSE_CMD) -f docker-compose.dev.yml build
 
 .PHONY: build-full
 build-full:
@@ -27,12 +28,12 @@ publish-latest:
 
 .PHONY: start
 start:
-	docker-compose -f docker-compose.dev.yml up
+	$(DOCKER_COMPOSE_CMD) -f docker-compose.dev.yml up
 
 .PHONY: stop
 stop:
-	docker-compose -f docker-compose.dev.yml down
+	$(DOCKER_COMPOSE_CMD) -f docker-compose.dev.yml down
 
 .PHONY: stop-full
 stop-v:
-	docker-compose -f docker-compose.dev.yml down -v
+	$(DOCKER_COMPOSE_CMD) -f docker-compose.dev.yml down -v


### PR DESCRIPTION
## Overview

Docker v2 has different command for `docker compose`. Adjust Makefile to handle both based on availability.

## Related

- [WP-602](https://tacc-main.atlassian.net/browse/WP-602)
- mimics https://github.com/TACC/Core-CMS-Custom/pull/295

## Changes

- **added** conditional `docker compose` command to Makefile

## Testing

1. `make build` — no error firing command from Makefile
2. `make start` — no error firing command from Makefile

## UI

Skipped.