### PR TITLE
task/stashed-extension-modal-styles

### DIFF
--- a/apcd-cms/src/client/src/components/Extensions/EditExtensionModal/EditExtensionModal.tsx
+++ b/apcd-cms/src/client/src/components/Extensions/EditExtensionModal/EditExtensionModal.tsx
@@ -3,7 +3,6 @@ import {
   Modal,
   ModalBody,
   ModalHeader,
-  Button,
   Label,
   FormGroup,
   Row,
@@ -26,6 +25,8 @@ import { useEntities } from 'hooks/entities';
 import QueryWrapper from 'core-wrappers/QueryWrapper';
 import { convertPeriodLabelToApiValue, convertApiValueToPeriodLabel } from 'utils/dateUtil';
 import styles from './EditExtensionModal.module.css';
+import FieldWrapper from 'core-wrappers/FieldWrapperFormik';
+import Button from 'core-components/Button';
 
 interface EditExtensionModalProps {
   isVisible: boolean;
@@ -176,17 +177,13 @@ const EditExtensionModal: React.FC<EditExtensionModalProps> = ({
       <Modal
         isOpen={isVisible}
         onClose={onClose}
-        className={styles.customModal}
-        onClosed={handleClose}
+        className="modal-dialog modal-lg"
       >
         <ModalHeader close={closeBtn}>
           Edit Extension ID {extension.ext_id} for {extension.org_name}
         </ModalHeader>
         <ModalBody>
-          <Alert color="success" isOpen={showSuccessMessage}>
-            Success: The extension data has been successfully updated.
-          </Alert>
-          <div className={styles.greyRectangle}>Edit Selected Extension</div>
+          <h4 className="modal-header">Edit Selected Exception</h4>
           <QueryWrapper
             isLoading={entitiesLoading}
             error={entitiesError as Error}
@@ -194,14 +191,12 @@ const EditExtensionModal: React.FC<EditExtensionModalProps> = ({
             <FormikProvider value={formik}>
               <form onSubmit={formik.handleSubmit}>
                 <Row>
-                  <Col md={6}>
-                    <FormGroup>
-                      <Label
-                        for="applicable_data_period"
-                        className={styles.customLabel}
-                      >
-                        <strong>Applicable Data Period</strong>
-                      </Label>
+                  <Col md={3}>
+                      <FieldWrapper
+                          name="applicable_data_period"
+                          label="Applicable Data Period"
+                          required={false}
+                        >
                       <Field
                         as="select"
                         name="applicable_data_period"
@@ -211,7 +206,6 @@ const EditExtensionModal: React.FC<EditExtensionModalProps> = ({
                         )}
                         onChange={formik.handleChange}
                         onBlur={formik.handleBlur}
-                        className={`form-control ${styles.viewRecord}`}
                       >
                         {submitterData?.submitters
                           .find(
@@ -227,27 +221,17 @@ const EditExtensionModal: React.FC<EditExtensionModalProps> = ({
                             </option>
                           ))}
                       </Field>
-                      <small
-                        className="form-text text-muted"
-                        style={{ fontStyle: 'italic' }}
-                      >
-                        Current: {extension.applicable_data_period}
-                      </small>
-                      <ErrorMessage
-                        name="applicable_data_period"
-                        component="div"
-                        className="text-danger"
-                      />
-                    </FormGroup>
+                      <div
+                        className="help-text">
+                                Current:{' '}{(extension.applicable_data_period)}
+                      </div>
+                      </FieldWrapper>
                   </Col>
-                  <Col md={6}>
-                    <FormGroup>
-                      <Label
-                        for="approved_expiration_date"
-                        className={styles.customLabel}
-                      >
-                        <strong>Approved Expiration Date</strong>
-                      </Label>
+                  <Col md={3}>
+                    <FieldWrapper
+                      name="approved_expiration_date"
+                      label="Approved Expiration Date"
+                      required={false}>
                       <Field
                         type="date"
                         name="approved_expiration_date"
@@ -259,11 +243,9 @@ const EditExtensionModal: React.FC<EditExtensionModalProps> = ({
                         }
                         onChange={formik.handleChange}
                         onBlur={formik.handleBlur}
-                        className={`form-control ${styles.viewRecord}`}
                       />
-                      <small
-                        className="form-text text-muted"
-                        style={{ fontStyle: 'italic' }}
+                      <div
+                        className="help-text"
                       >
                         Current:{' '}
                         {extension.approved_expiration_date
@@ -271,26 +253,19 @@ const EditExtensionModal: React.FC<EditExtensionModalProps> = ({
                               extension.approved_expiration_date
                             ).toLocaleDateString()
                           : 'None'}
-                      </small>
-                      <ErrorMessage
-                        name="approved_expiration_date"
-                        component="div"
-                        className="text-danger"
-                      />
-                    </FormGroup>
+                      </div>
+                      </FieldWrapper>
                   </Col>
-                  <Col md={6}>
-                    <FormGroup>
-                      <Label for="ext_status" className={styles.customLabel}>
-                        <strong>Extension Status</strong>
-                      </Label>
+                  <Col md={3}>
+                    <FieldWrapper name = "ext_status"
+                    label="Exception Status"
+                    required={false}>
                       <Field
                         as="select"
                         name="ext_status"
                         id="ext_status"
                         onChange={formik.handleChange}
                         onBlur={formik.handleBlur}
-                        className={`form-control ${styles.viewRecord}`}
                         value={formik.values.ext_status}
                       >
                         {statusOptions?.map(
@@ -306,25 +281,17 @@ const EditExtensionModal: React.FC<EditExtensionModalProps> = ({
                             )
                         )}
                       </Field>
-                      <ErrorMessage
-                        name="ext_status"
-                        component="div"
-                        className="text-danger"
-                      />
-                    </FormGroup>
+                      </FieldWrapper>
                   </Col>
-                  <Col md={6}>
-                    <FormGroup>
-                      <Label for="ext_outcome" className={styles.customLabel}>
-                        <strong>Extension Outcome</strong>
-                      </Label>
+                  <Col md={3}>
+                      <FieldWrapper name="ext_outcome" label="Extension Outcome"
+                      required={false}>
                       <Field
                         as="select"
                         name="ext_outcome"
                         id="ext_outcome"
                         onChange={formik.handleChange}
                         onBlur={formik.handleBlur}
-                        className={`form-control ${styles.viewRecord}`}
                         value={formik.values.ext_outcome}
                       >
                         {outcomeOptions?.map((opt) => (
@@ -337,18 +304,10 @@ const EditExtensionModal: React.FC<EditExtensionModalProps> = ({
                           </option>
                         ))}
                       </Field>
-                      <ErrorMessage
-                        name="ext_outcome"
-                        component="div"
-                        className="text-danger"
-                      />
-                    </FormGroup>
+                    </FieldWrapper>
                   </Col>
                   <Col md={6}>
-                    <FormGroup>
-                      <Label for="notes" className={styles.customLabel}>
-                        <strong>Notes</strong>
-                      </Label>
+                    <FieldWrapper name ="notes" label="Notes" required={false}>
                       <Field
                         as="textarea"
                         name="notes"
@@ -357,31 +316,29 @@ const EditExtensionModal: React.FC<EditExtensionModalProps> = ({
                         maxLength="2000" // Set the maxLength attribute
                         onChange={formik.handleChange}
                         onBlur={formik.handleBlur}
-                        className={`form-control ${styles.viewRecord}`}
                       />
-                      <small
-                        className="form-text text-muted"
-                        style={{ fontStyle: 'italic' }}
+                      <div
+                        className="help-text"
                       >
                         2000 character limit
-                      </small>
-                      <ErrorMessage
-                        name="notes"
-                        component="div"
-                        className="text-danger"
-                      />
-                    </FormGroup>
+                      </div>
+                    </FieldWrapper>
                   </Col>
                 </Row>
                 <br />
+                <Alert
+                color="success"
+                isOpen={showSuccessMessage}
+              >
+                Success: The exception data has been successfully updated.
+              </Alert>
                 <Alert color="danger" isOpen={showErrorMessage}>
                   Error: {errorMessage}
                 </Alert>
                 <Button
-                  type="submit"
-                  color="primary"
+                  type="primary"
+                  attr="submit"
                   disabled={formik.isSubmitting}
-                  className={styles.customSubmitButton}
                 >
                   Submit
                 </Button>
@@ -389,7 +346,8 @@ const EditExtensionModal: React.FC<EditExtensionModalProps> = ({
             </FormikProvider>
           </QueryWrapper>
           <hr />
-          <div className={styles.viewRecord}>
+          <h4 className="modal-header">Current Exception Information</h4>
+          <div>
             {userFields.map((field, index) => (
               <Row key={index}>
                 <Col md={6}>


### PR DESCRIPTION


## Overview

I was trying to crack the code on the data refresh for the extension edit modal, and all I got were these lousy style changes that I already had stashed away 🤷‍♀️ .  

If you want to apply these to your modal to look like the exception modal feel free to merge this into your PR! But if you don't love it, it's not blocking changes for merging to the feature branch

## Related
- requires https://github.com/TACC/Core-CMS-Custom/pull/370


## Changes

…

## Testing

1.

## UI
![Screenshot 2024-11-20 at 3 18 18 PM](https://github.com/user-attachments/assets/f0bf65c6-b191-405b-807b-27f2a9c24d61)


<!--
## Notes

…
-->
