### PR TITLE
Bug/WP-711: Do not use hardcoded org names for user list

### DIFF
--- a/apcd-cms/src/apps/view_users/views.py
+++ b/apcd-cms/src/apps/view_users/views.py
@@ -53,7 +53,9 @@ class ViewUsersTable(TemplateView):
     def get_options(self, request):
         try:
             status_options = ['All', 'Active', 'Inactive']
-            org_options = ['All', 'TEST Meritan Health', 'UTHealth - SPH CHCD: APCD', 'None', 'Not Applicable']
+            user_content = get_users()
+            user_list = sorted(list(set(user[4] if user[4] else 'None' for user in user_content)))
+            org_options = ['All'] + user_list
             return JsonResponse({
                 'status_options': status_options,
                 'org_options': org_options
@@ -106,7 +108,7 @@ class ViewUsersTable(TemplateView):
                 'user_id': usr[1],
                 'user_email': usr[2],
                 'user_name': usr[3],
-                'entity_name': usr[4] if usr[4] else "Not Applicable",
+                'entity_name': usr[4] if usr[4] else 'None',
                 'created_at': usr[5],
                 'updated_at': usr[6],
                 'notes': usr[7],
@@ -129,8 +131,6 @@ class ViewUsersTable(TemplateView):
         context = {
             'header': ['User ID', 'Name', 'Entity Organization', 'Role', 'Status', 'User Number', 'See More'],
             'page': [],
-            'status_options': ['All', 'Active', 'Inactive'],
-            'org_options': ['All', 'TEST Meritan Health', 'UTHealth - SPH CHCD: APCD', 'None', 'Not Applicable'],
             'selected_status': 'All',
             'query_str': '',
             'pagination_url_namespaces': 'administration:view_users'


### PR DESCRIPTION
## Overview
The list of org names is derived from actual data.

## Related
- [WP-711](https://tacc-main.atlassian.net/browse/WP-711)

## Changes

* Adjust the `view-users/api/options`  to read from DB.
* Since option api is available, remove the hard coded list from actual data.


## Testing

1.http://localhost:8000/administration/view-users/?org=None
