### PR TITLE
hotfix/address-null-in-filters 

### DIFF
--- a/apcd_cms/src/apps/admin_exception/templates/list_admin_exception.html
+++ b/apcd_cms/src/apps/admin_exception/templates/list_admin_exception.html
@@ -26,7 +26,7 @@
           <option class="dropdown-text" {% if option == selected_org %}selected{% endif %}>{{ option }}</option>
         {% endfor %}
       </select>
-      {% if selected_status or selected_org %}
+      {% if selected_status != 'All' or selected_org != 'All' %}
           <button onclick="clearSelections()">Clear Options</button>
       {% endif %}
     </div>

--- a/apcd_cms/src/apps/admin_exception/views.py
+++ b/apcd_cms/src/apps/admin_exception/views.py
@@ -110,7 +110,7 @@ class AdminExceptionsTable(TemplateView):
             # to be able to access any exception in a template using exceptions var in the future
             context['exceptions'].append(_set_exceptions(exception))
             entity_name = title_case(exception[21])
-            status = title_case(exception[19])
+            status = title_case(exception[19]) if exception[19] else 'None'
             outcome = title_case(exception[5])
             if entity_name not in context['org_options']:
                 context['org_options'].append(entity_name)

--- a/apcd_cms/src/apps/admin_exception/views.py
+++ b/apcd_cms/src/apps/admin_exception/views.py
@@ -69,7 +69,7 @@ class AdminExceptionsTable(TemplateView):
                 'requestor_name': exception[2],
                 'request_type': title_case(exception[3]) if exception[3] else None, # to make sure if val doesn't exist, utils don't break page
                 'explanation_justification': exception[4],
-                'outcome': title_case(exception[5]) if exception[3] else None,
+                'outcome': title_case(exception[5]) if exception[5] else None,
                 'created_at': exception[6],
                 'updated_at': exception[7],
                 'submitter_code': exception[8],
@@ -83,7 +83,7 @@ class AdminExceptionsTable(TemplateView):
                 'requested_expiration_date': exception[16],
                 'approved_threshold': exception[17],
                 'approved_expiration_date': exception[18],
-                'status': title_case(exception[19])if exception[3] else None,
+                'status': title_case(exception[19])if exception[19] else 'None',
                 'notes': exception[20],
                 'entity_name': exception[21],
                 'data_file_name': exception[22]
@@ -115,26 +115,24 @@ class AdminExceptionsTable(TemplateView):
             if entity_name not in context['org_options']:
                 context['org_options'].append(entity_name)
                 # to make sure All is first in the dropdown filter options after sorting alphabetically
-                context['org_options'] = sorted(context['org_options'],key=lambda x: (x is not None, x != 'All', x if x is not None else ''))
+                context['org_options'] = sorted(context['org_options'],key=lambda x: (x != 'All', x is None, x if x is not None else ''))
                 # Remove empty strings
                 context['org_options'] = [option for option in context['org_options'] if option != '']
             if status not in context['status_options']:
-                if status != None:
-                    context['status_options'].append(status)
-                    # to make sure All is first in the dropdown filter options after sorting alphabetically
-                    context['status_options'] = sorted(context['status_options'], key=lambda x: (x is not None, x != 'All', x if x is not None else ''))
+                context['status_options'].append(status)
+                context['status_options'] = sorted(context['status_options'], key=lambda x: (x != 'All', x is None, x if x is not None else ''))
             if outcome not in context['outcome_options']:
                 context['outcome_options'].append(outcome)
-                context['outcome_options'] = sorted(context['outcome_options'],key=lambda x: (x is not None, x != 'All', x if x is not None else ''))
+                context['outcome_options'] = sorted(context['outcome_options'], key=lambda x: (x != 'All', x is None, x if x is not None else ''))
 
-        context['selected_status'] = None
-        if status_filter is not None and status_filter != 'All':
+        context['selected_status'] = 'All'
+        if status_filter and status_filter != 'All':
             context['selected_status'] = status_filter
             queryStr += f'&status={status_filter}'
             exception_table_entries = table_filter(status_filter, exception_table_entries, 'status')
 
-        context['selected_org'] = None
-        if org_filter is not None and org_filter != 'All':
+        context['selected_org'] = 'All'
+        if org_filter and org_filter != 'All':
             context['selected_org'] = org_filter
             queryStr += f'&org={org_filter}'
             exception_table_entries = table_filter(org_filter.replace("(", "").replace(")",""), exception_table_entries, 'entity_name')

--- a/apcd_cms/src/apps/admin_extension/templates/list_admin_extension.html
+++ b/apcd_cms/src/apps/admin_extension/templates/list_admin_extension.html
@@ -26,7 +26,7 @@
           <option class="dropdown-text" {% if option == selected_org %}selected{% endif %}>{{ option }}</option>
         {% endfor %}
       </select>
-      {% if selected_status or selected_org %}
+      {% if selected_status != 'All' or selected_org != 'All' %}
         <button onclick="clearSelections()">Clear Options</button>
       {% endif %}
     </div>

--- a/apcd_cms/src/apps/admin_extension/views.py
+++ b/apcd_cms/src/apps/admin_extension/views.py
@@ -104,7 +104,7 @@ class AdminExtensionsTable(TemplateView):
             # to be able to access any extension in a template
             context['extensions'].append(_set_extensions(extension))
             entity_name = title_case(extension[18])
-            status = title_case(extension[7])
+            status = title_case(extension[7]) if extension[7] else 'None'
             outcome = title_case(extension[8])
             if entity_name not in context['org_options']:
                 context['org_options'].append(entity_name)

--- a/apcd_cms/src/apps/admin_extension/views.py
+++ b/apcd_cms/src/apps/admin_extension/views.py
@@ -67,14 +67,14 @@ class AdminExtensionsTable(TemplateView):
                 # to separate small carrier into two words
                 'extension_type': title_case(extension[5].replace('_', ' ')) if extension[5] else None,
                 'applicable_data_period': _get_applicable_data_period(extension[6]),
-                'status': title_case(extension[7]),
-                'outcome': title_case(extension[8]),
+                'status': title_case(extension[7]) if extension[7] else 'None',
+                'outcome': title_case(extension[8]) if extension[8] else None,
                 'created_at': extension[9],
                 'updated_at': extension[10],
                 'submitter_code': extension[11],
                 'payor_code': extension[12],
                 'user_id': extension[13],
-                'requestor_name': title_case(extension[14]),
+                'requestor_name': title_case(extension[14]) if extension[14] else None,
                 'requestor_email': extension[15],
                 'explanation_justification': extension[16],
                 'notes': extension[17],
@@ -108,27 +108,27 @@ class AdminExtensionsTable(TemplateView):
             outcome = title_case(extension[8])
             if entity_name not in context['org_options']:
                 context['org_options'].append(entity_name)
-                context['org_options'] = sorted(context['org_options'], key=lambda x: (x is not None, x != 'All', x if x is not None else ''))
+                context['org_options'] = sorted(context['org_options'], key=lambda x: (x != 'All', x is None, x if x is not None else ''))
                 # Remove empty strings
                 context['org_options'] = [option for option in context['org_options'] if option != '']
             if status not in context['status_options']:
                 context['status_options'].append(status)
-                context['status_options'] = sorted(context['status_options'], key=lambda x: (x is not None, x != 'All', x if x is not None else ''))
+                context['status_options'] = sorted(context['status_options'], key=lambda x: (x != 'All', x is None, x if x is not None else ''))
             if outcome not in context['outcome_options']:
                 context['outcome_options'].append(outcome)
-                context['outcome_options'] = sorted(context['outcome_options'],key=lambda x: (x is not None, x != 'All', x if x is not None else ''))
+                context['outcome_options'] = sorted(context['outcome_options'], key=lambda x: (x != 'All', x is None, x if x is not None else ''))
 
         queryStr = ''
         status_filter = self.request.GET.get('status')
         org_filter = self.request.GET.get('org')
 
-        context['selected_status'] = None
+        context['selected_status'] = 'All'
         if status_filter is not None and status_filter != 'All':
             context['selected_status'] = status_filter
             queryStr += f'&status={status_filter}'
             extension_table_entries = table_filter(status_filter, extension_table_entries, 'status')
 
-        context['selected_org'] = None
+        context['selected_org'] = 'All'
         if org_filter is not None and org_filter != 'All':
             context['selected_org'] = org_filter
             queryStr += f'&org={org_filter}'

--- a/apcd_cms/src/apps/admin_regis_table/templates/list_registrations.html
+++ b/apcd_cms/src/apps/admin_regis_table/templates/list_registrations.html
@@ -28,7 +28,7 @@
           <option class="dropdown-text" {% if option == selected_org %}selected{% endif %}>{{ option }}</option>
         {% endfor %}
       </select>
-      {% if selected_status or selected_org %}
+      {% if selected_status != 'All' or selected_org != 'All' %}
         <button onclick="clearSelections()">Clear Options</button>
       {% endif %}
     </div>

--- a/apcd_cms/src/apps/admin_regis_table/views.py
+++ b/apcd_cms/src/apps/admin_regis_table/views.py
@@ -73,6 +73,7 @@ class RegistrationsTable(TemplateView):
 
         context['header'] = ['Business Name', 'Year', 'Type', 'Location', 'Registration Status', 'Actions']
         context['status_options'] = ['All', 'Received', 'Processing', 'Complete', 'Withdrawn']
+        context['status_options'] = sorted(context['status_options'], key=lambda x: (x != 'All', x is None, x if x is not None else ''))
         context['org_options'] = ['All']
 
         try:
@@ -94,19 +95,20 @@ class RegistrationsTable(TemplateView):
             org_name = registration[5]
             if org_name not in context['org_options']:
                 context['org_options'].append(org_name)
+                context['org_options'] = sorted(context['org_options'],key=lambda x: (x != 'All', x is None, x if x is not None else ''))
 
         queryStr = ''
         status_filter = self.request.GET.get('status')
         org_filter = self.request.GET.get('org')
 
-        context['selected_status'] = None
-        if status_filter is not None and status_filter != 'All':
+        context['selected_status'] = 'All'
+        if status_filter and status_filter != 'All':
             context['selected_status'] = status_filter
             queryStr += f'&status={status_filter}'
             registration_table_entries = table_filter(status_filter, registration_table_entries, 'reg_status')
 
-        context['selected_org'] = None
-        if org_filter is not None and org_filter != 'All':
+        context['selected_org'] = 'All'
+        if org_filter and org_filter != 'All':
             context['selected_org'] = org_filter
             queryStr += f'&org={org_filter}'
             registration_table_entries = table_filter(org_filter.replace("(", "").replace(")",""), registration_table_entries, 'biz_name')

--- a/apcd_cms/src/apps/admin_submissions/templates/list_admin_submissions.html
+++ b/apcd_cms/src/apps/admin_submissions/templates/list_admin_submissions.html
@@ -21,7 +21,7 @@
     <div class="filter-content">
       <span><b>Filter by Status: </b></span>
       <select id="statusFilter" class="status-filter" onchange="filterTableByStatus()">
-        {% for option in filter_options %}
+        {% for option in status_options %}
           <option class="dropdown-text" {% if option == selected_status %}selected{% endif %}>{{ option }}</option>
         {% endfor %}
       </select>
@@ -32,7 +32,7 @@
           <option class="dropdown-text" value={{option}} {% if option == selected_sort %}selected{% endif %}>{{ display_text }}</option>
         {% endfor %}
       </select>
-      {% if selected_status or selected_sort %}
+      {% if selected_status  != 'All' or selected_sort != None %}
         <button onclick="clearSelections()">Clear Options</button>
       {% endif %}
     </div>

--- a/apcd_cms/src/apps/admin_submissions/views.py
+++ b/apcd_cms/src/apps/admin_submissions/views.py
@@ -24,6 +24,14 @@ class AdminSubmissionsTable(TemplateView):
 
         submission_content = get_all_submissions_and_logs()
 
+        context['status_options'] = ['All']
+        for i in submission_content: 
+            status = title_case(i['status']) if i['status'] else 'None'
+            if status not in context['status_options']:
+                context['status_options'].append(status)
+        context['status_options'] = sorted(context['status_options'], key=lambda x: (x != 'All', x is None, x if x is not None else ''))
+
+
         queryStr = ''
         dateSort = self.request.GET.get('sort')
         status_filter = self.request.GET.get('status')
@@ -42,7 +50,7 @@ class AdminSubmissionsTable(TemplateView):
         except:
             page_num = 1
 
-        context['selected_status'] = None
+        context['selected_status'] = 'All'
         if status_filter is not None and status_filter != 'All':
             context['selected_status'] = status_filter
             queryStr += f'&status={status_filter}'
@@ -54,18 +62,17 @@ class AdminSubmissionsTable(TemplateView):
         # modifies the object fields for display, only modifies a subset of entries that will be displayed 
         # on the current page using offset and limit
         for s in submission_content[offset:offset + limit]:
-            s['status'] = title_case(s['status'])
-            s['entity_name'] = title_case(s['entity_name'])
-            s['outcome'] = title_case(s['outcome'])
+            s['status'] = title_case(s['status']) if s['status'] else None
+            s['entity_name'] = title_case(s['entity_name']) if s['entity_name'] else None
+            s['outcome'] = title_case(s['outcome']) if s['outcome'] else None
             s['received_timestamp'] = parser.parse(s['received_timestamp']) if s['received_timestamp'] else None
             s['updated_at'] = parser.parse(s['updated_at']) if s['updated_at'] else None
             s['view_modal_content'] = [{
                 **t,
-                'outcome': title_case(t['outcome'])
+                'outcome': title_case(t['outcome']) if t['outcome'] else None
             } for t in (s['view_modal_content'] or [])]
 
         context['header'] = ['Received', 'Entity Organization', 'File Name', ' ', 'Outcome', 'Status', 'Last Updated', 'Actions']
-        context['filter_options'] = ['All', 'In Process', 'Complete']
         context['sort_options'] = {'newDate': 'Newest Received', 'oldDate': 'Oldest Received'}
 
         context['query_str'] = queryStr

--- a/apcd_cms/src/apps/submissions/templates/list_submissions.html
+++ b/apcd_cms/src/apps/submissions/templates/list_submissions.html
@@ -20,7 +20,7 @@
     <div class="filter-content">
       <span><b>Filter by Status: </b></span>
       <select id="statusFilter" class="status-filter" onchange="filterTableByStatus()">
-        {% for option in filter_options %}
+        {% for option in status_options %}
           <option class="dropdown-text" {% if option == selected_status %}selected{% endif %}>{{ option }}</option>
         {% endfor %}
       </select>
@@ -31,7 +31,7 @@
           <option class="dropdown-text" value={{option}} {% if option == selected_sort %}selected{% endif %}>{{ display_text }}</option>
         {% endfor %}
       </select>
-      {% if selected_status or selected_sort %}
+      {% if selected_status  != 'All' or selected_sort != None %}
         <button onclick="clearSelections()">Clear Options</button>
       {% endif %}
     </div>

--- a/apcd_cms/src/apps/submissions/views.py
+++ b/apcd_cms/src/apps/submissions/views.py
@@ -46,7 +46,7 @@ class SubmissionsTable(TemplateView):
         except:
             page_num = 1
 
-        context['selected_status'] = None
+        context['selected_status'] = 'All'
         if status_filter is not None and status_filter != 'All':
             context['selected_status'] = status_filter
             queryStr += f'&status={status_filter}'
@@ -58,18 +58,18 @@ class SubmissionsTable(TemplateView):
         # modifies the object fields for display, only modifies a subset of entries that will be displayed 
         # on the current page using offset and limit
         for s in submission_content[offset:offset + limit]:
-            s['status'] = title_case(s['status'])
-            s['outcome'] = title_case(s['outcome'])
+            s['status'] = title_case(s['status']) if s['status'] else None
+            s['outcome'] = title_case(s['outcome']) if s['outcome'] else None
             s['received_timestamp'] = parser.parse(s['received_timestamp']) if s['received_timestamp'] else None
             s['updated_at'] = parser.parse(s['updated_at']) if s['updated_at'] else None
             s['view_modal_content'] = [{
                 **t,
-                'outcome': title_case(t['outcome'])
+                'outcome': title_case(t['outcome']) if t['outcome'] else None
             } for t in (s['view_modal_content'] or [])]
 
 
         context['header'] = ['Received', 'File Name', ' ', 'Outcome', 'Status', 'Last Updated', 'Actions']
-        context['filter_options'] = ['All', 'In Process', 'Complete']
+        context['status_options'] = ['All', 'Complete', 'In Process']
         context['sort_options'] = {'newDate': 'Newest Received', 'oldDate': 'Oldest Received'}
 
         context['query_str'] = queryStr

--- a/apcd_cms/src/apps/utils/apcd_database.py
+++ b/apcd_cms/src/apps/utils/apcd_database.py
@@ -722,8 +722,7 @@ def create_other_exception(form, sub_data):
             requested_expiration_date,
             explanation_justification,
             status,
-            required_threshold
-        ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+        ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
         """
         values = (
             form["business-name"],

--- a/apcd_cms/src/apps/view_users/templates/view_users.html
+++ b/apcd_cms/src/apps/view_users/templates/view_users.html
@@ -28,8 +28,7 @@
           <option class="dropdown-text" {% if option == selected_org %}selected{% endif %}>{{ option }}</option>
         {% endfor %}
       </select>
-
-  {% if selected_status or selected_org %}
+      {% if selected_status != 'All' or selected_org != 'All' %}
         <button onclick="clearSelections()">Clear Options</button>
       {% endif %}
      </div>

--- a/apcd_cms/src/apps/view_users/views.py
+++ b/apcd_cms/src/apps/view_users/views.py
@@ -64,7 +64,7 @@ class ViewUsersTable(TemplateView):
                     'user_id': usr[1],
                     'user_email': usr[2],
                     'user_name': usr[3],
-                    'entity_name': usr[4] if usr[4] else "Not Applicable",
+                    'entity_name': usr[4] if usr[4] else 'None',
                     'created_at': usr[5],
                     'updated_at': usr[6],
                     'notes': usr[7],
@@ -99,15 +99,14 @@ class ViewUsersTable(TemplateView):
             org_name = user[4]
             if org_name not in context['filter_options']:  # prevent duplicates
                 context['filter_options'].append(user[4])
-            if org_name is None and 'Not Applicable' not in context['filter_options']:
-                context['filter_options'].append('Not Applicable')
+                context['filter_options'] = sorted(context['filter_options'],key=lambda x: (x != 'All', x is None, x if x is not None else ''))
 
         queryStr = ''
         status_filter = self.request.GET.get('status')
         org_filter = self.request.GET.get('org')
         role_filter = self.request.GET.get('role_name')
 
-        context['selected_status'] = None
+        context['selected_status'] = 'All'
         if status_filter is not None and status_filter !='All':
             context['selected_status'] = status_filter
             queryStr += f'&status={status_filter}'
@@ -117,7 +116,7 @@ class ViewUsersTable(TemplateView):
             context['selected_role'] = role_filter
             table_entries = table_filter(role_filter, table_entries, 'role_name', False)        
 
-        context['selected_org'] = None
+        context['selected_org'] = 'All'
         if org_filter is not None and org_filter != 'All':
             context['selected_org'] = org_filter
             queryStr += f'&org={org_filter}'

--- a/apcd_cms/src/taccsite_custom/apcd_cms/static/apcd_cms/css/table.css
+++ b/apcd_cms/src/taccsite_custom/apcd_cms/static/apcd_cms/css/table.css
@@ -124,7 +124,6 @@ table {
     width: 150px;
     appearance: none;
     -webkit-appearance: none;
-    box-sizing: border-box;
 
     background-image: url("data:image/svg+xml,%3Csvg id='tacc-arrows' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 130.34 292.4'%3E%3Cdefs%3E%3Cstyle%3E.arrow%7Bfill:%23484848;%7D%3C/style%3E%3C/defs%3E%3Cg id='tacc-arrows——root'%3E%3Cpath id='Path_3088' data-name='Path 3088' class='arrow' d='M82.24,96.17,148.09,0l64.45,96.17Z' transform='translate(-82.2)'/%3E%3Cpath id='Path_3089' data-name='Path 3089' class='arrow' d='M212.5,196.23,146.65,292.4,82.2,196.23Z' transform='translate(-82.2)'/%3E%3C/g%3E%3C/svg%3E");
     background-repeat: no-repeat;


### PR DESCRIPTION
## Overview

Checks for null for filter options for listings in admin listing tables and user submission table.


## Related
[WA-349](https://tacc-main.atlassian.net/browse/WA-349)

## Changes

…

## Testing

1. Checkout main then pull this branch
2. Go to each listing page and make sure they're listed alphabetically and sorted correctly.

- http://localhost:8000/submissions/list-submissions/
- http://localhost:8000/administration/list-registration-requests/
- http://localhost:8000/administration/view-users/
- http://localhost:8000/administration/list-exceptions/
- http://localhost:8000/administration/list-extensions/
- http://localhost:8000/administration/list-submissions/

3. Toggle filters and make sure they work correct (known race conditions if you change them too quickly before load)
4. Review code to check for consistency and null checking

## UI