### PR TITLE
task/WP-695: Add status change to edit registration modal

### DIFF
--- a/apcd_cms/src/apps/registrations/templates/submission_form/registration_form_body.html
+++ b/apcd_cms/src/apps/registrations/templates/submission_form/registration_form_body.html
@@ -5,17 +5,18 @@
         <input type="hidden" name="edit-registration-form" value>
         <input type="hidden" name="reg_id" value="{{r.reg_id}}">
 
-        <label for="reg_status"> Registration Status </label>
-
-        <div class="field-wrapper select">
-            <select name="reg_status" class="choicefield" id="reg_status">
-                {% for option in status_options %}
-                {% if not forloop.first %}
-                    <option class="dropdown-text" {% if option == r.reg_status %}selected{% endif %}>{{ option }}</option>
-                {% endif %}
-                {% endfor %} 
-            </select>
-        </div>
+        {% if not renew %}
+            <label for="reg_status"> Registration Status </label>
+            <div class="field-wrapper select">
+                <select name="reg_status" class="choicefield" id="reg_status">
+                    {% for option in status_options %}
+                    {% if not forloop.first %}
+                        <option class="dropdown-text" {% if option == r.reg_status %}selected{% endif %}>{{ option }}</option>
+                    {% endif %}
+                    {% endfor %} 
+                </select>
+            </div>
+        {% endif %}
 
     {% endif %}
 

--- a/apcd_cms/src/apps/registrations/templates/submission_form/registration_form_body.html
+++ b/apcd_cms/src/apps/registrations/templates/submission_form/registration_form_body.html
@@ -4,6 +4,19 @@
     {% if r %}
         <input type="hidden" name="edit-registration-form" value>
         <input type="hidden" name="reg_id" value="{{r.reg_id}}">
+
+        <label for="reg_status"> Registration Status </label>
+
+        <div class="field-wrapper select">
+            <select name="reg_status" class="choicefield" id="reg_status">
+                {% for option in status_options %}
+                {% if not forloop.first %}
+                    <option class="dropdown-text" {% if option == r.reg_status %}selected{% endif %}>{{ option }}</option>
+                {% endif %}
+                {% endfor %} 
+            </select>
+        </div>
+
     {% endif %}
 
     <div class="form-errors" style="display: none"></div>

--- a/apcd_cms/src/apps/utils/apcd_database.py
+++ b/apcd_cms/src/apps/utils/apcd_database.py
@@ -255,6 +255,7 @@ def update_registration(form, reg_id):
         operation = """UPDATE registrations
             SET
             submitting_for_self = %s,
+            registration_status = %s,
             org_type = %s,
             business_name = %s,
             mail_address = %s,
@@ -267,6 +268,7 @@ def update_registration(form, reg_id):
         RETURNING registration_id"""
         values = (
             True if form['on-behalf-of'] == 'true' else False,
+            form['reg_status'],
             form['type'],
             _clean_value(form['business-name']),
             _clean_value(form['mailing-address']),


### PR DESCRIPTION
## Overview
…

## Related

- [WP-695](https://tacc-main.atlassian.net/browse/WP-695)
<!--
- requires https://github.com/TACC/Core-CMS/pull/117
-->…

## Changes
- Adds new `<select>` element to registration form, only rendered if registration data is being loaded to the form + is not a registration renewal
- Adds write to `registration_status` field on registrations table on database for `update_registration` db util function 
…

## Testing

1. Go to http://localhost:8000/administration/list-registration-requests/
2. Select a record to edit via Actions column -> "Edit Record"
3. Confirm that a new drop down labeled 'Registration Status' appears at the top of the 'Organization' portion of the form
4. Confirm this drop down's pre-selected value matches that in the 'Registration Status' column for the same record on the table
5. Select a different option in the drop down and then submit that change
6. Confirm you are directed to a success page, then return to the List Registrations page and confirm the value you selected shows in both the table for the record you edited + the same 'Edit Record' modal
7. Confirm this new field does not appear on the following pages:
   - http://localhost:8000/register/request-to-submit/ (reg form)
   - http://localhost:8000/register/request-to-submit/?reg_id=2 (reg renewal form)

## UI
![image](https://github.com/user-attachments/assets/b1463e40-9a57-4ce1-9391-1d611b9ca352)

…

<!--
## Notes

…
-->
