### PR TITLE
WP-744: Registration Table - fix clear selection button

### DIFF
--- a/apcd-cms/src/apps/admin_regis_table/static/admin_regis_table/css/table.css
+++ b/apcd-cms/src/apps/admin_regis_table/static/admin_regis_table/css/table.css
@@ -1,5 +1,6 @@
 .status-filter.org-filter {
     width: max-content;
+    padding-right: 20px;
 }
 
 /* SEE: https://css-tricks.com/responsive-data-tables/ */

--- a/apcd-cms/src/client/src/components/Registrations/RegistrationList/RegistrationList.tsx
+++ b/apcd-cms/src/client/src/components/Registrations/RegistrationList/RegistrationList.tsx
@@ -5,6 +5,7 @@ import Paginator from 'core-components/Paginator';
 import ViewRegistrationModal from 'apcd-components/Registrations/ViewRegistrationModal/ViewRegistrationModal';
 import EditRegistrationModal from 'apcd-components/Registrations/EditRegistrationModal/EditRegistrationModal';
 import styles from './RegistrationList.module.css';
+import Button from 'core-components/Button';
 
 export const RegistrationList: React.FC<{
   useDataHook: any;
@@ -88,7 +89,7 @@ export const RegistrationList: React.FC<{
             <select
               id="statusFilter"
               className="status-filter"
-              defaultValue={data?.selected_status} // Use defaultValue to set the initial selected value
+              value={status}
               onChange={(e) => setStatus(e.target.value)}
             >
               {data?.status_options.map((status, index) => (
@@ -98,14 +99,13 @@ export const RegistrationList: React.FC<{
               ))}
             </select>
 
-            {/* Filter by Organization */}
             <span>
               <b>Filter by Organization: </b>
             </span>
             <select
               id="organizationFilter"
               className="status-filter org-filter"
-              defaultValue={data?.selected_org} // Use defaultValue to set the initial selected value
+              value={org}
               onChange={(e) => setOrg(e.target.value)}
             >
               {data?.org_options.map((org, index) => (
@@ -115,7 +115,7 @@ export const RegistrationList: React.FC<{
               ))}
             </select>
             {data?.selected_status || data?.selected_org ? (
-              <button onClick={clearSelections}>Clear Options</button>
+              <Button onClick={clearSelections}>Clear Options</Button>
             ) : null}
           </div>
         </div>


### PR DESCRIPTION
## Overview

* Clear selection button is not clear all selections
* Also fix spacing issue on long org names.
* Use common button.

## Related
[WP-744](https://tacc-main.atlassian.net/browse/WP-744)

## Changes


## Testing

Go to http://localhost:8000/administration/list-registration-requests/
  * Select different options for both filters. 
  * Clear selection
  * the filter value should reset and the data should be accurate.

