### PR TITLE
Task/WP-387: Fix path URLs to not contain regex

### DIFF
--- a/apcd_cms/src/apps/admin_regis_table/urls.py
+++ b/apcd_cms/src/apps/admin_regis_table/urls.py
@@ -1,10 +1,10 @@
-from django.urls import path
+from django.urls import path, re_path
 from apps.admin_regis_table.views import RegistrationsTable
 
 app_name = 'admin_regis_table'
 urlpatterns = [
     path('list-registration-requests/', RegistrationsTable.as_view(), name='admin_regis_table'),
-    path(r'list-registration-requests/?status=(?P<status>)/', RegistrationsTable.as_view(), name='admin_regis_table'),
-    path(r'list-registration-requests/?org=(?P<org>)/', RegistrationsTable.as_view(), name='admin_regis_table'),
-    path(r'list-registration-requests/?status=(?P<status>)&org=(?P<org>)/', RegistrationsTable.as_view(), name='admin_regis_table')
+    re_path(r'list-registration-requests/?status= status>)/', RegistrationsTable.as_view(), name='admin_regis_table'),
+    re_path(r'list-registration-requests/?org=(?P<org>)/', RegistrationsTable.as_view(), name='admin_regis_table'),
+    re_path(r'list-registration-requests/?status=(?P<status>)&org=(?P<org>)/', RegistrationsTable.as_view(), name='admin_regis_table')
 ]

--- a/apcd_cms/src/apps/admin_submissions/urls.py
+++ b/apcd_cms/src/apps/admin_submissions/urls.py
@@ -1,10 +1,10 @@
-from django.urls import path
+from django.urls import path, re_path
 from apps.admin_submissions.views import AdminSubmissionsTable
 
 app_name = 'administration'
 urlpatterns = [
     path('list-submissions/', AdminSubmissionsTable.as_view(), name="admin_submissions"),
-    path(r'list-submissions/?status=(?P<status>)/', AdminSubmissionsTable.as_view(), name="admin_submissions"),
-    path(r'list-submissions/?sort=(?P<sort>)/', AdminSubmissionsTable.as_view(), name="admin_submissions"),
-    path(r'list-submissions/?sort=(?P<sort>)&filter=(?P<status>)/', AdminSubmissionsTable.as_view(), name="admin_submissions"),
+    re_path(r'list-submissions/?status=(?P<status>)/', AdminSubmissionsTable.as_view(), name="admin_submissions"),
+    re_path(r'list-submissions/?sort=(?P<sort>)/', AdminSubmissionsTable.as_view(), name="admin_submissions"),
+    re_path(r'list-submissions/?sort=(?P<sort>)&filter=(?P<status>)/', AdminSubmissionsTable.as_view(), name="admin_submissions"),
 ]

--- a/apcd_cms/src/apps/submissions/urls.py
+++ b/apcd_cms/src/apps/submissions/urls.py
@@ -1,11 +1,11 @@
-from django.urls import path
+from django.urls import path, re_path
 from apps.submissions.views import SubmissionsTable, check_submitter_role
 
 app_name = 'submissions'
 urlpatterns = [
     path('list-submissions/', SubmissionsTable.as_view(), name="list_submissions"),
-    path(r'list-submissions/?status=(?P<status>)/', SubmissionsTable.as_view(), name="list_submissions"),
-    path(r'list-submissions/?sort=(?P<sort>)/', SubmissionsTable.as_view(), name="list_submissions"),
-    path(r'list-submissions/?sort=(?P<sort>)&status=(?P<status>)/', SubmissionsTable.as_view(), name="list_submissions"),
+    re_path(r'list-submissions/?status=(?P<status>)/', SubmissionsTable.as_view(), name="list_submissions"),
+    re_path(r'list-submissions/?sort=(?P<sort>)/', SubmissionsTable.as_view(), name="list_submissions"),
+    re_path(r'list-submissions/?sort=(?P<sort>)&status=(?P<status>)/', SubmissionsTable.as_view(), name="list_submissions"),
     path('check-submitter-role/', check_submitter_role),
 ]

--- a/apcd_cms/src/apps/submitter_renewals_listing/urls.py
+++ b/apcd_cms/src/apps/submitter_renewals_listing/urls.py
@@ -1,10 +1,10 @@
-from django.urls import path
+from django.urls import path, re_path
 from apps.submitter_renewals_listing.views import SubmittersTable
 
 app_name = 'register'
 urlpatterns = [
     path('list-registration-requests/', SubmittersTable.as_view(), name='submitter_regis_table'),
-    path(r'list-registration-requests/?status=(?P<status>)/', SubmittersTable.as_view(), name='submitter_regis_table'),
-    path(r'list-registration-requests/?org=(?P<org>)/', SubmittersTable.as_view(), name='submitter_regis_table'),
-    path(r'list-registration-requests/?status=(?P<status>)&org=(?P<org>)/', SubmittersTable.as_view(), name='submitter_regis_table')
+    re_path(r'list-registration-requests/?status=(?P<status>)/', SubmittersTable.as_view(), name='submitter_regis_table'),
+    re_path(r'list-registration-requests/?org=(?P<org>)/', SubmittersTable.as_view(), name='submitter_regis_table'),
+    re_path(r'list-registration-requests/?status=(?P<status>)&org=(?P<org>)/', SubmittersTable.as_view(), name='submitter_regis_table')
 ]


### PR DESCRIPTION
## Overview

Docker gives warnings for us having regular expressions (regexes) in our URLs. This change prevents those warnings.

## Related

[WP-387](https://tacc-main.atlassian.net/browse/WP-387)

## Changes

I imported `re_path` and applied it to any `path` that contained a regex.

## Testing

1. Turn on the Docker containers using `make start` and fire up the client with `npm run dev` as usual.
2. Login to the admin site.
3. Navigate to any page.
4. Watch the Docker logs to see that there are no more warnings.

## UI

![image](https://github.com/user-attachments/assets/6579674d-5ed0-4072-ba47-cfd657851c51)

<!--
## Notes

…
-->
