### PR TITLE
task/WP-742: Fix renew registration in react

### DIFF
--- a/apcd-cms/src/apps/registrations/views.py
+++ b/apcd-cms/src/apps/registrations/views.py
@@ -25,7 +25,7 @@ class RegistrationFormView(TemplateView):
     def get(self, request):
         formatted_reg_data = []
         renew = False
-        reg_id = request.GET.get('reg_id', None)
+        reg_id = request.GET.get('reg_id', None).strip('/')  # reg_id coming from renew has trailing slash appended, need to remove to pass correct request through
         if reg_id and (has_groups(request.user, ['APCD_ADMIN', 'SUBMITTER_ADMIN'])):
             try:
                 response = get_submitter_code(request.user)

--- a/apcd-cms/src/client/src/components/Forms/Registrations/RegistrationForm.tsx
+++ b/apcd-cms/src/client/src/components/Forms/Registrations/RegistrationForm.tsx
@@ -258,7 +258,7 @@ export const RegistrationForm: React.FC<{
           validateOnMount={true}
           initialValues={
             data
-              ? transformToRegistrationFormValues(data)
+              ? transformToRegistrationFormValues(data['registration_data'], data['renew'])
               : inputValues ?? initialValues
           }
           initialTouched={initialTouched}

--- a/apcd-cms/src/client/src/hooks/registrations/index.ts
+++ b/apcd-cms/src/client/src/hooks/registrations/index.ts
@@ -1,5 +1,5 @@
 export type RegFormData = {
-  registration_data: RegistrationRow;
+  registration_data: RegistrationContent;
   renew: boolean;
 };
 
@@ -110,7 +110,7 @@ export type RegistrationFormValues = {
 };
 
 export function transformToRegistrationFormValues(
-  registration: RegistrationContent
+  registration: RegistrationContent, renew?: boolean | undefined
 ): RegistrationFormValues {
 
   const typeValueMap:Record<string, string> = { // to set database value for field rather than display value
@@ -118,10 +118,9 @@ export function transformToRegistrationFormValues(
     'Plan Administrator¹ (TPA/ASO)': 'tpa_aso',
     'Pharmacy Benefit Manager (PBM)': 'pbm'
   }
-  
   return {
     on_behalf_of: registration.for_self?.toString() ?? '',
-    reg_year: registration.year.toString(),
+    reg_year: (registration.year + (renew ? 1 : 0)).toString(),
     type: registration.type ? typeValueMap[registration.type] : '',
     business_name: registration.biz_name,
     mailing_address: registration.address,

--- a/apcd-cms/src/client/src/hooks/registrations/useForm.ts
+++ b/apcd-cms/src/client/src/hooks/registrations/useForm.ts
@@ -17,10 +17,10 @@ const getRegFormData = async (reg_id: string | null) => {
 
 export const useRegFormData = (
   reg_id: string | null
-): UseQueryResult<RegistrationContent> => {
+): UseQueryResult<RegFormData> => {
   const query = useQuery(['reg_form', reg_id], () => getRegFormData(reg_id), {
     enabled: !!reg_id,
-  }) as UseQueryResult<RegistrationContent>;
+  }) as UseQueryResult<RegFormData>;
 
   return { ...query };
 };


### PR DESCRIPTION
## Overview
Resolves a couple of bugs in hookup for renewing registration via registration form
…

## Related

- [WP-742](https://tacc-main.atlassian.net/browse/WP-742)
<!--
- requires https://github.com/TACC/Core-CMS/pull/117
-->…

## Changes
- In registration form view, remove trailing slash to properly grab registration data to pass along to form
- `useRegFormData` is now of type `RegFormData` instead of `RegistrationContent` to capture full response from view
- Pass `renew` along to reg data transform to index the registration year up by 1 on form populating
…

## Testing

1. Go to http://localhost:8000/register/list-registration-requests/
2. Click on the 'Renew Registration' action on a record in this listing and confirm the page reloads to the registration form, pre-populated with the data from said record

## UI

…

<!--
## Notes

…
-->
