### PR TITLE
WP-738 Hook up Edit Registration and Renew Registration to Registration Form.

### DIFF
--- a/apcd-cms/src/apps/admin_regis_table/urls.py
+++ b/apcd-cms/src/apps/admin_regis_table/urls.py
@@ -9,4 +9,7 @@ urlpatterns = [
     path(r'list-registration-requests/api/?status=(?P<status>)/', RegistrationsTable.as_view(), name='admin_regis_table_api'),
     path(r'list-registration-requests/api/?org=(?P<org>)/', RegistrationsTable.as_view(), name='admin_regis_table_api'),
     path(r'list-registration-requests/api/?status=(?P<status>)&org=(?P<org>)/', RegistrationsTable.as_view(), name='admin_regis_table_api'),
+    path(r'list-registration-requests/api/?reg_id=(?P<reg_id>)/', RegistrationsTable.as_view(), name='admin_regis_table_api'),
+    path(r'request-to-submit/api/<int:reg_id>/', RegistrationsTable.as_view(), name='admin_regis_update_api'),
+
 ]

--- a/apcd-cms/src/apps/submitter_renewals_listing/urls.py
+++ b/apcd-cms/src/apps/submitter_renewals_listing/urls.py
@@ -9,4 +9,5 @@ urlpatterns = [
     path(r'list-registration-requests/api/?status=(?P<status>)/', SubmittersTable.as_view(), name='submitter_regis_table_api'),
     path(r'list-registration-requests/api/?org=(?P<org>)/', SubmittersTable.as_view(), name='submitter_regis_table_api'),
     path(r'list-registration-requests/api/?status=(?P<status>)&org=(?P<org>)/', SubmittersTable.as_view(), name='submitter_regis_table_api'),
+    path(r'list-registration-requests/api/?reg_id=(?P<reg_id>)/', SubmittersTable.as_view(), name='submitter_regis_table_api'),
 ]

--- a/apcd-cms/src/apps/utils/apcd_database.py
+++ b/apcd-cms/src/apps/utils/apcd_database.py
@@ -411,7 +411,9 @@ def update_registration_entity(entity, reg_id):
     conn = None
     values = ()
     try:
-        if entity['entity_id'] < 0:
+        # if entity_id is not there or is less than 0, then 
+        # it is a new entity.
+        if 'entity_id' not in entity or entity['entity_id'] < 0:
             return create_registration_entity(entity, reg_id)
         values = (
             float(entity['total_claims_value']),
@@ -598,7 +600,9 @@ def update_registration_contact(contact, reg_id):
     conn = None
     values = ()
     try:
-        if contact['contact_id'] < 0:
+        # if contact_id is not there or is less than 0, then 
+        # it is a new contact.
+        if 'contact_id' not in contact or contact['contact_id'] < 0:
             return create_registration_contact(contact, reg_id)
 
         values = (

--- a/apcd-cms/src/apps/utils/registrations_data_formatting.py
+++ b/apcd-cms/src/apps/utils/registrations_data_formatting.py
@@ -79,7 +79,7 @@ def _set_registration(reg, reg_ent, reg_cont):
         'city': reg[7],
         'state': reg[8],
         'address': reg[6],
-        'zip': reg[9],
+        'zip': reg[9].strip(),
         'for_self': reg[2],
         'year': reg[10],
         'entities': [_set_entities(ent) for ent in reg_ent],

--- a/apcd-cms/src/apps/utils/registrations_data_formatting.py
+++ b/apcd-cms/src/apps/utils/registrations_data_formatting.py
@@ -1,22 +1,23 @@
-def _set_registration(reg, reg_ents, reg_conts):
-    org_types = {
-            'carrier': 'Insurance Carrier',
-            'tpa_aso': 'Plan Administrator¹ (TPA/ASO)',
-            'pbm': 'Pharmacy Benefit Manager (PBM)'
-    }
+def _get_orgtypes():
     return {
-            'biz_name': reg[5],
-            'type': org_types[reg[4]] if (reg[4] and reg[4] in org_types.keys()) else None,
-            'location': '{city}, {state}'.format
-                (
-                    city=reg[7],
-                    state=reg[8]
-                ),
-            'reg_status': reg[3].title() if reg[3] else None,
-            'reg_id': reg[0],
-            'year': reg[10],
-            'view_modal_content': _set_modal_content(reg, reg_ents, reg_conts, org_types)
-        }
+        'carrier': 'Insurance Carrier',
+        'tpa_aso': 'Plan Administrator¹ (TPA/ASO)',
+        'pbm': 'Pharmacy Benefit Manager (PBM)',
+    }
+
+
+def _set_registration_for_listing(reg):
+    org_types = _get_orgtypes()
+    return {
+        'biz_name': reg[5],
+        'type': org_types[reg[4]] if (reg[4] and reg[4] in org_types.keys()) else None,
+        'location': '{city}, {state}'.format(city=reg[7], state=reg[8]),
+        'reg_status': reg[3].title() if reg[3] else None,
+        'reg_id': reg[0],
+        'year': reg[10],
+    }
+
+
 def _set_entities(reg_ent):
     return {
         'claim_val': reg_ent[0],
@@ -40,6 +41,8 @@ def _set_entities(reg_ent):
             "Dental": reg_ent[16]
         }
     }
+
+
 def _set_contacts(reg_cont):
 
     def format_phone_number(num):
@@ -65,8 +68,12 @@ def _set_contacts(reg_cont):
         'phone': format_phone_number(reg_cont[5]) if reg_cont[5] else None,
         'email': reg_cont[6],
     }
-def _set_modal_content(reg, reg_ent, reg_cont, org_types):
+
+
+def _set_registration(reg, reg_ent, reg_cont):
+    org_types = _get_orgtypes()
     return {
+        'reg_id': reg[0],
         'biz_name': reg[5],
         'type': org_types[reg[4]] if (reg[4] and reg[4] in org_types.keys()) else None,
         'city': reg[7],

--- a/apcd-cms/src/client/src/components/Admin/Registrations/AdminRegistrations.tsx
+++ b/apcd-cms/src/client/src/components/Admin/Registrations/AdminRegistrations.tsx
@@ -3,5 +3,7 @@ import { RegistrationList } from 'apcd-components/Registrations/RegistrationList
 import { useAdminRegistrations } from 'hooks/registrations';
 
 export const AdminRegistrations: React.FC = () => {
-  return <RegistrationList useDataHook={useAdminRegistrations} />;
+  return (
+    <RegistrationList isAdmin={true} useDataHook={useAdminRegistrations} />
+  );
 };

--- a/apcd-cms/src/client/src/components/Forms/Registrations/index.ts
+++ b/apcd-cms/src/client/src/components/Forms/Registrations/index.ts
@@ -1,4 +1,2 @@
 // index.ts
-import { RegistrationForm } from './RegistrationForm';
-
-export { RegistrationForm };
+export * from './RegistrationForm';

--- a/apcd-cms/src/client/src/components/Registrations/EditRegistrationModal/EditRegistrationModal.tsx
+++ b/apcd-cms/src/client/src/components/Registrations/EditRegistrationModal/EditRegistrationModal.tsx
@@ -1,13 +1,25 @@
 import React from 'react';
 import { Modal, ModalBody } from 'reactstrap';
-import { RegistrationRow } from 'hooks/registrations';
+import {
+  transformToRegistrationFormValues,
+  RegistrationFormValues,
+  useAdminRegistration,
+} from 'hooks/registrations';
+import { RegistrationForm } from 'apcd-components/Forms/Registrations';
 
 const EditRegistrationModal: React.FC<{
-  registration: RegistrationRow;
+  reg_id: number;
   isVisible: boolean;
   onClose: () => void;
-}> = ({ registration, isVisible, onClose }) => {
-  const { reg_id } = registration;
+}> = ({ reg_id, isVisible, onClose }) => {
+  const { data, isLoading, error } = useAdminRegistration(reg_id);
+
+  if (isLoading) return <div>Loading...</div>;
+  if (error) return <div>Error: {error}</div>;
+  if (!data) return <div>No data Found.</div>;
+
+  const form_values: RegistrationFormValues =
+    transformToRegistrationFormValues(data);
 
   return (
     <Modal
@@ -17,17 +29,18 @@ const EditRegistrationModal: React.FC<{
       size="lg"
     >
       <div className="modal-header">
-        <h4 className="modal-title text-capitalize">
-          Edit Registration {reg_id}
-        </h4>
+        <h4 className="modal-title text-capitalize">Edit Registration</h4>
         <button type="button" className="close" onClick={onClose}>
           <span aria-hidden="true">&#xe912;</span>
         </button>
       </div>
       <ModalBody className="modal-body">
-        <div>
-          <h4>To be implemented</h4>
-        </div>
+        <RegistrationForm
+          isEdit={true}
+          inputValues={form_values}
+          isModal={true}
+          onSuccessCallback={onClose}
+        />
       </ModalBody>
     </Modal>
   );

--- a/apcd-cms/src/client/src/components/Registrations/RegistrationList/RegistrationList.tsx
+++ b/apcd-cms/src/client/src/components/Registrations/RegistrationList/RegistrationList.tsx
@@ -8,7 +8,7 @@ import styles from './RegistrationList.module.css';
 
 export const RegistrationList: React.FC<{
   useDataHook: any;
-  isAdmin: boolean;
+  isAdmin?: boolean;
 }> = ({ useDataHook, isAdmin = false }) => {
   const [status, setStatus] = useState('All');
   const [org, setOrg] = useState('All');

--- a/apcd-cms/src/client/src/components/Registrations/RegistrationList/RegistrationList.tsx
+++ b/apcd-cms/src/client/src/components/Registrations/RegistrationList/RegistrationList.tsx
@@ -6,9 +6,10 @@ import ViewRegistrationModal from 'apcd-components/Registrations/ViewRegistratio
 import EditRegistrationModal from 'apcd-components/Registrations/EditRegistrationModal/EditRegistrationModal';
 import styles from './RegistrationList.module.css';
 
-export const RegistrationList: React.FC<{ useDataHook: any }> = ({
-  useDataHook,
-}) => {
+export const RegistrationList: React.FC<{
+  useDataHook: any;
+  isAdmin: boolean;
+}> = ({ useDataHook, isAdmin = false }) => {
   const [status, setStatus] = useState('All');
   const [org, setOrg] = useState('All');
   const [page, setPage] = useState(1);
@@ -53,7 +54,7 @@ export const RegistrationList: React.FC<{ useDataHook: any }> = ({
 
   const openAction = (
     event: React.ChangeEvent<HTMLSelectElement>,
-    reg_id: string
+    reg_id: number
   ) => {
     const actionsDropdown = event.target;
     const selectedOption = actionsDropdown.value;
@@ -64,6 +65,13 @@ export const RegistrationList: React.FC<{ useDataHook: any }> = ({
       setIsViewModalOpen(true);
     } else if (selectedOption == 'editRegistration') {
       setIsEditModalOpen(true);
+    } else if (selectedOption == 'renewRegistration') {
+      var xhr, url;
+      url = `/register/request-to-submit/?reg_id=${reg_id}`;
+      xhr = new XMLHttpRequest();
+      xhr.open('GET', url);
+      xhr.send();
+      window.location.href = url;
     }
     actionsDropdown.selectedIndex = 0;
   };
@@ -137,7 +145,13 @@ export const RegistrationList: React.FC<{ useDataHook: any }> = ({
                 >
                   <option value="">Select Action</option>
                   <option value="viewRegistration">View Record</option>
-                  <option value="editRegistration">Edit Record</option>
+                  {isAdmin ? (
+                    <option value="editRegistration">Edit Record</option>
+                  ) : (
+                    <option value="renewRegistration">
+                      Renew Registration
+                    </option>
+                  )}
                 </select>
               </td>
             </tr>
@@ -154,12 +168,12 @@ export const RegistrationList: React.FC<{ useDataHook: any }> = ({
       {selectedRegistration && (
         <>
           <ViewRegistrationModal
-            registration={selectedRegistration}
+            reg_id={selectedRegistration.reg_id}
             isVisible={isViewModalOpen}
             onClose={() => setIsViewModalOpen(false)}
           />
           <EditRegistrationModal
-            registration={selectedRegistration}
+            reg_id={selectedRegistration.reg_id}
             isVisible={isEditModalOpen}
             onClose={() => setIsEditModalOpen(false)}
           />

--- a/apcd-cms/src/client/src/components/Registrations/ViewRegistrationModal/ViewRegistrationModal.tsx
+++ b/apcd-cms/src/client/src/components/Registrations/ViewRegistrationModal/ViewRegistrationModal.tsx
@@ -1,14 +1,18 @@
 import React from 'react';
 import { Modal, ModalBody } from 'reactstrap';
-import { RegistrationRow } from 'hooks/registrations';
+import { RegistrationContent, useAdminRegistration } from 'hooks/registrations';
 import styles from './ViewRegistrationModal.module.css';
 
 const ViewRegistrationModal: React.FC<{
-  registration: RegistrationRow;
+  reg_id: number;
   isVisible: boolean;
   onClose: () => void;
-}> = ({ registration, isVisible, onClose }) => {
-  const { view_modal_content } = registration;
+}> = ({ reg_id, isVisible, onClose }) => {
+  const { data, isLoading, error } = useAdminRegistration(reg_id);
+
+  if (isLoading) return <div>Loading...</div>;
+  if (error) return <div>Error: {error}</div>;
+  if (!data) return <div>No data Found.</div>;
 
   const {
     for_self,
@@ -21,7 +25,7 @@ const ViewRegistrationModal: React.FC<{
     zip,
     entities,
     contacts,
-  } = view_modal_content;
+  } = data;
 
   return (
     <Modal

--- a/apcd-cms/src/client/src/hooks/registrations/index.ts
+++ b/apcd-cms/src/client/src/hooks/registrations/index.ts
@@ -3,15 +3,15 @@ export type RegFormData = {
   renew: boolean;
 };
 
-export { useRegFormData } from './useForm';
+export { useRegFormData, usePostRegistration } from './useForm';
 
 export type StringMap = {
-  [key: string]: string;
+  [key: string]: boolean;
 };
 
 export type RegistrationEntity = {
   claim_val: string;
-  ent_id: string;
+  ent_id: number;
   claim_and_enc_vol: string;
   license: string | null | undefined;
   naic: string | null | undefined;
@@ -23,7 +23,7 @@ export type RegistrationEntity = {
 };
 
 export type RegistrationContact = {
-  cont_id: string;
+  cont_id: number;
   notif: string;
   role: string;
   name: string;
@@ -31,7 +31,8 @@ export type RegistrationContact = {
   email: string;
 };
 
-export type RegistrationModalContent = {
+export type RegistrationContent = {
+  reg_id: number;
   biz_name: string;
   type: string | null | undefined;
   city: string;
@@ -52,8 +53,7 @@ export type RegistrationRow = {
   type: string;
   location: string;
   reg_status: string;
-  reg_id: string;
-  view_modal_content: RegistrationModalContent;
+  reg_id: number;
 };
 
 export type RegistrationResult = {
@@ -69,7 +69,89 @@ export type RegistrationResult = {
   total_pages: number;
 };
 
+export type RegistrationFormValues = {
+  on_behalf_of: string;
+  reg_year: string;
+  type: string;
+  business_name: string;
+  mailing_address: string;
+  city: string;
+  state?: string | undefined;
+  zip_code: string;
+  reg_id?: number;
+  entities: {
+    entity_name: string;
+    fein: string;
+    license_number: string;
+    naic_company_code: string;
+    types_of_plans_commerical: boolean;
+    types_of_plans_medicare: boolean;
+    types_of_plans_medicaid: boolean;
+    types_of_files_eligibility_enrollment: boolean;
+    types_of_files_provider: boolean;
+    types_of_files_medical: boolean;
+    types_of_files_pharmacy: boolean;
+    types_of_files_dental: boolean;
+    total_covered_lives: any;
+    claims_encounters_volume: any;
+    total_claims_value: any;
+    entity_id?: number;
+  }[];
+  contacts: {
+    contact_type: string;
+    contact_name: string;
+    contact_phone: string;
+    contact_email: string;
+    contact_notifications: boolean;
+    contact_id?: number;
+  }[];
+};
+
+export function transformToRegistrationFormValues(
+  registration: RegistrationContent
+): RegistrationFormValues {
+  return {
+    on_behalf_of: registration.for_self ?? '',
+    reg_year: registration.year.toString(),
+    type: registration.type ?? '',
+    business_name: registration.biz_name,
+    mailing_address: registration.address,
+    city: registration.city,
+    state: registration.state as string,
+    zip_code: registration.zip.toString(),
+    reg_id: registration.reg_id,
+    entities: registration.entities.map((entity) => ({
+      entity_name: entity.ent_name,
+      fein: entity.fein ?? '',
+      license_number: entity.license ?? '',
+      naic_company_code: entity.naic ?? '',
+      types_of_plans_commerical: entity.plans_type['Commercial'],
+      types_of_plans_medicare: entity.plans_type['Medicare'],
+      types_of_plans_medicaid: entity.plans_type['Medicaid'],
+      types_of_files_eligibility_enrollment:
+        entity.files_type['Eligibility/Enrollment'],
+      types_of_files_provider: entity.files_type['Provider'],
+      types_of_files_medical: entity.files_type['Medical'],
+      types_of_files_pharmacy: entity.files_type['Pharmacy'],
+      types_of_files_dental: entity.files_type['Dental'],
+      total_covered_lives: entity.no_covered,
+      claims_encounters_volume: entity.claim_and_enc_vol,
+      total_claims_value: entity.claim_val,
+      entity_id: entity.ent_id,
+    })),
+    contacts: registration.contacts.map((contact) => ({
+      contact_type: contact.role,
+      contact_name: contact.name,
+      contact_phone: contact.phone,
+      contact_email: contact.email,
+      contact_notifications: contact.notif ? true : false,
+      contact_id: contact.cont_id,
+    })),
+  };
+}
+
 export {
   useAdminRegistrations,
   useSubmitterRegistrations,
+  useAdminRegistration,
 } from './useRegistrations';

--- a/apcd-cms/src/client/src/hooks/registrations/useForm.ts
+++ b/apcd-cms/src/client/src/hooks/registrations/useForm.ts
@@ -1,20 +1,58 @@
-import { useQuery, UseQueryResult } from 'react-query';
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  UseQueryResult,
+} from 'react-query';
 import { fetchUtil } from 'utils/fetchUtil';
-import { RegFormData } from '.';
+import { RegFormData, RegistrationFormValues, RegistrationContent } from '.';
 
-const getRegFormData = async (params: any) => {
-  const url = 'register/request-to-submit/api/';
+const getRegFormData = async (reg_id: string | null) => {
+  const url = `register/request-to-submit/api/?reg_id=${reg_id}/`;
   const response = await fetchUtil({
     url,
-    params,
   });
   return response.response;
 };
 
-export const useRegFormData = (params: any): UseQueryResult<RegFormData> => {
-  const query = useQuery(['reg_form', params], () =>
-    getRegFormData(params)
-  ) as UseQueryResult<RegFormData>;
+export const useRegFormData = (
+  reg_id: string | null
+): UseQueryResult<RegistrationContent> => {
+  const query = useQuery(['reg_form', reg_id], () => getRegFormData(reg_id), {
+    enabled: !!reg_id,
+  }) as UseQueryResult<RegistrationContent>;
 
   return { ...query };
 };
+
+const postRegistration = async (url: string, body: RegistrationFormValues) => {
+  const response = await fetchUtil({
+    url,
+    method: `POST`,
+    body: body,
+  });
+  return response;
+};
+
+export function usePostRegistration() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      url,
+      body,
+    }: {
+      url: string;
+      body: RegistrationFormValues;
+    }) => {
+      return postRegistration(url, body);
+    },
+    onError: (err: Error) => {
+      console.log(err);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['submitter-registrations', 'admin-registrations'],
+      });
+    },
+  });
+}

--- a/apcd-cms/src/client/src/hooks/registrations/useRegistrations.ts
+++ b/apcd-cms/src/client/src/hooks/registrations/useRegistrations.ts
@@ -1,6 +1,6 @@
 import { useQuery, UseQueryResult } from 'react-query';
 import { fetchUtil } from 'utils/fetchUtil';
-import { RegistrationResult } from '.';
+import { RegistrationResult, RegistrationContent } from '.';
 
 const getAdminRegistrations = async (params: any) => {
   const url = `/administration/list-registration-requests/api/`;
@@ -18,7 +18,7 @@ export const useAdminRegistrations = (
     org,
     page,
   };
-  const query = useQuery(['registrations', params], () =>
+  const query = useQuery(['admin-registrations', params], () =>
     getAdminRegistrations(params)
   ) as UseQueryResult<RegistrationResult>;
 
@@ -41,9 +41,21 @@ export const useSubmitterRegistrations = (
     org,
     page,
   };
-  const query = useQuery(['registrations', params], () =>
+  const query = useQuery(['submitter-registrations', params], () =>
     getSubmitterRegistrations(params)
   ) as UseQueryResult<RegistrationResult>;
 
+  return { ...query };
+};
+
+export const useAdminRegistration = (
+  reg_id: number
+): UseQueryResult<RegistrationContent> => {
+  const params: { reg_id: number } = {
+    reg_id,
+  };
+  const query = useQuery(['admin-registration', params], () =>
+    getAdminRegistrations(params)
+  ) as UseQueryResult<RegistrationContent>;
   return { ...query };
 };


### PR DESCRIPTION
## Overview
With RegistrationForm available, hookup edit registration and renew registration to it.
Reuse as much of the component code as possible.

## Related
- [WP-738](https://tacc-main.atlassian.net/browse/WP-738)

## Changes

* Make RegistrationForm adaptable to edit and also modal 
* Move the registration form submission to a `usePost` with `mutation` to allow invalidating the registration listing when an edit is done.
* Do not load all the registration modal content for listing page. Only load on demand. This is both a perf improvement and also to keep data in sync between updates.
* Update submitter listing
* Manage registration listing to allow renew for nonAdmin scenario and update for admin scenario. (different actions).
* Adjust the registration form to handle reg_id form url and make a request.


## Testing

1. Go to http://localhost:8000/administration/list-registration-requests/ and use edit action.
   * edit registration
   * add contact
   * add entitiy
   * remove contact and add contact
   * remove entity.
   * check if the updates are seen if edit action is opened again. 
   * check if the registration level updates are available in the listing and 'view' action
2. Go to http://localhost:8000/register/list-registration-requests/ and use renew action

## UI
Admin edit: 
<img width="1106" alt="Screenshot 2024-11-04 at 3 09 17 PM" src="https://github.com/user-attachments/assets/89aec1cc-2d4f-4b21-a444-3ad0cfc9dd07">

Submitter Listing: 
<img width="1139" alt="Screenshot 2024-11-04 at 3 07 58 PM" src="https://github.com/user-attachments/assets/cf8d3d8c-cdf8-402d-b5c5-6f1daa4f6902">

## Notes
* This request is still not available on server side: http://localhost:8000/register/request-to-submit/?reg_id=2