### PR TITLE
bug/WP-769-Submission-Sort-Bug

### DIFF
--- a/apcd-cms/src/apps/admin_submissions/views.py
+++ b/apcd-cms/src/apps/admin_submissions/views.py
@@ -63,6 +63,8 @@ class AdminSubmissionsTable(TemplateView):
         def getDate(submission):
             date = submission['received_timestamp']
             return parser.parse(date) if date is not None else parser.parse('1-1-3005')
+        
+        ## Initial API response sort
         submission_list = sorted(
             submission_content,
             key=lambda row: getDate(row),
@@ -71,8 +73,14 @@ class AdminSubmissionsTable(TemplateView):
         if status != 'All':
             submission_list = [submission for submission in submission_content 
                             if submission['status'].lower() == status.lower()]
-
+        ## Sorts filtered list 
+        submission_list = sorted(
+            submission_list,
+            key=lambda row: getDate(row),
+            reverse=(sort == 'Newest Received')
+        )
         return submission_list
+    
     def get_view_submissions_json(self, submission_content, selected_status='All', selected_sort='Newest Received'):
         context = {
             'page': [],

--- a/apcd-cms/src/apps/admin_submissions/views.py
+++ b/apcd-cms/src/apps/admin_submissions/views.py
@@ -64,22 +64,16 @@ class AdminSubmissionsTable(TemplateView):
             date = submission['received_timestamp']
             return parser.parse(date) if date is not None else parser.parse('1-1-3005')
         
-        ## Initial API response sort
-        submission_list = sorted(
+        if status != 'All':
+            submission_content = [submission for submission in submission_content 
+                            if submission['status'].lower() == status.lower()]
+
+        submission_content = sorted(
             submission_content,
             key=lambda row: getDate(row),
             reverse=(sort == 'Newest Received')
         )
-        if status != 'All':
-            submission_list = [submission for submission in submission_content 
-                            if submission['status'].lower() == status.lower()]
-        ## Sorts filtered list 
-        submission_list = sorted(
-            submission_list,
-            key=lambda row: getDate(row),
-            reverse=(sort == 'Newest Received')
-        )
-        return submission_list
+        return submission_content
     
     def get_view_submissions_json(self, submission_content, selected_status='All', selected_sort='Newest Received'):
         context = {

--- a/apcd-cms/src/apps/submissions/views.py
+++ b/apcd-cms/src/apps/submissions/views.py
@@ -66,22 +66,16 @@ class SubmissionsTable(TemplateView):
             date = submission['received_timestamp']
             return parser.parse(date) if date is not None else parser.parse('1-1-3005')
         
-        ## Initial API response sort
-        submission_list = sorted(
+        if status != 'All':
+            submission_content = [submission for submission in submission_content 
+                            if submission['status'].lower() == status.lower()]
+             
+        submission_content= sorted(
             submission_content,
             key=lambda row: getDate(row),
             reverse=(sort == 'Newest Received')
         )
-        if status != 'All':
-            submission_list = [submission for submission in submission_content 
-                            if submission['status'].lower() == status.lower()]
-        ## Sorts filtered list 
-        submission_list = sorted(
-            submission_list,
-            key=lambda row: getDate(row),
-            reverse=(sort == 'Newest Received')
-        )
-        return submission_list
+        return submission_content
     
     def get_view_submissions_json(self, submission_content, selected_status='All', selected_sort='Newest Received'):
         context = {

--- a/apcd-cms/src/client/src/components/Submissions/ViewFileSubmissions/ViewSubmissions.tsx
+++ b/apcd-cms/src/client/src/components/Submissions/ViewFileSubmissions/ViewSubmissions.tsx
@@ -73,7 +73,7 @@ export const ViewFileSubmissions: React.FC = () => {
 
   const clearSelections = () => {
     setStatus('All');
-    setSort('All');
+    setSort('Newest Received');
     setPage(1);
   };
 


### PR DESCRIPTION
## Overview

Addresses issue when select sort, then status, then sort again. It doesn’t sort by date for both Submission and Admin Submission Tables. 

## Related

- [WP-769](https://tacc-main.atlassian.net/browse/WP-769)


## Changes

Added sort of list in view for both admin and submitter submission tables

## Testing

1. Go to [http://localhost:8000/administration/list-submissions/](http://localhost:8000/administration/list-submissions/) and change filters in various ways to make sure they work
2. Go to [http://localhost:8000/submissions/list-submissions/](http://localhost:8000/submissions/list-submissions/) and change filters in various ways to make sure they work

## UI

…

<!--
## Notes

…
-->
