### PR TITLE
WP-752: ExtensionForm expected date fix, required field UI

### DIFF
--- a/apcd-cms/src/apps/extension/urls.py
+++ b/apcd-cms/src/apps/extension/urls.py
@@ -1,11 +1,9 @@
 from django.urls import path
 from django.views.generic import TemplateView
 from apps.extension.views import ExtensionFormView
-from . import views
 
 app_name = 'extension'
 urlpatterns = [
     path('extension-request/', TemplateView.as_view(template_name='extension_submission_form/extension_submission_form.html'), name='extension'),
-    path('get-expected-date/', views.get_expected_date, name='get-expected-date'),
     path('extension/api/', ExtensionFormView.as_view(), name='extension-api'),
 ]

--- a/apcd-cms/src/apps/extension/views.py
+++ b/apcd-cms/src/apps/extension/views.py
@@ -17,30 +17,6 @@ class ExtensionFormView(TemplateView):
             return HttpResponseRedirect('/')
         return super(ExtensionFormView, self).dispatch(request, *args, **kwargs)
 
-    def get(self, request, *args, **kwargs):
-        """
-        Handle GET request to return form data as JSON
-        """
-        user = request.user.username
-        submitters = apcd_database.get_submitter_info(user)
-        
-        # Prepare context data for JSON response
-        context = {
-            "submitters": [],
-            "applicable_data_periods": []
-        }
-
-        # Build context data
-        for submitter in submitters: 
-            context['submitters'].append(self._set_submitter(submitter))
-            applicable_data_periods = apcd_database.get_applicable_data_periods(submitter[0])
-            for data_period_tuple in applicable_data_periods:
-                for data_period in data_period_tuple:
-                    data_period = self._get_applicable_data_period(data_period)
-                    context['applicable_data_periods'].append(data_period)
-
-        context['applicable_data_periods'] = sorted(context['applicable_data_periods'], reverse=True)
-        return JsonResponse(context)
 
     def post(self, request):
         """
@@ -66,27 +42,6 @@ class ExtensionFormView(TemplateView):
         else:
             return HttpResponseRedirect('/')
 
-    def _set_submitter(self, sub):
-        """
-        Helper function to structure the submitter info 
-        """
-        return {
-            "submitter_id": sub[0],
-            "submitter_code": sub[1],
-            "payor_code": sub[2],
-            "user_name": sub[3],
-            "entity_name": title_case(sub[4])
-        }
-
-    def _get_applicable_data_period(self, value):
-        """
-        Helper function to convert date format
-        """
-        try:
-            return datetime.strptime(str(value), '%Y%m').strftime('%Y-%m')
-        except Exception:
-            return None
-
     def _err_msg(self, resp):
         """
         Helper function to extract error messages
@@ -96,13 +51,3 @@ class ExtensionFormView(TemplateView):
         if isinstance(resp, Exception):
             return str(resp)
         return None
-
-def get_expected_date(request):
-    """
-    Handle AJAX request to get expected date based on submitter and applicable data period
-    """
-    applicable_data_period = request.GET.get('applicable_data_period')
-    submitter_id = request.GET.get('submitter_id')
-    expected_date = apcd_database.get_current_exp_date(submitter_id=submitter_id, applicable_data_period=applicable_data_period)
-
-    return JsonResponse(expected_date, safe=False)

--- a/apcd-cms/src/client/src/components/Components/FormLabel/FormLabel.module.css
+++ b/apcd-cms/src/client/src/components/Components/FormLabel/FormLabel.module.css
@@ -1,0 +1,4 @@
+/* To match CEP styles of required fields */
+.requiredBadge {
+  margin-left: 10px;
+}

--- a/apcd-cms/src/client/src/components/Components/FormLabel/FormLabel.tsx
+++ b/apcd-cms/src/client/src/components/Components/FormLabel/FormLabel.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Label, Badge, LabelProps } from 'reactstrap';
+import styles from './FormLabel.module.css';
+
+interface FormLabelProps extends LabelProps {
+  label: string;
+  labelFor: string;
+  isRequired?: boolean;
+}
+
+export const FormLabel: React.FC<FormLabelProps> = ({
+  label,
+  labelFor,
+  isRequired = false,
+  children,
+  ...props
+}) => {
+  return (
+    <Label for={labelFor} {...props}>
+      {children}
+      {label}
+      {isRequired && (
+        <Badge color="badge badge-danger" className={styles.requiredBadge}>
+          Required
+        </Badge>
+      )}
+    </Label>
+  );
+};

--- a/apcd-cms/src/client/src/components/Submitter/Extensions/ExtensionsForm.tsx
+++ b/apcd-cms/src/client/src/components/Submitter/Extensions/ExtensionsForm.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Formik, Form, Field, ErrorMessage } from 'formik';
 import * as Yup from 'yup';
-import { FormGroup, Label } from 'reactstrap';
+import { FormGroup } from 'reactstrap';
 import styles from './ExtensionsForm.module.css';
 import ExtensionFormInfo from './ExtensionFormInfo';
 import { useEntities } from 'hooks/entities';
@@ -9,11 +9,17 @@ import { fetchUtil } from 'utils/fetchUtil';
 import LoadingSpinner from 'core-components/LoadingSpinner';
 import SectionMessage from 'core-components/SectionMessage';
 import Button from 'core-components/Button';
+import { FormLabel } from 'apcd-components/Components/FormLabel/FormLabel';
 
 const validationSchema = Yup.object().shape({
   extensions: Yup.array().of(
     Yup.object().shape({
-      businessName: Yup.string().required('Business Name is required'),
+      businessName: Yup.number()
+        .transform((val, original) =>
+          original == '' || isNaN(original) ? undefined : val
+        )
+        .typeError('Business name is required')
+        .required('Business name is required'),
       extensionType: Yup.string().required('Extension Type is required'),
       applicableDataPeriod: Yup.string().required(
         'Applicable Data Period is required'
@@ -201,6 +207,11 @@ export const ExtensionRequestForm: React.FC = () => {
                     compliant.**
                   </p>
                   <FormGroup className="field-wrapper required">
+                    <FormLabel
+                      labelFor={'justification'}
+                      label={''}
+                      isRequired={true}
+                    />
                     <Field
                       as="textarea"
                       name="justification"
@@ -224,7 +235,11 @@ export const ExtensionRequestForm: React.FC = () => {
                   </p>
                   <div className={styles.fieldRows}>
                     <FormGroup className="field-wrapper required">
-                      <Label htmlFor="requestorName">Requestor Name</Label>
+                      <FormLabel
+                        labelFor={'requestorName'}
+                        label={'Requestor Name'}
+                        isRequired={true}
+                      />
                       <Field
                         type="text"
                         name="requestorName"
@@ -238,7 +253,11 @@ export const ExtensionRequestForm: React.FC = () => {
                       />
                     </FormGroup>
                     <FormGroup className="field-wrapper required">
-                      <Label htmlFor="requestorEmail">Requestor Email</Label>
+                      <FormLabel
+                        labelFor={'requestorEmail'}
+                        label={'Requestor Email'}
+                        isRequired={true}
+                      />
                       <Field
                         type="email"
                         name="requestorEmail"
@@ -251,21 +270,28 @@ export const ExtensionRequestForm: React.FC = () => {
                         className={styles.isInvalid}
                       />
                     </FormGroup>
-                    <FormGroup className="field-wrapper required" check>
-                      <Label for="acceptTerms" check>
-                        {' '}
-                        Accept
-                      </Label>
+                  </div>
+                  <div className={styles.fieldRows}>
+                    <FormGroup check inline>
                       <Field
                         name="acceptTerms"
                         type="checkbox"
                         className={styles.termsCheckbox}
                       />
-                      <ErrorMessage
-                        name="acceptTerms"
-                        component="div"
-                        className={styles.isInvalid}
+                      <FormLabel
+                        labelFor={'acceptTerms'}
+                        label={'Accept'}
+                        isRequired={true}
+                        check
+                        style={{ marginLeft: '4px' }}
                       />
+                      <div style={{ paddingLeft: '4px' }}>
+                        <ErrorMessage
+                          name="acceptTerms"
+                          component="div"
+                          className={styles.isInvalid}
+                        />
+                      </div>
                     </FormGroup>
                   </div>
                   {isSuccess ? (
@@ -279,7 +305,11 @@ export const ExtensionRequestForm: React.FC = () => {
                         Submit Another Extension
                       </Button>
                       <div className={styles.fieldRows}>
-                        <SectionMessage type="success" canDismiss={true}>
+                        <SectionMessage
+                          type="success"
+                          canDismiss={true}
+                          onDismiss={() => setIsSuccess(false)}
+                        >
                           Your extension request was successfully sent.
                         </SectionMessage>
                       </div>

--- a/apcd-cms/src/client/src/hooks/entities/index.ts
+++ b/apcd-cms/src/client/src/hooks/entities/index.ts
@@ -8,6 +8,12 @@ export type Entities = {
   payor_code: number;
   user_id: string;
   entity_name: string;
+  data_periods: ApplicableDataPeriod[];
+};
+
+export type ApplicableDataPeriod = {
+  data_period: string;
+  expected_date: string;
 };
 
 export { useEntities } from './useEntities';


### PR DESCRIPTION
## Overview
* Get the applicable dates, and set it accordingly to the entity id.
* Set the max value for extended date
* Set the expected date.
* Wire up the backend for this.
* Write a custom component for Label
* Use required field new look.

## Related

- [WP-752](https://tacc-main.atlassian.net/browse/WP-752)

## Testing

1. Request extension here: http://localhost:8000/submissions/extension-request/ 
2. Enter nothing and see the required field messages
3. Checkout the applicable date periods and date management
4. See the max date.

## UI
<img width="1213" alt="Screenshot 2024-11-06 at 2 39 52 PM" src="https://github.com/user-attachments/assets/7efaae8e-7ec7-47da-9b8c-a825c091d2ee">

