### PR TITLE
task/WP-324: Add message for no data to show in listing tables

### DIFF
--- a/apcd-cms/src/client/src/components/Admin/Exceptions/AdminExceptions.tsx
+++ b/apcd-cms/src/client/src/components/Admin/Exceptions/AdminExceptions.tsx
@@ -120,28 +120,36 @@ export const AdminExceptions: React.FC = () => {
           </tr>
         </thead>
         <tbody>
-          {data?.page.map((row: ExceptionRow, rowIndex: number) => (
-            <tr key={rowIndex}>
-              <td>{formatDate(row.created_at)}</td>
-              <td>{row.entity_name}</td>
-              <td>{row.requestor_name}</td>
-              <td>{row.request_type}</td>
-              <td>{row.outcome}</td>
-              <td>{row.status}</td>
-              <td className="modal-cell">
-                <select
-                  id={`actionsDropdown_${row.exception_id}`}
-                  value={dropdownValue}
-                  className="status-filter"
-                  onChange={(e) => openAction(e, row)}
-                >
-                  <option value="">Select Action</option>
-                  <option value="viewException">View Record</option>
-                  <option value="editException">Edit Record</option>
-                </select>
+          {data?.page && data.page.length > 0 ? (
+            data?.page.map((row: ExceptionRow, rowIndex: number) => (
+              <tr key={rowIndex}>
+                <td>{formatDate(row.created_at)}</td>
+                <td>{row.entity_name}</td>
+                <td>{row.requestor_name}</td>
+                <td>{row.request_type}</td>
+                <td>{row.outcome}</td>
+                <td>{row.status}</td>
+                <td className="modal-cell">
+                  <select
+                    id={`actionsDropdown_${row.exception_id}`}
+                    value={dropdownValue}
+                    className="status-filter"
+                    onChange={(e) => openAction(e, row)}
+                  >
+                    <option value="">Select Action</option>
+                    <option value="viewException">View Record</option>
+                    <option value="editException">Edit Record</option>
+                  </select>
+                </td>
+              </tr>
+            ))
+          ) : (
+            <tr>
+              <td colSpan={7} style={{ textAlign: 'center' }}>
+                No Data available
               </td>
             </tr>
-          ))}
+          )}
         </tbody>
       </table>
       <div className={styles.paginatorContainer}>

--- a/apcd-cms/src/client/src/components/Admin/Extensions/AdminExtensions.tsx
+++ b/apcd-cms/src/client/src/components/Admin/Extensions/AdminExtensions.tsx
@@ -119,29 +119,37 @@ export const AdminExtensions: React.FC = () => {
           </tr>
         </thead>
         <tbody>
-          {data?.page.map((row: ExtensionRow, rowIndex: number) => (
-            <tr key={rowIndex}>
-              <td>{formatDate(row.created)}</td>
-              <td>{row.org_name}</td>
-              <td>{row.requestor}</td>
-              <td>{row.type}</td>
-              <td>{row.ext_outcome}</td>
-              <td>{row.ext_status}</td>
-              <td>{formatDate(row.approved_expiration_date)}</td>
-              <td className="modal-cell">
-                <select
-                  id={`actionsDropdown_${row.ext_id}`}
-                  defaultValue=""
-                  className="status-filter"
-                  onChange={(e) => openAction(e, row.ext_id)}
-                >
-                  <option value="">Select Action</option>
-                  <option value="viewExtension">View Record</option>
-                  <option value="editExtension">Edit Record</option>
-                </select>
+          {data?.page && data.page.length > 0 ? (
+            data?.page.map((row: ExtensionRow, rowIndex: number) => (
+              <tr key={rowIndex}>
+                <td>{formatDate(row.created)}</td>
+                <td>{row.org_name}</td>
+                <td>{row.requestor}</td>
+                <td>{row.type}</td>
+                <td>{row.ext_outcome}</td>
+                <td>{row.ext_status}</td>
+                <td>{formatDate(row.approved_expiration_date)}</td>
+                <td className="modal-cell">
+                  <select
+                    id={`actionsDropdown_${row.ext_id}`}
+                    defaultValue=""
+                    className="status-filter"
+                    onChange={(e) => openAction(e, row.ext_id)}
+                  >
+                    <option value="">Select Action</option>
+                    <option value="viewExtension">View Record</option>
+                    <option value="editExtension">Edit Record</option>
+                  </select>
+                </td>
+              </tr>
+            ))
+          ) : (
+            <tr>
+              <td colSpan={8} style={{ textAlign: 'center' }}>
+                No Data available
               </td>
             </tr>
-          ))}
+          )}
         </tbody>
       </table>
       <div className={styles.paginatorContainer}>

--- a/apcd-cms/src/client/src/components/Admin/Submissions/AdminSubmissions.tsx
+++ b/apcd-cms/src/client/src/components/Admin/Submissions/AdminSubmissions.tsx
@@ -132,29 +132,37 @@ export const AdminSubmissions: React.FC = () => {
           </tr>
         </thead>
         <tbody>
-          {submissionData?.page.map(
-            (row: FileSubmissionRow, rowIndex: number) => (
-              <tr key={rowIndex}>
-                <td>{formatDate(row.received_timestamp)}</td>
-                <td>{titleCase(row.entity_name)}</td>
-                <td>{row.file_name}</td>
-                <td>{titleCase(row.outcome)}</td>
-                <td>{titleCase(row.status)}</td>
-                <td>{formatDate(row.updated_at)}</td>
-                <td>
-                  <Button
-                    type="link"
-                    onClick={() => {
-                      setSelectedSubmission(row);
-                      setSelectedSubmissionLog(row?.view_modal_content);
-                      setViewModalOpen(true);
-                    }}
-                  >
-                    View Logs
-                  </Button>
-                </td>
-              </tr>
+          {submissionData?.page && submissionData.page.length > 0 ? (
+            submissionData?.page.map(
+              (row: FileSubmissionRow, rowIndex: number) => (
+                <tr key={rowIndex}>
+                  <td>{formatDate(row.received_timestamp)}</td>
+                  <td>{titleCase(row.entity_name)}</td>
+                  <td>{row.file_name}</td>
+                  <td>{titleCase(row.outcome)}</td>
+                  <td>{titleCase(row.status)}</td>
+                  <td>{formatDate(row.updated_at)}</td>
+                  <td>
+                    <Button
+                      type="link"
+                      onClick={() => {
+                        setSelectedSubmission(row);
+                        setSelectedSubmissionLog(row?.view_modal_content);
+                        setViewModalOpen(true);
+                      }}
+                    >
+                      View Logs
+                    </Button>
+                  </td>
+                </tr>
+              )
             )
+          ) : (
+            <tr>
+              <td colSpan={7} style={{ textAlign: 'center' }}>
+                No Data available
+              </td>
+            </tr>
           )}
         </tbody>
       </table>

--- a/apcd-cms/src/client/src/components/Admin/ViewUsers/ViewUsers.tsx
+++ b/apcd-cms/src/client/src/components/Admin/ViewUsers/ViewUsers.tsx
@@ -144,28 +144,36 @@ export const ViewUsers: React.FC = () => {
             </tr>
           </thead>
           <tbody>
-            {userData?.page.map((user: UserRow, rowIndex: number) => (
-              <tr key={rowIndex}>
-                <td>{user.user_id}</td>
-                <td>{user.user_name}</td>
-                <td>{user.entity_name}</td>
-                <td>{user.role_name}</td>
-                <td>{user.status}</td>
-                <td>{user.user_number}</td>
-                <td>
-                  <select
-                    onChange={(event) => handleActionChange(event, user)}
-                    value={dropdownValue}
-                  >
-                    <option value="" disabled>
-                      Select Action
-                    </option>
-                    <option value="view">View Record</option>
-                    <option value="edit">Edit Record</option>
-                  </select>
+            {userData?.page && userData.page.length > 0 ? (
+              userData?.page.map((user: UserRow, rowIndex: number) => (
+                <tr key={rowIndex}>
+                  <td>{user.user_id}</td>
+                  <td>{user.user_name}</td>
+                  <td>{user.entity_name}</td>
+                  <td>{user.role_name}</td>
+                  <td>{user.status}</td>
+                  <td>{user.user_number}</td>
+                  <td>
+                    <select
+                      onChange={(event) => handleActionChange(event, user)}
+                      value={dropdownValue}
+                    >
+                      <option value="" disabled>
+                        Select Action
+                      </option>
+                      <option value="view">View Record</option>
+                      <option value="edit">Edit Record</option>
+                    </select>
+                  </td>
+                </tr>
+              ))
+            ) : (
+              <tr>
+                <td colSpan={7} style={{ textAlign: 'center' }}>
+                  No Data available
                 </td>
               </tr>
-            ))}
+            )}
           </tbody>
         </table>
       </div>

--- a/apcd-cms/src/client/src/components/Submissions/ViewFileSubmissions/ViewSubmissions.tsx
+++ b/apcd-cms/src/client/src/components/Submissions/ViewFileSubmissions/ViewSubmissions.tsx
@@ -127,29 +127,37 @@ export const ViewFileSubmissions: React.FC = () => {
           </tr>
         </thead>
         <tbody>
-          {submissionData?.page.map(
-            (row: FileSubmissionRow, rowIndex: number) => (
-              <tr key={rowIndex}>
-                <td>{formatDate(row.received_timestamp)}</td>
-                <td>{titleCase(row.entity_name)}</td>
-                <td>{titleCase(row.file_name)}</td>
-                <td>{titleCase(row.outcome)}</td>
-                <td>{titleCase(row.status)}</td>
-                <td>{formatDate(row.updated_at)}</td>
-                <td>
-                  <Button
-                    type="link"
-                    onClick={() => {
-                      setSelectedSubmission(row);
-                      setSelectedSubmissionLog(row?.view_modal_content);
-                      setViewModalOpen(true);
-                    }}
-                  >
-                    View Logs
-                  </Button>
-                </td>
-              </tr>
+          {submissionData?.page && submissionData.page.length > 0 ? (
+            submissionData?.page.map(
+              (row: FileSubmissionRow, rowIndex: number) => (
+                <tr key={rowIndex}>
+                  <td>{formatDate(row.received_timestamp)}</td>
+                  <td>{titleCase(row.entity_name)}</td>
+                  <td>{titleCase(row.file_name)}</td>
+                  <td>{titleCase(row.outcome)}</td>
+                  <td>{titleCase(row.status)}</td>
+                  <td>{formatDate(row.updated_at)}</td>
+                  <td>
+                    <Button
+                      type="link"
+                      onClick={() => {
+                        setSelectedSubmission(row);
+                        setSelectedSubmissionLog(row?.view_modal_content);
+                        setViewModalOpen(true);
+                      }}
+                    >
+                      View Logs
+                    </Button>
+                  </td>
+                </tr>
+              )
             )
+          ) : (
+            <tr>
+              <td colSpan={7} style={{ textAlign: 'center' }}>
+                No Data available
+              </td>
+            </tr>
           )}
         </tbody>
       </table>


### PR DESCRIPTION
## Overview

…

## Related

- [WP-324](https://tacc-main.atlassian.net/browse/WP-324)
<!--
- requires https://github.com/TACC/Core-CMS/pull/117
-->…

## Changes
- Puts a wrapper around table rows that checks if there is any row data in the response, otherwise displays a message reading 'No Data available' (from registrations listing)
…

## Testing

1. Go to each listing (excluding registrations listings) and use the following filter combos to check if the 'No Data available':
  - Admin Exceptions: Status to 'Pending', Organization to 'Uthealth - Sph Chcd: Apcd'
  - Admin Extensions: Couldn't find a combo as only one org on local db, can skip
  - Admin Users: Status to 'Active', Org to 'UTHealth - SPH CHCD: APCD'
  - Admin Submissions: Couldn't find a combo as only one filter + all statuses present on table, can skip
  - User Submissions: Dependent on if you have attempted submissions on dev DB, try toggling between status values in filter

## UI

…

<!--
## Notes

…
-->
