### PR TITLE
Task/WP-387: Remove regex from path URLs

### DIFF
--- a/apcd_cms/src/apps/admin_exception/urls.py
+++ b/apcd_cms/src/apps/admin_exception/urls.py
@@ -5,14 +5,6 @@ from apps.admin_exception.views import AdminExceptionsTable, UpdateExceptionView
 app_name = 'admin_exception'
 urlpatterns = [
     path('list-exceptions/', TemplateView.as_view(template_name='list_admin_exception.html'), name="list_exceptions"),
-    path('list-exceptions/<str:status>', AdminExceptionsTable.as_view(), name='status'),
-    path('list-exceptions/<str:org>', AdminExceptionsTable.as_view(), name='org'),
-    path('list-exceptions/<str:status><str:org>', AdminExceptionsTable.as_view(), name='status_org'),
-    path(r'list-exceptions/api/', AdminExceptionsTable.as_view(), name='admin_exceptions_table_api'),
-    path(r'list-exceptions/api/?status=(?P<status>)/', AdminExceptionsTable.as_view(),
-         name='admin_exceptions_table_api'),
-    path(r'list-exceptions/api/?org=(?P<org>)/', AdminExceptionsTable.as_view(), name='admin_exceptions_table_api'),
-    path(r'list-exceptions/api/?status=(?P<status>)&org=(?P<org>)/', AdminExceptionsTable.as_view(),
-         name='admin_exceptions_table_api'),
+    path('list-exceptions/api/', AdminExceptionsTable.as_view(), name='admin_exceptions_table_api'),
     path('exceptions/<int:exception_id>/', UpdateExceptionView.as_view(), name='update_exceptions'),
 ]

--- a/apcd_cms/src/apps/admin_extension/urls.py
+++ b/apcd_cms/src/apps/admin_extension/urls.py
@@ -5,10 +5,7 @@ from apps.admin_extension.views import AdminExtensionsTable, UpdateExtensionsVie
 
 app_name = 'admin_extension'
 urlpatterns = [
-    path('list-extensions/',  TemplateView.as_view(template_name='list_admin_extension.html'), name="list_extensions"),
-    path(r'list-extensions/api/', AdminExtensionsTable.as_view(), name='admin_extensions_table_api'),
-    path(r'list-extensions/api/?status=(?P<status>)/', AdminExtensionsTable.as_view(), name='admin_extensions_table_api'),
-    path(r'list-extensions/api/?org=(?P<org>)/', AdminExtensionsTable.as_view(), name='admin_extensions_table_api'),
-    path(r'list-extensions/api/?status=(?P<status>)&org=(?P<org>)/', AdminExtensionsTable.as_view(), name='admin_extensions_table_api'),
-    path(r'update-extension/<int:ext_id>/', UpdateExtensionsView.as_view(), name='update_extension'),
+    path('list-extensions/', TemplateView.as_view(template_name='list_admin_extension.html'), name="list_extensions"),
+    path('list-extensions/api/', AdminExtensionsTable.as_view(), name='admin_extensions_table_api'),
+    path('update-extension/<int:ext_id>/', UpdateExtensionsView.as_view(), name='update_extension'),
 ]

--- a/apcd_cms/src/apps/admin_regis_table/urls.py
+++ b/apcd_cms/src/apps/admin_regis_table/urls.py
@@ -5,11 +5,6 @@ from apps.admin_regis_table.views import RegistrationsTable
 app_name = 'admin_regis_table'
 urlpatterns = [
     path('list-registration-requests/', TemplateView.as_view(template_name='list_registrations.html'), name='admin_regis_table'),
-    path(r'list-registration-requests/api/', RegistrationsTable.as_view(), name='admin_regis_table_api'),
-    path(r'list-registration-requests/api/?status=(?P<status>)/', RegistrationsTable.as_view(), name='admin_regis_table_api'),
-    path(r'list-registration-requests/api/?org=(?P<org>)/', RegistrationsTable.as_view(), name='admin_regis_table_api'),
-    path(r'list-registration-requests/api/?status=(?P<status>)&org=(?P<org>)/', RegistrationsTable.as_view(), name='admin_regis_table_api'),
-    path(r'list-registration-requests/api/?reg_id=(?P<reg_id>)/', RegistrationsTable.as_view(), name='admin_regis_table_api'),
-    path(r'request-to-submit/api/<int:reg_id>/', RegistrationsTable.as_view(), name='admin_regis_update_api'),
-
+    path('list-registration-requests/api/', RegistrationsTable.as_view(), name='admin_regis_table_api'),
+    path('request-to-submit/api/<int:reg_id>/', RegistrationsTable.as_view(), name='admin_regis_update_api'),
 ]

--- a/apcd_cms/src/apps/registrations/urls.py
+++ b/apcd_cms/src/apps/registrations/urls.py
@@ -5,7 +5,5 @@ from apps.registrations.views import RegistrationFormView
 app_name = 'registrations'
 urlpatterns = [
     path('request-to-submit/', TemplateView.as_view(template_name='registration_form.html'), name='register_form'),
-    path(r'request-to-submit/api/', RegistrationFormView.as_view(), name='register_form_api'),
-    path(r'request-to-submit/api/?reg_id=(?P<reg_id>)/', RegistrationFormView.as_view(), name='register_form_api'),
-
+    path('request-to-submit/api/', RegistrationFormView.as_view(), name='register_form_api'),
 ]

--- a/apcd_cms/src/apps/submitter_renewals_listing/urls.py
+++ b/apcd_cms/src/apps/submitter_renewals_listing/urls.py
@@ -5,9 +5,5 @@ from apps.submitter_renewals_listing.views import SubmittersTable
 app_name = 'register'
 urlpatterns = [
     path('list-registration-requests/', TemplateView.as_view(template_name='list_submitter_registrations.html'), name='submitter_regis_table'),
-    path(r'list-registration-requests/api/', SubmittersTable.as_view(), name='submitter_regis_table_api'),
-    path(r'list-registration-requests/api/?status=(?P<status>)/', SubmittersTable.as_view(), name='submitter_regis_table_api'),
-    path(r'list-registration-requests/api/?org=(?P<org>)/', SubmittersTable.as_view(), name='submitter_regis_table_api'),
-    path(r'list-registration-requests/api/?status=(?P<status>)&org=(?P<org>)/', SubmittersTable.as_view(), name='submitter_regis_table_api'),
-    path(r'list-registration-requests/api/?reg_id=(?P<reg_id>)/', SubmittersTable.as_view(), name='submitter_regis_table_api'),
+    path('list-registration-requests/api/', SubmittersTable.as_view(), name='submitter_regis_table_api'),
 ]

--- a/apcd_cms/src/apps/view_users/urls.py
+++ b/apcd_cms/src/apps/view_users/urls.py
@@ -8,6 +8,5 @@ urlpatterns = [
     path('view-users/api/', ViewUsersTable.as_view(), name='view_users_api'),
     path('view-users/api/options', ViewUsersTable.as_view(), name='view_users_api_options'),
     path('view-users/api/modal/<str:modal_type>/', ViewUsersTable.as_view(), name='view_users_modal'),
-    path('view-users/api/modal/<str:modal_type>/', ViewUsersTable.as_view(), name='view_users_modal'),
     path('users/<int:user_number>/', UpdateUserView.as_view(), name='update_user'),
 ]


### PR DESCRIPTION
## Overview

Several of our URLs contains regular expressions (or regexes) that passed in variables when a user sorted any of the tables by a given variable. This was throwing warnings in back-end terminals as well as Docker.

## Related

- [WP-387](https://tacc-main.atlassian.net/browse/WP-387)

## Changes

I replaced all instances of `r'(?P<variable>'` with `'<variable>'` from Django's `urls.path` library in order to continue to pass in these variables. 

## Testing

1. Log in as an Admin as usual.
2. Fire up the containers as usual.
3. Navigate to any page containing (for example, Admin > List Registration Requests).
4. Toggle either dropdown menu to anything other than its default value.
5. Notice in the back-end terminal or Docker that there are no more warnings!

## UI

![image](https://github.com/user-attachments/assets/e0a90fa5-308c-44e2-875b-73ab5aa401a0)

<!--
## Notes

…
-->
