### PR TITLE
hotfix/allow-zero-in-reg-forms

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file
+
+# architecture
+/.github/  @wesleyboar
+.gitignore @wesleyboar
+
+# projects
+#             simple customizations
+/*_assets/    @wesleyboar
+#             uses incomplete tup-cms circa 2023
+/demdata_cms/ @wesleyboar
+
+# docs
+/docs/ @wesleyboar
+/README.md @wesleyboar

--- a/apcd_cms/src/apps/registrations/templates/submission_form/registration_form_body.html
+++ b/apcd_cms/src/apps/registrations/templates/submission_form/registration_form_body.html
@@ -463,7 +463,7 @@
                         class="integerfield"
                         id="total_covered_lives_{{ent_no}}_{{r.reg_id}}"
                         inputmode="numeric"
-             ^(0|[1-9][0-9]*)$
+                        pattern="^(0|[1-9][0-9]*)$"
                         value="{% if not renew %}{{ entity.no_covered }}{% endif %}"
                     />
                     </div>
@@ -482,7 +482,7 @@
                         class="integerfield"
                         id="claims_encounters_volume_{{ent_no}}_{{r.reg_id}}"
                         inputmode="numeric"
-             ^(0|[1-9][0-9]*)$
+                        pattern="^(0|[1-9][0-9]*)$"
                         value="{% if not renew %}{{ entity.claim_and_enc_vol }}{% endif %}"
                     />
 
@@ -506,7 +506,7 @@
                         class="integerfield"
                         id="total_claims_value_{{ent_no}}_{{r.reg_id}}"
                         inputmode="numeric"
-             ^(0|[1-9][0-9]*)$
+                        pattern="^(0|[1-9][0-9]*)$"
                         value="{% if not renew %}{{ entity.claim_val }}{% endif %}"
                     />
                     </div>
@@ -760,7 +760,7 @@
                 class="integerfield"
                 id="total_covered_lives_1"
                 inputmode="numeric"
-     ^(0|[1-9][0-9]*)$
+                pattern="^(0|[1-9][0-9]*)$"
                 />
             </div>
 
@@ -778,7 +778,7 @@
                 class="integerfield"
                 id="claims_encounters_volume_1"
                 inputmode="numeric"
-     ^(0|[1-9][0-9]*)$
+                pattern="^(0|[1-9][0-9]*)$"
                 />
 
                 <div class="help-text">
@@ -801,7 +801,7 @@
                 class="integerfield"
                 id="total_claims_value_1"
                 inputmode="numeric"
-     ^(0|[1-9][0-9]*)$
+                pattern="^(0|[1-9][0-9]*)$"
                 />
             </div>
             {# Additional entities rendered here... #}

--- a/apcd_cms/src/apps/registrations/templates/submission_form/registration_form_body.html
+++ b/apcd_cms/src/apps/registrations/templates/submission_form/registration_form_body.html
@@ -463,7 +463,7 @@
                         class="integerfield"
                         id="total_covered_lives_{{ent_no}}_{{r.reg_id}}"
                         inputmode="numeric"
-                        pattern="^[1-9]+[0-9]*$"
+                        pattern="^[0-9]*$"
                         value="{% if not renew %}{{ entity.no_covered }}{% endif %}"
                     />
                     </div>
@@ -482,7 +482,7 @@
                         class="integerfield"
                         id="claims_encounters_volume_{{ent_no}}_{{r.reg_id}}"
                         inputmode="numeric"
-                        pattern="^[1-9]+[0-9]*$"
+                        pattern="^[0-9]*$"
                         value="{% if not renew %}{{ entity.claim_and_enc_vol }}{% endif %}"
                     />
 
@@ -506,7 +506,7 @@
                         class="integerfield"
                         id="total_claims_value_{{ent_no}}_{{r.reg_id}}"
                         inputmode="numeric"
-                        pattern="^(?=.*[1-9])[0-9]*[.]?[0-9]{1,2}$"
+                        pattern="^[0-9]*$"
                         value="{% if not renew %}{{ entity.claim_val }}{% endif %}"
                     />
                     </div>
@@ -760,7 +760,7 @@
                 class="integerfield"
                 id="total_covered_lives_1"
                 inputmode="numeric"
-                pattern="^[1-9]+[0-9]*$"
+                pattern="^[0-9]*$"
                 />
             </div>
 
@@ -778,7 +778,7 @@
                 class="integerfield"
                 id="claims_encounters_volume_1"
                 inputmode="numeric"
-                pattern="^[1-9]+[0-9]*$"
+                pattern="^[0-9]*$"
                 />
 
                 <div class="help-text">
@@ -801,7 +801,7 @@
                 class="integerfield"
                 id="total_claims_value_1"
                 inputmode="numeric"
-                pattern="^(?=.*[1-9])[0-9]*[.]?[0-9]{1,2}$"
+                pattern="^[0-9]*$"
                 />
             </div>
             {# Additional entities rendered here... #}

--- a/apcd_cms/src/apps/registrations/templates/submission_form/registration_form_body.html
+++ b/apcd_cms/src/apps/registrations/templates/submission_form/registration_form_body.html
@@ -506,7 +506,7 @@
                         class="integerfield"
                         id="total_claims_value_{{ent_no}}_{{r.reg_id}}"
                         inputmode="numeric"
-                        pattern="^(0|[1-9][0-9]*)$"
+                        pattern="^(0|[1-9][0-9]*)(\.[0-9]{1,2})?$"
                         value="{% if not renew %}{{ entity.claim_val }}{% endif %}"
                     />
                     </div>
@@ -801,7 +801,7 @@
                 class="integerfield"
                 id="total_claims_value_1"
                 inputmode="numeric"
-                pattern="^(0|[1-9][0-9]*)$"
+                pattern="^(0|[1-9][0-9]*)(\.[0-9]{1,2})?$"
                 />
             </div>
             {# Additional entities rendered here... #}

--- a/apcd_cms/src/apps/registrations/templates/submission_form/registration_form_body.html
+++ b/apcd_cms/src/apps/registrations/templates/submission_form/registration_form_body.html
@@ -463,7 +463,7 @@
                         class="integerfield"
                         id="total_covered_lives_{{ent_no}}_{{r.reg_id}}"
                         inputmode="numeric"
-                        pattern="^[0-9]*$"
+             ^(0|[1-9][0-9]*)$
                         value="{% if not renew %}{{ entity.no_covered }}{% endif %}"
                     />
                     </div>
@@ -482,7 +482,7 @@
                         class="integerfield"
                         id="claims_encounters_volume_{{ent_no}}_{{r.reg_id}}"
                         inputmode="numeric"
-                        pattern="^[0-9]*$"
+             ^(0|[1-9][0-9]*)$
                         value="{% if not renew %}{{ entity.claim_and_enc_vol }}{% endif %}"
                     />
 
@@ -506,7 +506,7 @@
                         class="integerfield"
                         id="total_claims_value_{{ent_no}}_{{r.reg_id}}"
                         inputmode="numeric"
-                        pattern="^[0-9]*$"
+             ^(0|[1-9][0-9]*)$
                         value="{% if not renew %}{{ entity.claim_val }}{% endif %}"
                     />
                     </div>
@@ -760,7 +760,7 @@
                 class="integerfield"
                 id="total_covered_lives_1"
                 inputmode="numeric"
-                pattern="^[0-9]*$"
+     ^(0|[1-9][0-9]*)$
                 />
             </div>
 
@@ -778,7 +778,7 @@
                 class="integerfield"
                 id="claims_encounters_volume_1"
                 inputmode="numeric"
-                pattern="^[0-9]*$"
+     ^(0|[1-9][0-9]*)$
                 />
 
                 <div class="help-text">
@@ -801,7 +801,7 @@
                 class="integerfield"
                 id="total_claims_value_1"
                 inputmode="numeric"
-                pattern="^[0-9]*$"
+     ^(0|[1-9][0-9]*)$
                 />
             </div>
             {# Additional entities rendered here... #}

--- a/apcd_cms/src/apps/registrations/templates/submission_form/registration_form_scripts.html
+++ b/apcd_cms/src/apps/registrations/templates/submission_form/registration_form_scripts.html
@@ -316,7 +316,7 @@
             class="integerfield"
             id="total_covered_lives_${entities}${reg_id_substr}"
             inputmode="numeric"
-            pattern="^[0-9]*$"
+ ^(0|[1-9][0-9]*)$
           />
           <div id="help-text-total_covered_lives_${entities}" class="help-text">
           </div>
@@ -333,7 +333,7 @@
             class="integerfield"
             id="claims_encounters_volume_${entities}${reg_id_substr}"
             inputmode="numeric"
-            pattern="^[0-9]*$"
+ ^(0|[1-9][0-9]*)$
           />
           <div id="help-text-claims_encounters_volume_${entities}" class="help-text">
             Enter a whole number.
@@ -352,7 +352,7 @@
             class="integerfield"
             id="total_claims_value_${entities}${reg_id_substr}"
             inputmode="numeric"
-            pattern="^[0-9]*$"
+ ^(0|[1-9][0-9]*)$
           />
           <div id="help-text-total_claims_value_${entities}" class="help-text">
           </div>

--- a/apcd_cms/src/apps/registrations/templates/submission_form/registration_form_scripts.html
+++ b/apcd_cms/src/apps/registrations/templates/submission_form/registration_form_scripts.html
@@ -316,7 +316,7 @@
             class="integerfield"
             id="total_covered_lives_${entities}${reg_id_substr}"
             inputmode="numeric"
-            pattern="^[1-9]+[0-9]*$"
+            pattern="^[0-9]*$"
           />
           <div id="help-text-total_covered_lives_${entities}" class="help-text">
           </div>
@@ -333,7 +333,7 @@
             class="integerfield"
             id="claims_encounters_volume_${entities}${reg_id_substr}"
             inputmode="numeric"
-            pattern="^[1-9]+[0-9]*$"
+            pattern="^[0-9]*$"
           />
           <div id="help-text-claims_encounters_volume_${entities}" class="help-text">
             Enter a whole number.
@@ -352,7 +352,7 @@
             class="integerfield"
             id="total_claims_value_${entities}${reg_id_substr}"
             inputmode="numeric"
-            pattern="^(?=.*[1-9])[0-9]*[.]?[0-9]{1,2}$"
+            pattern="^[0-9]*$"
           />
           <div id="help-text-total_claims_value_${entities}" class="help-text">
           </div>

--- a/apcd_cms/src/apps/registrations/templates/submission_form/registration_form_scripts.html
+++ b/apcd_cms/src/apps/registrations/templates/submission_form/registration_form_scripts.html
@@ -316,7 +316,7 @@
             class="integerfield"
             id="total_covered_lives_${entities}${reg_id_substr}"
             inputmode="numeric"
- ^(0|[1-9][0-9]*)$
+            pattern="^(0|[1-9][0-9]*)$"
           />
           <div id="help-text-total_covered_lives_${entities}" class="help-text">
           </div>
@@ -333,7 +333,7 @@
             class="integerfield"
             id="claims_encounters_volume_${entities}${reg_id_substr}"
             inputmode="numeric"
- ^(0|[1-9][0-9]*)$
+            pattern="^(0|[1-9][0-9]*)$"
           />
           <div id="help-text-claims_encounters_volume_${entities}" class="help-text">
             Enter a whole number.
@@ -352,7 +352,7 @@
             class="integerfield"
             id="total_claims_value_${entities}${reg_id_substr}"
             inputmode="numeric"
- ^(0|[1-9][0-9]*)$
+            pattern="^(0|[1-9][0-9]*)$"
           />
           <div id="help-text-total_claims_value_${entities}" class="help-text">
           </div>

--- a/apcd_cms/src/apps/registrations/templates/submission_form/registration_form_scripts.html
+++ b/apcd_cms/src/apps/registrations/templates/submission_form/registration_form_scripts.html
@@ -352,7 +352,7 @@
             class="integerfield"
             id="total_claims_value_${entities}${reg_id_substr}"
             inputmode="numeric"
-            pattern="^(0|[1-9][0-9]*)$"
+            pattern="^(0|[1-9][0-9]*)(\.[0-9]{1,2})?$"
           />
           <div id="help-text-total_claims_value_${entities}" class="help-text">
           </div>


### PR DESCRIPTION
## Overview

Allow registration to allow zero in some numeric input fields

## Related

<!--
- [WP-123](https://tacc-main.atlassian.net/browse/WP-123)
- requires https://github.com/TACC/Core-CMS/pull/117
-->…

## Changes

Changed pattern in registration form so that the following allows 0 as an input

- total_covered_lives
- claims_encounters_volume
- total_claims_value


## Testing

1. Go to [http://localhost:8000/register/request-to-submit/](http://localhost:8000/register/request-to-submit/)
2. Input zero for the following fields in 2 different entity forms
    - total_covered_lives
    - claims_encounters_volume
    - total_claims_value
3. Go to [http://localhost:8000/administration/list-registration-requests/](http://localhost:8000/administration/list-registration-requests/) and select a test entry to edit
4. Input zero for the following fields in two different entities
    - total_covered_lives
    - claims_encounters_volume
    - total_claims_value
## UI

…

<!--
## Notes

…
-->
