### PR TITLE
Task/wp 743 exception form testing changes

### DIFF
--- a/apcd-cms/src/apps/exception/templates/exception_submission_form.html
+++ b/apcd-cms/src/apps/exception/templates/exception_submission_form.html
@@ -3,7 +3,6 @@
 
 {% block content %}
 
-<link rel="stylesheet" href="{% static 'forms/css/exception_submission_form.css' %}">
 <div class="container">
   {% include "nav_cms_breadcrumbs.html" %}
       <div id="exception-submission-root">

--- a/apcd-cms/src/client/src/components/Submitter/Exceptions/ExceptionForm.module.css
+++ b/apcd-cms/src/client/src/components/Submitter/Exceptions/ExceptionForm.module.css
@@ -29,7 +29,6 @@
   background-color: #e9ecef;
   color: #6c757d;
   border-color: #ced4da;
-  cursor: not-allowed;
 }
 .requiredThreshold,
 .thresholdRequested {
@@ -50,4 +49,8 @@
   margin-top: 0.25rem;
   font-size: 80%;
   color: #dc3545;
+}
+/* To match CEP styles of required fields */
+.requiredBadge {
+  margin-left: 10px;
 }

--- a/apcd-cms/src/client/src/components/Submitter/Exceptions/ExceptionForm.tsx
+++ b/apcd-cms/src/client/src/components/Submitter/Exceptions/ExceptionForm.tsx
@@ -1,13 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import { useFormikContext, Field, ErrorMessage } from 'formik';
-import * as Yup from 'yup';
-import { FormGroup, Label } from 'reactstrap';
+import { FormGroup, Label, Badge } from 'reactstrap';
 import { cdlObject, useCDLs, cdl } from 'hooks/cdls';
 import { Entities, useEntities } from 'hooks/entities';
 import styles from './ExceptionForm.module.css';
 import LoadingSpinner from 'core-components/LoadingSpinner';
 import SectionMessage from 'core-components/SectionMessage';
 import { Link } from 'react-router-dom';
+import Pill from 'core-components/Pill';
 
 export const ExceptionForm: React.FC<{ index: number }> = ({ index }) => {
   const [cdlData, setCdlData] = useState<cdlObject>();
@@ -51,7 +51,7 @@ export const ExceptionForm: React.FC<{ index: number }> = ({ index }) => {
     } else if (fetchedCDLData && fetchedCDLData.cdls) {
       setCdlData(fetchedCDLData);
     }
-  }, [fetchedCDLData, selectedFileType, setFieldValue, index]);
+  }, [selectedCDL, selectedFileType, setFieldValue, index]);
 
   if (entitiesLoading)
     return (
@@ -65,7 +65,8 @@ export const ExceptionForm: React.FC<{ index: number }> = ({ index }) => {
       <hr />
       <h4>Requested Threshold Reduction {index + 1}</h4>
       <FormGroup className="field-wrapper required">
-        <Label for={`exceptions[${index}].businessName`}>Business Name</Label>
+        <Label for={`exceptions[${index}].businessName`}>Business Name       
+          <Badge color="badge badge-danger" className={styles.requiredBadge}>Required</Badge></Label>
         {submitterData && (
           <>
             <Field
@@ -100,7 +101,10 @@ export const ExceptionForm: React.FC<{ index: number }> = ({ index }) => {
         )}
       </FormGroup>
       <FormGroup className="field-wrapper required">
-        <Label for={`exceptions[${index}].fileType`}>File Type</Label>
+        <Label for={`exceptions[${index}].fileType`}>
+          File Type
+          <Badge color="badge badge-danger" className={styles.requiredBadge}>Required</Badge>
+        </Label>
 
         <Field
           as="select"
@@ -125,7 +129,10 @@ export const ExceptionForm: React.FC<{ index: number }> = ({ index }) => {
         />
       </FormGroup>
       <FormGroup className="field-wrapper required">
-        <Label for={`exceptions[${index}].fieldCode`}>Field Code</Label>
+        <Label for={`exceptions[${index}].fieldCode`}>
+          Field Code
+          <Badge color="badge badge-danger" className={styles.requiredBadge}>Required</Badge>
+        </Label>
 
         <Field
           as="select"
@@ -169,6 +176,7 @@ export const ExceptionForm: React.FC<{ index: number }> = ({ index }) => {
         <FormGroup className="field-wrapper required">
           <Label for={`exceptions[${index}].expiration_date`}>
             Expiration Date*
+            <Badge color="badge badge-danger" className={styles.requiredBadge}>Required</Badge>
           </Label>
           <Field
             type="date"
@@ -184,6 +192,7 @@ export const ExceptionForm: React.FC<{ index: number }> = ({ index }) => {
         <FormGroup className="field-wrapper required">
           <Label for={`exceptions[${index}].requested_threshold`}>
             Requested Threshold Percentage
+            <Badge color="badge badge-danger" className={styles.requiredBadge}>Required</Badge>
           </Label>
           <Field
             type="number"
@@ -199,9 +208,16 @@ export const ExceptionForm: React.FC<{ index: number }> = ({ index }) => {
           />
 
           {selectedCDL && (
+            selectedCDL.threshold_value != 0 ? (
+            
             <div className="help-text">
               Must be less than the {selectedCDL.threshold_value} required.
             </div>
+            ) : (
+            <div className="help-text">
+              This field code does not require an exception submission.<br/> Please choose another.
+            </div>
+            )
           )}
         </FormGroup>
         <FormGroup className="field-wrapper required">
@@ -211,9 +227,15 @@ export const ExceptionForm: React.FC<{ index: number }> = ({ index }) => {
           <Field
             className={styles.requiredThreshold}
             type="number"
+            readOnly
             name={`exceptions[${index}].required_threshold`}
             id={`exceptions[${index}].required_threshold`}
           ></Field>
+          <ErrorMessage
+            name={`exceptions[${index}].required_threshold`}
+            component="div"
+            className={styles.isInvalid}
+          />
         </FormGroup>
       </div>
     </>

--- a/apcd-cms/src/client/src/components/Submitter/Exceptions/ExceptionForm.tsx
+++ b/apcd-cms/src/client/src/components/Submitter/Exceptions/ExceptionForm.tsx
@@ -65,8 +65,12 @@ export const ExceptionForm: React.FC<{ index: number }> = ({ index }) => {
       <hr />
       <h4>Requested Threshold Reduction {index + 1}</h4>
       <FormGroup className="field-wrapper required">
-        <Label for={`exceptions[${index}].businessName`}>Business Name       
-          <Badge color="badge badge-danger" className={styles.requiredBadge}>Required</Badge></Label>
+        <Label for={`exceptions[${index}].businessName`}>
+          Business Name
+          <Badge color="badge badge-danger" className={styles.requiredBadge}>
+            Required
+          </Badge>
+        </Label>
         {submitterData && (
           <>
             <Field
@@ -103,7 +107,9 @@ export const ExceptionForm: React.FC<{ index: number }> = ({ index }) => {
       <FormGroup className="field-wrapper required">
         <Label for={`exceptions[${index}].fileType`}>
           File Type
-          <Badge color="badge badge-danger" className={styles.requiredBadge}>Required</Badge>
+          <Badge color="badge badge-danger" className={styles.requiredBadge}>
+            Required
+          </Badge>
         </Label>
 
         <Field
@@ -131,7 +137,9 @@ export const ExceptionForm: React.FC<{ index: number }> = ({ index }) => {
       <FormGroup className="field-wrapper required">
         <Label for={`exceptions[${index}].fieldCode`}>
           Field Code
-          <Badge color="badge badge-danger" className={styles.requiredBadge}>Required</Badge>
+          <Badge color="badge badge-danger" className={styles.requiredBadge}>
+            Required
+          </Badge>
         </Label>
 
         <Field
@@ -176,7 +184,9 @@ export const ExceptionForm: React.FC<{ index: number }> = ({ index }) => {
         <FormGroup className="field-wrapper required">
           <Label for={`exceptions[${index}].expiration_date`}>
             Expiration Date*
-            <Badge color="badge badge-danger" className={styles.requiredBadge}>Required</Badge>
+            <Badge color="badge badge-danger" className={styles.requiredBadge}>
+              Required
+            </Badge>
           </Label>
           <Field
             type="date"
@@ -192,7 +202,9 @@ export const ExceptionForm: React.FC<{ index: number }> = ({ index }) => {
         <FormGroup className="field-wrapper required">
           <Label for={`exceptions[${index}].requested_threshold`}>
             Requested Threshold Percentage
-            <Badge color="badge badge-danger" className={styles.requiredBadge}>Required</Badge>
+            <Badge color="badge badge-danger" className={styles.requiredBadge}>
+              Required
+            </Badge>
           </Label>
           <Field
             type="number"
@@ -207,18 +219,17 @@ export const ExceptionForm: React.FC<{ index: number }> = ({ index }) => {
             className={styles.isInvalid}
           />
 
-          {selectedCDL && (
-            selectedCDL.threshold_value != 0 ? (
-            
-            <div className="help-text">
-              Must be less than the {selectedCDL.threshold_value} required.
-            </div>
+          {selectedCDL &&
+            (selectedCDL.threshold_value != 0 ? (
+              <div className="help-text">
+                Must be less than the {selectedCDL.threshold_value} required.
+              </div>
             ) : (
-            <div className="help-text">
-              This field code does not require an exception submission.<br/> Please choose another.
-            </div>
-            )
-          )}
+              <div className="help-text">
+                This field code does not require an exception submission.
+                <br /> Please choose another.
+              </div>
+            ))}
         </FormGroup>
         <FormGroup className="field-wrapper required">
           <Label for={`exceptions[${index}].required_threshold`}>

--- a/apcd-cms/src/client/src/components/Submitter/Exceptions/ExceptionForm.tsx
+++ b/apcd-cms/src/client/src/components/Submitter/Exceptions/ExceptionForm.tsx
@@ -42,7 +42,16 @@ export const ExceptionForm: React.FC<{ index: number }> = ({ index }) => {
         selectedCDL?.threshold_value || ''
       );
     }
-  }, [selectedCDL, setFieldValue, index]);
+    if (!selectedFileType || selectedFileType === '') {
+      setCdlData(undefined);
+      setSelectedCDL(undefined);
+      setFieldValue(`exceptions[${index}].fieldCode`, '');
+      setFieldValue(`exceptions[${index}].required_threshold`, '');
+      setFieldValue(`exceptions[${index}].requested_threshold`, '');
+    } else if (fetchedCDLData && fetchedCDLData.cdls) {
+      setCdlData(fetchedCDLData);
+    }
+  }, [fetchedCDLData, selectedFileType, setFieldValue, index]);
 
   if (entitiesLoading)
     return (
@@ -64,7 +73,7 @@ export const ExceptionForm: React.FC<{ index: number }> = ({ index }) => {
               name={`exceptions[${index}].businessName`}
               id={`exceptions[${index}].businessName`}
             >
-              <option>-- Select a Business --</option>
+              <option>Select a Business Name</option>
               {submitterData?.submitters?.map((submitter: Entities) => (
                 <option
                   value={submitter.submitter_id}
@@ -102,7 +111,7 @@ export const ExceptionForm: React.FC<{ index: number }> = ({ index }) => {
             setFieldValue(`exceptions[${index}].fieldCode`, '');
           }}
         >
-          <option value="">-- Choose File Type --</option>
+          <option value="">Select a File Type</option>
           <option value="dc">Dental Claims</option>
           <option value="mc">Medical Claims</option>
           <option value="me">Member Eligibility</option>
@@ -133,7 +142,7 @@ export const ExceptionForm: React.FC<{ index: number }> = ({ index }) => {
         >
           {cdlData ? (
             <>
-              <option value="">-- Select Field Code --</option>
+              <option value="">Select Field Code</option>
               {cdlData.cdls.map((cdl: any) => (
                 <option
                   key={cdl.field_list_code}
@@ -147,7 +156,7 @@ export const ExceptionForm: React.FC<{ index: number }> = ({ index }) => {
               ))}
             </>
           ) : (
-            <option value="">-- Select a File Type Above First --</option>
+            <option value="">Select a File Type Above First</option>
           )}
         </Field>
         <ErrorMessage

--- a/apcd-cms/src/client/src/components/Submitter/Exceptions/ExceptionFormPage.tsx
+++ b/apcd-cms/src/client/src/components/Submitter/Exceptions/ExceptionFormPage.tsx
@@ -32,8 +32,7 @@ interface FormValues {
 export const ExceptionFormPage: React.FC = () => {
   const [selectedExceptionType, setSelectedExceptionType] =
     useState<string>('');
-  const [numberOfExceptionBlocks] =
-    useState<number>(1);
+  const [numberOfExceptionBlocks] = useState<number>(1);
 
   // Dynamically determines validation schema based on selectedExceptionType state
   const baseSchema = {
@@ -42,7 +41,9 @@ export const ExceptionFormPage: React.FC = () => {
       .max(2000, 'Must be 2000 characters or less')
       .required('Justification is required'),
     requestorName: Yup.string().required('Requestor name is required'),
-    requestorEmail: Yup.string().email('Invalid email').required('Requestor email is required'),
+    requestorEmail: Yup.string()
+      .email('Invalid email')
+      .required('Requestor email is required'),
     acceptTerms: Yup.boolean().oneOf([true], 'You must accept the terms'),
   };
 
@@ -51,14 +52,17 @@ export const ExceptionFormPage: React.FC = () => {
       // Allows users to pick from human readable business names, but passes submitter id to
       // database query which is what the table looks for to match exception with submitter
       businessName: Yup.number()
-        .transform((val,original) => original == "" || isNaN(original) ? undefined : val)
-        .typeError("Business name is required")
-        .required("Business name is required"),
+        .transform((val, original) =>
+          original == '' || isNaN(original) ? undefined : val
+        )
+        .typeError('Business name is required')
+        .required('Business name is required'),
       fileType: Yup.string().required('File type is required'),
       fieldCode: Yup.string().required('Field code is required'),
       expiration_date: Yup.date().required('Expiration date is required'),
-      requested_threshold: Yup.number()
-        .required('Requested threshold is required'),
+      requested_threshold: Yup.number().required(
+        'Requested threshold is required'
+      ),
       required_threshold: Yup.number()
         .min(1, 'This field code does not require an exception submission.')
         .required('Required'),
@@ -103,6 +107,7 @@ export const ExceptionFormPage: React.FC = () => {
 
   const [errorMessage, setErrorMessage] = useState('');
   const [isSuccess, setIsSuccess] = useState<boolean>(false);
+  const [lastSubmitCount] = useState(0);
 
   const {
     data: submitterData,
@@ -143,12 +148,12 @@ export const ExceptionFormPage: React.FC = () => {
     }
   };
 
-  if (entitiesLoading)  {
+  if (entitiesLoading) {
     return (
       <div className={styles.loadingField}>
-        <LoadingSpinner/>
+        <LoadingSpinner />
       </div>
-    )
+    );
   }
 
   const getExceptionTitle = () => {
@@ -187,12 +192,27 @@ export const ExceptionFormPage: React.FC = () => {
         validationSchema={validationSchema}
         onSubmit={handleSubmit}
       >
-        {({ values, isSubmitting, setFieldValue, resetForm }) => {
+        {({
+          values,
+          isSubmitting,
+          setFieldValue,
+          resetForm,
+          isValid,
+          submitCount,
+          handleSubmit,
+        }) => {
+          // To reset values to initial values if the form submits successfully
           useEffect(() => {
             if (isSuccess) {
               resetForm({ values: { ...initialValues } });
             }
           }, [isSuccess, resetForm]);
+          // To display message next to submit if fields are invalid on submit
+          useEffect(() => {
+            if (submitCount > lastSubmitCount && !isValid) {
+              setErrorMessage('All required fields must be valid');
+            }
+          }, [submitCount, isValid, lastSubmitCount, handleSubmit]);
           return (
             <Form id="threshold-form">
               <h4>Select Exception Type</h4>
@@ -225,9 +245,9 @@ export const ExceptionFormPage: React.FC = () => {
                 </FormGroup>
                 {selectedExceptionType !== '' && (
                   <div>
-                    <b>Note:</b>{' '}Your changes will not be saved if you change the exception
-                    type.
-                    </div>
+                    <b>Note:</b> Your changes will not be saved if you change
+                    the exception type.
+                  </div>
                 )}
               </div>
               {selectedExceptionType == 'threshold' && (
@@ -281,7 +301,12 @@ export const ExceptionFormPage: React.FC = () => {
                         <FormGroup className="field-wrapper ">
                           <Label for={`otherExceptionBusinessName`}>
                             Business Name
-                            <Badge color="badge badge-danger" className={styles.requiredBadge}>Required</Badge>
+                            <Badge
+                              color="badge badge-danger"
+                              className={styles.requiredBadge}
+                            >
+                              Required
+                            </Badge>
                           </Label>
                           <Field
                             as="select"
@@ -325,7 +350,12 @@ export const ExceptionFormPage: React.FC = () => {
                     <FormGroup className="field-wrapper required">
                       <Label for={'expirationDateOther'}>
                         Requested Expiration Date
-                        <Badge color="badge badge-danger" className={styles.requiredBadge}>Required</Badge>
+                        <Badge
+                          color="badge badge-danger"
+                          className={styles.requiredBadge}
+                        >
+                          Required
+                        </Badge>
                       </Label>
                       <Field
                         type="date"
@@ -355,7 +385,12 @@ export const ExceptionFormPage: React.FC = () => {
                       submission requirements for which relief is being sought.
                       If applicable, indicate how the organization plans to
                       become compliant.**
-                      <Badge color="badge badge-danger" className={styles.requiredBadge}>Required</Badge>
+                      <Badge
+                        color="badge badge-danger"
+                        className={styles.requiredBadge}
+                      >
+                        Required
+                      </Badge>
                     </Label>
 
                     <Field
@@ -373,7 +408,7 @@ export const ExceptionFormPage: React.FC = () => {
                   </FormGroup>
                   <hr />
                   <h4>Acknowledgment of Terms</h4>
-                  <Label className='form-wrapper'>
+                  <Label className="form-wrapper">
                     I understand and acknowledge that the Texas Department of
                     Insurance (TDI) may review the validity of the information
                     submitted on this form.
@@ -382,7 +417,12 @@ export const ExceptionFormPage: React.FC = () => {
                     <FormGroup className="field-wrapper required">
                       <Label for="requestorName">
                         Requestor Name
-                        <Badge color="badge badge-danger" className={styles.requiredBadge}>Required</Badge>
+                        <Badge
+                          color="badge badge-danger"
+                          className={styles.requiredBadge}
+                        >
+                          Required
+                        </Badge>
                       </Label>
                       <Field
                         type="text"
@@ -398,7 +438,12 @@ export const ExceptionFormPage: React.FC = () => {
                     <FormGroup className="field-wrapper required">
                       <Label for="requestorEmail">
                         Requestor E-mail
-                        <Badge color="badge badge-danger" className={styles.requiredBadge}>Required</Badge>
+                        <Badge
+                          color="badge badge-danger"
+                          className={styles.requiredBadge}
+                        >
+                          Required
+                        </Badge>
                       </Label>
                       <Field
                         type="email"
@@ -415,7 +460,12 @@ export const ExceptionFormPage: React.FC = () => {
                       <Label for="acceptTerms" check>
                         {' '}
                         Accept
-                        <Badge color="badge badge-danger" className={styles.requiredBadge}>Required</Badge>
+                        <Badge
+                          color="badge badge-danger"
+                          className={styles.requiredBadge}
+                        >
+                          Required
+                        </Badge>
                       </Label>
                       <Field
                         type="checkbox"

--- a/apcd-cms/src/client/src/components/Submitter/Exceptions/ExceptionFormPage.tsx
+++ b/apcd-cms/src/client/src/components/Submitter/Exceptions/ExceptionFormPage.tsx
@@ -298,7 +298,7 @@ export const ExceptionFormPage: React.FC = () => {
                   <div className={styles.fieldRows}>
                     {submitterData && (
                       <>
-                        <FormGroup className="field-wrapper ">
+                        <FormGroup className="field-wrapper required">
                           <Label for={`otherExceptionBusinessName`}>
                             Business Name
                             <Badge

--- a/apcd-cms/src/client/src/components/Submitter/Exceptions/ExceptionFormPage.tsx
+++ b/apcd-cms/src/client/src/components/Submitter/Exceptions/ExceptionFormPage.tsx
@@ -398,7 +398,7 @@ export const ExceptionFormPage: React.FC = () => {
                     <FormGroup className="field-wrapper required">
                       <Label for="requestorEmail">
                         Requestor E-mail
-                        <Badge color="badge badge-danger">Required</Badge>
+                        <Badge color="badge badge-danger" className={styles.requiredBadge}>Required</Badge>
                       </Label>
                       <Field
                         type="email"


### PR DESCRIPTION
## Overview

Addresses bugs and UI fixes from APCD testing session 

## Related

- [WP-743](https://tacc-main.atlassian.net/browse/WP-743)

## Changes

…

## Testing

1. Go to [http://localhost:8000/submissions/exception/](http://localhost:8000/submissions/exception/)
2. Make sure that the UI has been updated to reflect these issues ( see Jira issue for another view of the breakdown of changes)

- [ ] If you change from a selected file type back to “-- Choose File Type ---”, it does not clear the field code drop down from cdls from previous selection. It resets to – Select Field Code --, but still has previous options from first selection

- [ ] Should notify if there are form field errors and it does not submit next to submit button.

- [ ] change email validation error to match extension form

- [ ] Change select business name default to match extension form

- [ ] On both types, it should not box the phrase “Your changes will not be saved if you change the exception type.” That box look just like the pull down box to change type. Use text only with a bold word “Note: Your changes will not be saved if you change the exception type.” 

- [ ] Mark fields as required with core-components Badge like CEP

- [ ] After selecting a business and then selecting “Select a Business” again the following error is shown:
- exceptions[0].businessName must be a `number` type, but the final value was: `NaN` (cast from the value `"-- Select a Business --"`).

- Address confusing requested threshold validation message when zero. : Requested Threshold Percentage - This message is confusing: “Must be less than the 0 required.” I tried 0.25, .25, 25, and 0. None worked. I wasn’t able to submit the form. 

## UI

#### Threshold page

<img width="948" alt="Screenshot 2024-11-04 at 5 11 38 PM" src="https://github.com/user-attachments/assets/76ccde4a-f7b9-445d-9f28-6f0cb97247e6">

### Other exception page

<img width="1203" alt="Screenshot 2024-11-04 at 5 14 07 PM" src="https://github.com/user-attachments/assets/e23562ef-e042-4bb3-af9c-cde46c76b760">

<!--
## Notes

…
-->
