### PR TITLE
WP-687: Hotfix: Org dropdown being mistakenly populated by city

### DIFF
--- a/apcd_cms/src/apps/admin_regis_table/views.py
+++ b/apcd_cms/src/apps/admin_regis_table/views.py
@@ -91,7 +91,7 @@ class RegistrationsTable(TemplateView):
             associated_entities = [ent for ent in registrations_entities if ent[1] == registration[0]]
             associated_contacts = [cont for cont in registrations_contacts if cont[1] == registration[0]]
             registration_table_entries.append(_set_registration(registration, associated_entities, associated_contacts))
-            org_name = registration[7]
+            org_name = registration[5]
             if org_name not in context['org_options']:
                 context['org_options'].append(org_name)
 


### PR DESCRIPTION
Incorrect index is being used to populate org dropdown, this pull request fixes this issue.

## Overview

…

## Related
[WP-687](https://tacc-main.atlassian.net/browse/WP-687)

## Changes

Updated index on ln 94 on the admin_regis_table/views.py file

## Testing

1. Navigate to http://localhost:8000/administration/list-registration-requests/ and verify the "Filter by Organization" dropdown is being correctly populated by organizations.
2. Verify dropdown is filtering properly

## UI

…

<!--
## Notes

…
-->
