### PR TITLE
View Users: clear options button behavior

### DIFF
--- a/apcd-cms/src/client/src/components/Admin/ViewUsers/ViewUsers.tsx
+++ b/apcd-cms/src/client/src/components/Admin/ViewUsers/ViewUsers.tsx
@@ -130,7 +130,7 @@ export const ViewUsers: React.FC = () => {
                 </option>
               ))}
             </select>
-            {userData?.selected_status || userData?.selected_org ? (
+            {status !== 'All' || org !== 'All' ? (
               <Button onClick={clearSelections}>Clear Options</Button>
             ) : null}
           </div>


### PR DESCRIPTION
## Overview
* Remove clear options button when the filters are default. This matches prod behavior

## Related

[WP-750](https://tacc-main.atlassian.net/browse/WP-750)

## Testing

1. Go to http://localhost:8000/administration/view-users/
and test clear options behavior

