### PR TITLE
task/WP-695: Add 'Withdrawn' to status options

### DIFF
--- a/apcd_cms/src/apps/admin_regis_table/views.py
+++ b/apcd_cms/src/apps/admin_regis_table/views.py
@@ -72,7 +72,7 @@ class RegistrationsTable(TemplateView):
         context = super(RegistrationsTable, self).get_context_data(*args, **kwargs)
 
         context['header'] = ['Business Name', 'Year', 'Type', 'Location', 'Registration Status', 'Actions']
-        context['status_options'] = ['All', 'Received', 'Processing', 'Complete']
+        context['status_options'] = ['All', 'Received', 'Processing', 'Complete', 'Withdrawn']
         context['org_options'] = ['All']
 
         try:


### PR DESCRIPTION
## Overview

…

## Related

- [WP-695](https://tacc-main.atlassian.net/browse/WP-695)
<!--
- requires https://github.com/TACC/Core-CMS/pull/117
-->…

## Changes
- Adds 'Withdrawn' to status options for admin registrations listing + edit record modal 'Registration Status' field
…

## Testing

1. Go to http://localhost:8000/administration/list-registration-requests/
2. Confirm that the 'Status' filter on the page now has 'Withdrawn' as an additional option
3. Confirm the same for the 'Registration Status' field on the 'Edit Record' modal on a record on the table
    - Additionally, try updating the value for the record to 'Withdrawn' and submit, confirm it succeeds and, upon reloading the page, this 'Withdrawn' status shows up on the related row for the record and in the same edit record modal
4. Confirm the same for the [submitter admin registrations listing](http://localhost:8000/register/list-registration-requests/) (just the status drop down on the page)
