### PR TITLE
bugs/WP-756: [APCD][React] Fix modal close button

### DIFF
--- a/apcd-cms/src/client/src/components/Admin/EditExceptionModal/EditExceptionModal.tsx
+++ b/apcd-cms/src/client/src/components/Admin/EditExceptionModal/EditExceptionModal.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import {
   Modal,
   ModalBody,
-  ModalFooter,
+  ModalHeader,
   Button,
   Label,
   FormGroup,
@@ -11,9 +11,7 @@ import {
   Alert,
 } from 'reactstrap';
 import {
-  Formik,
   Field,
-  Form,
   ErrorMessage,
   useFormik,
   FormikHelpers,
@@ -146,6 +144,12 @@ const EditExceptionModal: React.FC<EditRecordModalProps> = ({
     },
   ];
 
+  const closeBtn = (
+    <button className="close" onClick={onClose} type="button">
+      &times;
+    </button>
+  );
+
   return (
     <>
       <Modal
@@ -154,15 +158,9 @@ const EditExceptionModal: React.FC<EditRecordModalProps> = ({
         className={styles.customModal}
         onClosed={handleClose}
       >
-        <div className={`modal-header ${styles.modalHeader}`}>
-          <h4 className="modal-title">
-            Edit Exception ID {exception.exception_id} for{' '}
-            {exception.entity_name}
-          </h4>
-          <button className="close" onClick={onClose} type="button">
-            &times;
-          </button>
-        </div>
+        <ModalHeader close={closeBtn}>
+          Edit Exception ID {exception.exception_id} for {exception.entity_name}
+        </ModalHeader>
         <ModalBody>
           <Alert color="success" isOpen={showSuccessMessage}>
             Success: The exception data has been successfully updated.

--- a/apcd-cms/src/client/src/components/Admin/EditExceptionModal/EditExceptionModal.tsx
+++ b/apcd-cms/src/client/src/components/Admin/EditExceptionModal/EditExceptionModal.tsx
@@ -155,16 +155,12 @@ const EditExceptionModal: React.FC<EditRecordModalProps> = ({
         onClosed={handleClose}
       >
         <div className={`modal-header ${styles.modalHeader}`}>
-          <Label className={styles.customModalTitle}>
+          <h4 className="modal-title">
             Edit Exception ID {exception.exception_id} for{' '}
             {exception.entity_name}
-          </Label>
-          <button
-            type="button"
-            className={`close ${styles.customCloseButton}`}
-            onClick={onClose}
-          >
-            <span aria-hidden="true">&times;</span>
+          </h4>
+          <button className="close" onClick={onClose} type="button">
+            &times;
           </button>
         </div>
         <ModalBody>

--- a/apcd-cms/src/client/src/components/Admin/ViewExceptionModal/ViewExceptionModal.tsx
+++ b/apcd-cms/src/client/src/components/Admin/ViewExceptionModal/ViewExceptionModal.tsx
@@ -1,12 +1,5 @@
-import React, { useState, useEffect } from 'react';
-import {
-  Modal,
-  ModalHeader,
-  ModalBody,
-  ModalFooter,
-  Row,
-  Col,
-} from 'reactstrap';
+import React from 'react';
+import { Modal, ModalHeader, ModalBody, Row, Col } from 'reactstrap';
 import { ExceptionModalContent, ExceptionRow } from 'hooks/admin';
 import styles from './ViewExceptionModal.module.css';
 
@@ -15,6 +8,12 @@ export const ViewExceptionModal: React.FC<{
   isOpen: boolean;
   onClose: () => void;
 }> = ({ exception, isOpen, onClose }) => {
+  const closeBtn = (
+    <button className="close" onClick={onClose} type="button">
+      &times;
+    </button>
+  );
+
   const {
     created_at,
     entity_name,
@@ -37,12 +36,7 @@ export const ViewExceptionModal: React.FC<{
 
   return (
     <Modal title="View Exception" isOpen={isOpen} toggle={onClose} size="lg">
-      <div className="modal-header">
-        <h4 className="modal-title text-capitalize">Exception Details</h4>
-        <button className="close" onClick={onClose} type="button">
-          &times;
-        </button>
-      </div>
+      <ModalHeader close={closeBtn}>Exception Detail</ModalHeader>
       <ModalBody className="modal-body">
         <div>
           <h4>Details</h4>

--- a/apcd-cms/src/client/src/components/Admin/ViewExceptionModal/ViewExceptionModal.tsx
+++ b/apcd-cms/src/client/src/components/Admin/ViewExceptionModal/ViewExceptionModal.tsx
@@ -39,8 +39,8 @@ export const ViewExceptionModal: React.FC<{
     <Modal title="View Exception" isOpen={isOpen} toggle={onClose} size="lg">
       <div className="modal-header">
         <h4 className="modal-title text-capitalize">Exception Details</h4>
-        <button type="button" className="close" onClick={onClose}>
-          <span aria-hidden="true">&#xe912;</span>
+        <button className="close" onClick={onClose} type="button">
+          &times;
         </button>
       </div>
       <ModalBody className="modal-body">

--- a/apcd-cms/src/client/src/components/Admin/ViewUsers/EditRecordModal.tsx
+++ b/apcd-cms/src/client/src/components/Admin/ViewUsers/EditRecordModal.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import {
   Modal,
   ModalBody,
-  ModalFooter,
+  ModalHeader,
   Button,
   Label,
   FormGroup,
@@ -104,17 +104,18 @@ const EditRecordModal: React.FC<EditRecordModalProps> = ({
     { label: 'Notes', value: user.notes ? user.notes : 'None' },
   ];
 
+  const closeBtn = (
+    <button className="close" onClick={toggle} type="button">
+      &times;
+    </button>
+  );
+
   return (
     <>
       <Modal isOpen={isOpen} toggle={toggle} className={styles.customModal}>
-        <div className={`modal-header ${styles.modalHeader}`}>
-          <h4 className="modal-title">
-            Edit User ID: {user.user_id} for {user.user_name}
-          </h4>
-          <button className="close" onClick={toggle} type="button">
-            &times;
-          </button>
-        </div>
+        <ModalHeader close={closeBtn}>
+          Edit User ID: {user.user_id} for {user.user_name}
+        </ModalHeader>
         <ModalBody>
           <div className={styles.greyRectangle}>Edit Selected User</div>
           <Formik

--- a/apcd-cms/src/client/src/components/Admin/ViewUsers/EditRecordModal.tsx
+++ b/apcd-cms/src/client/src/components/Admin/ViewUsers/EditRecordModal.tsx
@@ -108,15 +108,11 @@ const EditRecordModal: React.FC<EditRecordModalProps> = ({
     <>
       <Modal isOpen={isOpen} toggle={toggle} className={styles.customModal}>
         <div className={`modal-header ${styles.modalHeader}`}>
-          <Label className={styles.customModalTitle}>
+          <h4 className="modal-title">
             Edit User ID: {user.user_id} for {user.user_name}
-          </Label>
-          <button
-            type="button"
-            className={`close ${styles.customCloseButton}`}
-            onClick={toggle}
-          >
-            <span aria-hidden="true">&times;</span>
+          </h4>
+          <button className="close" onClick={toggle} type="button">
+            &times;
           </button>
         </div>
         <ModalBody>

--- a/apcd-cms/src/client/src/components/Admin/ViewUsers/ViewRecordModal.tsx
+++ b/apcd-cms/src/client/src/components/Admin/ViewUsers/ViewRecordModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Modal, Row, Col, ModalBody } from 'reactstrap';
+import { Modal, ModalHeader, Row, Col, ModalBody } from 'reactstrap';
 import { UserRow } from 'hooks/admin';
 import styles from './ViewUsers.module.scss';
 import { formatDate } from 'utils/dateUtil';
@@ -23,12 +23,8 @@ const UserDetailsModal: React.FC<UserDetailsModalProps> = ({
         <h4 className="modal-title">
           Details for User: {user.user_name} ({user.user_id})
         </h4>
-        <button
-          type="button"
-          className={`close ${styles.customCloseButton}`}
-          onClick={toggle}
-        >
-          <span aria-hidden="true">&#xe912;</span>
+        <button className="close" onClick={toggle} type="button">
+          &times;
         </button>
       </div>
 

--- a/apcd-cms/src/client/src/components/Admin/ViewUsers/ViewRecordModal.tsx
+++ b/apcd-cms/src/client/src/components/Admin/ViewUsers/ViewRecordModal.tsx
@@ -16,17 +16,16 @@ const UserDetailsModal: React.FC<UserDetailsModalProps> = ({
   user,
 }) => {
   if (!user) return null;
-
+  const closeBtn = (
+    <button className="close" onClick={toggle} type="button">
+      &times;
+    </button>
+  );
   return (
     <Modal isOpen={isOpen} toggle={toggle} className={styles.customModal}>
-      <div className={`modal-header ${styles.modalHeader}`}>
-        <h4 className="modal-title">
-          Details for User: {user.user_name} ({user.user_id})
-        </h4>
-        <button className="close" onClick={toggle} type="button">
-          &times;
-        </button>
-      </div>
+      <ModalHeader close={closeBtn}>
+        Details for User: {user.user_name} ({user.user_id})
+      </ModalHeader>
 
       <ModalBody className="modal-content">
         <div className={styles.userListing}>

--- a/apcd-cms/src/client/src/components/Extensions/EditExtensionModal/EditExtensionModal.tsx
+++ b/apcd-cms/src/client/src/components/Extensions/EditExtensionModal/EditExtensionModal.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import {
   Modal,
   ModalBody,
-  ModalFooter,
+  ModalHeader,
   Button,
   Label,
   FormGroup,
@@ -171,6 +171,11 @@ const EditExtensionModal: React.FC<EditExtensionModalProps> = ({
       value: extension.notes ? extension.notes : 'None',
     },
   ];*/
+  const closeBtn = (
+    <button className="close" onClick={onClose} type="button">
+      &times;
+    </button>
+  );
 
   return (
     <>
@@ -180,18 +185,9 @@ const EditExtensionModal: React.FC<EditExtensionModalProps> = ({
         className={styles.customModal}
         onClosed={handleClose}
       >
-        <div className={`modal-header ${styles.modalHeader}`}>
-          <Label className={styles.customModalTitle}>
-            Edit Extension ID {extension.ext_id} for {extension.org_name}
-          </Label>
-          <button
-            type="button"
-            className={`close ${styles.customCloseButton}`}
-            onClick={onClose}
-          >
-            <span aria-hidden="true">&times;</span>
-          </button>
-        </div>
+        <ModalHeader close={closeBtn}>
+          Edit Extension ID {extension.ext_id} for {extension.org_name}
+        </ModalHeader>
         <ModalBody>
           <Alert color="success" isOpen={showSuccessMessage}>
             Success: The extension data has been successfully updated.

--- a/apcd-cms/src/client/src/components/Extensions/ViewExtensionModal/ViewExtensionModal.tsx
+++ b/apcd-cms/src/client/src/components/Extensions/ViewExtensionModal/ViewExtensionModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Modal, ModalBody } from 'reactstrap';
+import { Modal, ModalHeader, ModalBody } from 'reactstrap';
 import { ExtensionRow } from 'hooks/admin';
 import styles from './ViewExtensionModal.module.css';
 
@@ -8,16 +8,17 @@ const ViewExtensionModal: React.FC<{
   isVisible: boolean;
   onClose: () => void;
 }> = ({ extension, isVisible, onClose }) => {
+  const closeBtn = (
+    <button className="close" onClick={onClose} type="button">
+      &times;
+    </button>
+  );
   return (
     <Modal title="View Extension" isOpen={isVisible} toggle={onClose} size="lg">
-      <div className="modal-header">
-        <h4 className="modal-title">
-          Extension Details ID {extension.ext_id} for {extension.org_name}
-        </h4>
-        <button type="button" className="close" onClick={onClose}>
-          <span aria-hidden="true">&#xe912;</span>
-        </button>
-      </div>
+      <ModalHeader close={closeBtn}>
+        Extension Details ID {extension.ext_id} for {extension.org_name}
+      </ModalHeader>
+
       <ModalBody className="modal-body">
         <div>
           <h4>Details</h4>

--- a/apcd-cms/src/client/src/components/Registrations/EditRegistrationModal/EditRegistrationModal.tsx
+++ b/apcd-cms/src/client/src/components/Registrations/EditRegistrationModal/EditRegistrationModal.tsx
@@ -30,8 +30,8 @@ const EditRegistrationModal: React.FC<{
     >
       <div className="modal-header">
         <h4 className="modal-title text-capitalize">Edit Registration</h4>
-        <button type="button" className="close" onClick={onClose}>
-          <span aria-hidden="true">&#xe912;</span>
+        <button className="close" onClick={onClose} type="button">
+          &times;
         </button>
       </div>
       <ModalBody className="modal-body">

--- a/apcd-cms/src/client/src/components/Registrations/EditRegistrationModal/EditRegistrationModal.tsx
+++ b/apcd-cms/src/client/src/components/Registrations/EditRegistrationModal/EditRegistrationModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Modal, ModalBody } from 'reactstrap';
+import { Modal, ModalHeader, ModalBody } from 'reactstrap';
 import {
   transformToRegistrationFormValues,
   RegistrationFormValues,
@@ -21,6 +21,12 @@ const EditRegistrationModal: React.FC<{
   const form_values: RegistrationFormValues =
     transformToRegistrationFormValues(data);
 
+  const closeBtn = (
+    <button className="close" onClick={onClose} type="button">
+      &times;
+    </button>
+  );
+
   return (
     <Modal
       title="Edit Registration"
@@ -28,12 +34,7 @@ const EditRegistrationModal: React.FC<{
       toggle={onClose}
       size="lg"
     >
-      <div className="modal-header">
-        <h4 className="modal-title text-capitalize">Edit Registration</h4>
-        <button className="close" onClick={onClose} type="button">
-          &times;
-        </button>
-      </div>
+      <ModalHeader close={closeBtn}>Edit Registration</ModalHeader>
       <ModalBody className="modal-body">
         <RegistrationForm
           isEdit={true}

--- a/apcd-cms/src/client/src/components/Registrations/ViewRegistrationModal/ViewRegistrationModal.tsx
+++ b/apcd-cms/src/client/src/components/Registrations/ViewRegistrationModal/ViewRegistrationModal.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Modal, ModalBody } from 'reactstrap';
-import { RegistrationContent, useAdminRegistration } from 'hooks/registrations';
+import { Modal, ModalHeader, ModalBody } from 'reactstrap';
+import { useAdminRegistration } from 'hooks/registrations';
 import styles from './ViewRegistrationModal.module.css';
 
 const ViewRegistrationModal: React.FC<{
@@ -27,6 +27,12 @@ const ViewRegistrationModal: React.FC<{
     contacts,
   } = data;
 
+  const closeBtn = (
+    <button className="close" onClick={onClose} type="button">
+      &times;
+    </button>
+  );
+
   return (
     <Modal
       title="View Registration"
@@ -34,12 +40,8 @@ const ViewRegistrationModal: React.FC<{
       toggle={onClose}
       size="lg"
     >
-      <div className="modal-header">
-        <h4 className="modal-title text-capitalize">View Registration</h4>
-        <button className="close" onClick={onClose} type="button">
-          &times;
-        </button>
-      </div>
+      <ModalHeader close={closeBtn}>View Registration</ModalHeader>
+
       <ModalBody className="modal-body">
         <div>
           <h4>Organization</h4>

--- a/apcd-cms/src/client/src/components/Registrations/ViewRegistrationModal/ViewRegistrationModal.tsx
+++ b/apcd-cms/src/client/src/components/Registrations/ViewRegistrationModal/ViewRegistrationModal.tsx
@@ -36,8 +36,8 @@ const ViewRegistrationModal: React.FC<{
     >
       <div className="modal-header">
         <h4 className="modal-title text-capitalize">View Registration</h4>
-        <button type="button" className="close" onClick={onClose}>
-          <span aria-hidden="true">&#xe912;</span>
+        <button className="close" onClick={onClose} type="button">
+          &times;
         </button>
       </div>
       <ModalBody className="modal-body">


### PR DESCRIPTION
## Overview

Modal close icon is broken after styles update.

## Related

[WP-756](https://tacc-main.atlassian.net/browse/WP-756)

## Changes

1. Use times
2. be consistent on modal header.

## Testing

1. Go to http://localhost:8000/administration/list-registration-requests/ and checkout view and edit modal.
2. Same for http://localhost:8000/administration/view-users/
3. And http://localhost:8000/administration/list-exceptions/

## UI
![Screenshot 2024-11-12 at 2 46 07 PM](https://github.com/user-attachments/assets/263cf8da-0404-4ec0-a3f4-e94d1d67b21a)


