### PR TITLE
[APCD][React] Use dynamic data in business name field in extensions. Use relative links for tickets

### DIFF
--- a/apcd-cms/src/client/src/components/Submitter/Exceptions/ExceptionForm.tsx
+++ b/apcd-cms/src/client/src/components/Submitter/Exceptions/ExceptionForm.tsx
@@ -7,6 +7,8 @@ import { Entities, useEntities } from 'hooks/entities';
 import styles from './ExceptionForm.module.css';
 import LoadingSpinner from 'core-components/LoadingSpinner';
 import SectionMessage from 'core-components/SectionMessage';
+import { Link, useLocation } from 'react-router-dom';
+
 
 export const ExceptionForm: React.FC<{ index: number }> = ({ index }) => {
   const [cdlData, setCdlData] = useState<cdlObject>();
@@ -83,9 +85,9 @@ export const ExceptionForm: React.FC<{ index: number }> = ({ index }) => {
         {entitiesError && (
           <SectionMessage type="error">
             There was an error finding your associated businesses.{' '}
-            <a href="https://txapcd.org/workbench/dashboard/tickets/create">
+            <Link to="/workbench/dashboard/tickets/create" className="wb-link">
               Please submit a ticket.
-            </a>
+            </Link>
           </SectionMessage>
         )}
       </FormGroup>

--- a/apcd-cms/src/client/src/components/Submitter/Extensions/ExtensionFormInfo.tsx
+++ b/apcd-cms/src/client/src/components/Submitter/Extensions/ExtensionFormInfo.tsx
@@ -2,8 +2,14 @@ import React from 'react';
 import { Field, ErrorMessage, FieldArray } from 'formik';
 import { FormGroup, Label, Row, Col, FormFeedback } from 'reactstrap';
 import styles from './ExtensionsForm.module.css';
+import { SubmitterEntityData, Entities } from 'hooks/entities';
+import SectionMessage from 'core-components/SectionMessage';
+import { Link, useLocation } from 'react-router-dom';
 
-const ExtensionFormInfo: React.FC<{ index: number }> = ({ index }) => {
+const ExtensionFormInfo: React.FC<{
+  index: number;
+  submitterData: SubmitterEntityData | undefined;
+}> = ({ index, submitterData }) => {
   return (
     <div>
       <h4>Extension Information {index + 1}</h4>
@@ -13,21 +19,38 @@ const ExtensionFormInfo: React.FC<{ index: number }> = ({ index }) => {
         <Label htmlFor={`extensions.${index}.businessName`}>
           Business Name <span className={styles.requiredText}>(required)</span>
         </Label>
-        <Field
-          as="select"
-          name={`extensions.${index}.businessName`}
-          id={`extensions.${index}.businessName`}
-          className="form-control"
-        >
-          <option value="">Select Business Name</option>
-          <option value="Test Meritan Health">
-            Test Meritan Health - Payor Code: 10000003
-          </option>
-        </Field>
-        <ErrorMessage
-          name={`extensions.${index}.businessName`}
-          component={FormFeedback}
-        />
+        {submitterData && (
+          <>
+            <Field
+              as="select"
+              name={`extensions.${index}.businessName`}
+              id={`extensions.${index}.businessName`}
+              className="form-control"
+            >
+              <option value="">Select Business Name</option>
+              {submitterData?.submitters?.map((submitter: Entities) => (
+                <option
+                  value={submitter.submitter_id}
+                  key={submitter.submitter_id}
+                >
+                  {submitter.entity_name} - Payor Code: {submitter.payor_code}
+                </option>
+              ))}
+            </Field>
+            <ErrorMessage
+              name={`extensions.${index}.businessName`}
+              component={FormFeedback}
+            />
+          </>
+        )}
+        {!submitterData && (
+          <SectionMessage type="error">
+            There was an error finding your associated businesses.{' '}
+            <Link to="/workbench/dashboard/tickets/create" className="wb-link">
+              Please submit a ticket.
+            </Link>
+          </SectionMessage>
+        )}
       </FormGroup>
 
       <FormGroup>

--- a/apcd-cms/src/client/src/components/Submitter/Extensions/ExtensionsForm.module.css
+++ b/apcd-cms/src/client/src/components/Submitter/Extensions/ExtensionsForm.module.css
@@ -10,3 +10,11 @@
 .dateInputContainer {
   display: inline-block;
 }
+
+.loadingField {
+  display: inline-flex;
+  justify-content: flex-start;
+  align-items: center;
+  height: 100%;
+  width: 100%;
+}

--- a/apcd-cms/src/client/src/components/Submitter/Extensions/ExtensionsForm.tsx
+++ b/apcd-cms/src/client/src/components/Submitter/Extensions/ExtensionsForm.tsx
@@ -4,6 +4,8 @@ import * as Yup from 'yup';
 import { Button, Col, FormGroup, Label, Row, FormFeedback } from 'reactstrap';
 import styles from './ExtensionsForm.module.css';
 import ExtensionFormInfo from './ExtensionFormInfo';
+import { useEntities } from 'hooks/entities';
+import LoadingSpinner from 'core-components/LoadingSpinner';
 
 const validationSchema = Yup.object().shape({
   extensions: Yup.array().of(
@@ -66,6 +68,20 @@ export const ExtensionRequestForm: React.FC = () => {
     console.log('Form values:', values);
   };
 
+  const {
+    data: submitterData,
+    isLoading: entitiesLoading,
+    isError: entitiesError,
+  } = useEntities();
+
+  if (entitiesLoading) {
+    return (
+      <div className="loadingField">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
   return (
     <>
       <h1>Request an Extension</h1>
@@ -92,7 +108,11 @@ export const ExtensionRequestForm: React.FC = () => {
         {({ values, isSubmitting, setFieldValue }) => (
           <Form>
             {values.extensions.map((extension, index) => (
-              <ExtensionFormInfo key={index} index={index} />
+              <ExtensionFormInfo
+                key={index}
+                index={index}
+                submitterData={submitterData}
+              />
             ))}
             <Button
               className="c-button c-button--primary"


### PR DESCRIPTION
## Overview

* Use entities to load dynamic data for Extensions

## Related

[WP-720](https://tacc-main.atlassian.net/browse/WP-720)
## Changes
1) Dynamic entities list. useEntities provides it.
2) instead of static ticket create link, use relative links.

## Testing

1. Check the form loading for dynamic business names: http://localhost:8000/submissions/extension-request/
2. in extension form code, set submitterData={undefined} and see the error handling in UI

## UI

![Screenshot 2024-10-25 at 6 06 14 PM](https://github.com/user-attachments/assets/4d58430f-df55-4e96-8e9b-03894dcb8bc1)

Error handling: 
![Screenshot 2024-10-25 at 6 06 59 PM](https://github.com/user-attachments/assets/385c3e65-4938-4b80-b2de-0b9610c8828b)

## Notes:
* Pending: submit hook up
