### PR TITLE
task/WP-712-Create-useEntity-Hook

### DIFF
--- a/apcd-cms/src/apps/common_api/apps.py
+++ b/apcd-cms/src/apps/common_api/apps.py
@@ -1,0 +1,4 @@
+from django.apps import AppConfig
+
+class common_api(AppConfig):
+    name = 'apps.common_api'

--- a/apcd-cms/src/apps/common_api/urls.py
+++ b/apcd-cms/src/apps/common_api/urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+from apps.common_api.views import EntitiesView
+from . import views
+
+app_name = 'common_api'
+urlpatterns = [
+    path('entities/', EntitiesView.as_view(), name='entities_api')
+]

--- a/apcd-cms/src/apps/common_api/views.py
+++ b/apcd-cms/src/apps/common_api/views.py
@@ -1,0 +1,44 @@
+from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
+from django.template import loader
+from django.views.generic import TemplateView
+from apps.utils import apcd_database
+from apps.utils.apcd_groups import has_apcd_group
+from apps.utils.utils import title_case
+import logging
+import json
+
+logger = logging.getLogger(__name__)
+
+class EntitiesView(TemplateView):
+    def get(self, request, *args, **kwargs):
+        submitters = apcd_database.get_submitter_info(request.user.username)
+
+        submitter_info_json = self.get_submitter_info_json(submitters)
+
+        context = {**submitter_info_json}
+        return JsonResponse({'response': context})
+
+    def dispatch(self, request, *args, **kwargs):
+        if not request.user.is_authenticated or not has_apcd_group(request.user):
+            return HttpResponseRedirect('/')
+        return super(EntitiesView, self).dispatch(request, *args, **kwargs)
+
+    
+    def get_submitter_info_json(self, submitters):
+        context = {}
+
+        def _set_submitter(sub):
+            return {
+                "submitter_id": sub[0],
+                "submitter_code": sub[1],
+                "payor_code": sub[2],
+                "user_name": sub[3],
+                "entity_name": title_case(sub[4])
+            }
+
+        context["submitters"] = []
+
+        for submitter in submitters:
+            context["submitters"].append(_set_submitter(submitter))
+
+        return context

--- a/apcd-cms/src/client/src/hooks/entities/index.ts
+++ b/apcd-cms/src/client/src/hooks/entities/index.ts
@@ -1,0 +1,14 @@
+export type SubmitterEntityData = {
+  submitters: Entities[];
+}
+
+export type Entities = {
+    submitter_id: number; 
+    submitter_code: string; 
+    payor_code: number; 
+    user_id: string; 
+    entity_name: string;
+  };
+  
+  
+  export { useEntities } from './useEntities';

--- a/apcd-cms/src/client/src/hooks/entities/useEntities.ts
+++ b/apcd-cms/src/client/src/hooks/entities/useEntities.ts
@@ -1,0 +1,20 @@
+import { useQuery, UseQueryResult } from 'react-query';
+import { fetchUtil } from 'utils/fetchUtil';
+import { SubmitterEntityData } from '.';
+
+const getEntities = async () => {
+  const url = `common_api/entities/`;
+  const response = await fetchUtil({
+    url,
+  });
+  return response.response;
+};
+
+export const useEntities = (
+): UseQueryResult<SubmitterEntityData> => {
+  const query = useQuery(['entities'], () =>
+    getEntities()
+  ) as UseQueryResult<SubmitterEntityData>;
+
+  return { ...query };
+};

--- a/apcd-cms/src/taccsite_cms/custom_app_settings.py
+++ b/apcd-cms/src/taccsite_cms/custom_app_settings.py
@@ -1,4 +1,4 @@
-CUSTOM_APPS = ['apps.admin_regis_table', 'apps.apcd_login', 'apps.registrations', 'apps.submissions', 'apps.exception', 'apps.admin_submissions', 'apps.admin_extension', 'apps.admin_exception', 'apps.extension', 'apps.submitter_renewals_listing', 'apps.view_users', 'apps.components.paginator', 'apps.utils']
+CUSTOM_APPS = ['apps.admin_regis_table', 'apps.apcd_login', 'apps.registrations', 'apps.submissions', 'apps.exception', 'apps.admin_submissions', 'apps.admin_extension', 'apps.admin_exception', 'apps.extension', 'apps.submitter_renewals_listing', 'apps.view_users', 'apps.components.paginator', 'apps.utils', 'apps.common_api']
 CUSTOM_MIDDLEWARE = []
-STATICFILES_DIRS = ('taccsite_custom/apcd_cms', 'apps/admin_regis_table', 'apps/submissions', 'apps/exception', 'apps/extension', 'apps/submitter_renewals_listing', 'apps/view_users', 'apps/components/paginator', 'apps/utils', 'client/dist')
+STATICFILES_DIRS = ('taccsite_custom/apcd_cms', 'apps/admin_regis_table', 'apps/submissions', 'apps/exception', 'apps/extension', 'apps/submitter_renewals_listing', 'apps/view_users', 'apps/components/paginator', 'apps/utils', 'client/dist', 'apps/common_api')
 

--- a/apcd-cms/src/taccsite_cms/urls_custom.py
+++ b/apcd-cms/src/taccsite_cms/urls_custom.py
@@ -11,5 +11,6 @@ custom_urls = [
     path('register/', include('apps.submitter_renewals_listing.urls', namespace='submitter_regis_table')),
     path('submissions/', include('apps.extension.urls', namespace='extension')),
     path('submissions/', include('apps.exception.urls', namespace='exception')),
-    path('submissions/', include('apps.submissions.urls', namespace='submissions'))
+    path('submissions/', include('apps.submissions.urls', namespace='submissions')),
+    path('common_api/', include('apps.common_api.urls', namespace='common_api'))
 ]


### PR DESCRIPTION
## Overview

Several forms make a call to get the submitter information to both submit the form and to dynamically populate different fields. Create a hook and app that implements the hook to fetch the entity and submitter information based on the logged in user.

## Related

- [WP-712](https://tacc-main.atlassian.net/browse/WP-712)

## Changes

- Creates common_api app with EntityView class
- Creates useEntity hook to fetch submitter and entity information for the logged in user

## Testing

1. Go to [http://localhost:8000/common_api/entities/](http://localhost:8000/common_api/entities/) 
2. Check that all your entities are listed here like it is in the database. You may have more than one submitter object if you're associated with more than one entity.


<!--
## Notes

…
-->
