### PR TITLE
Bugs/WP-789: Extension Edit Modal

### DIFF
--- a/apcd_cms/src/apps/admin_extension/views.py
+++ b/apcd_cms/src/apps/admin_extension/views.py
@@ -1,14 +1,11 @@
-from django.http import HttpResponseRedirect, HttpResponse, JsonResponse
-from django.core.paginator import Paginator, EmptyPage
+from django.http import HttpResponseRedirect, JsonResponse
 from django.views.generic.base import TemplateView
 from django.views import View
-from django.template import loader
-from apps.utils.apcd_database import get_all_extensions, update_extension 
+from apps.utils.apcd_database import get_all_extensions, update_extension
 from apps.utils.apcd_groups import is_apcd_admin
 from apps.utils.utils import table_filter
 from apps.utils.utils import title_case
 from apps.components.paginator.paginator import paginator
-from dateutil import parser
 from datetime import date as datetimeDate
 from datetime import datetime
 import logging
@@ -16,21 +13,18 @@ import json
 
 logger = logging.getLogger(__name__)
 
+
 class AdminExtensionsTable(TemplateView):
 
     template_name = 'list_admin_extension.html'
 
     def get(self, request, *args, **kwargs):
         extension_content = get_all_extensions()
-
-        #context = self.get_context_data(extension_content, *args,**kwargs)
-        #template = loader.get_template(self.template_name)
-        #return HttpResponse(template.render(context, request))
         context = self.get_extensions_list_json(extension_content, *args, **kwargs)
         return JsonResponse({'response': context})
 
     def dispatch(self, request, *args, **kwargs):
-        if not request.user.is_authenticated or not is_apcd_admin(request.user): 
+        if not request.user.is_authenticated or not is_apcd_admin(request.user):
             return HttpResponseRedirect('/')
         return super(AdminExtensionsTable, self).dispatch(request, *args, **kwargs)
 
@@ -131,12 +125,14 @@ class AdminExtensionsTable(TemplateView):
             'notes': ext[17] if ext[17] else "None",
         }
 
+
 # function converts int value in the format YYYYMM to a string with abbreviated month and year
 def _get_applicable_data_period(value):
     try:
         return datetime.strptime(str(value), '%Y%m').strftime('%b. %Y')
     except:
         return None
+
 
 class UpdateExtensionsView(View):
     def dispatch(self, request, *args, **kwargs):

--- a/apcd_cms/src/apps/common_api/urls.py
+++ b/apcd_cms/src/apps/common_api/urls.py
@@ -1,10 +1,10 @@
 from django.urls import path
-from apps.common_api.views import EntitiesView, cdlsView
-from . import views
+from apps.common_api.views import EntitiesView, cdlsView, DataPeriodsView
 
 app_name = 'common_api'
 urlpatterns = [
     path('entities/', EntitiesView.as_view(), name='entities_api'),
     path('cdls/', cdlsView.as_view(), name='cdls_api'),
-    path('cdls/<str:file_type>', cdlsView.as_view(), name='cdls_api')
+    path('cdls/<str:file_type>', cdlsView.as_view(), name='cdls_api'),
+    path('data_periods/', DataPeriodsView.as_view(), name='dataperiods_api')
 ]

--- a/apcd_cms/src/apps/common_api/views.py
+++ b/apcd_cms/src/apps/common_api/views.py
@@ -1,4 +1,4 @@
-from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
+from django.http import HttpResponse, HttpResponseRedirect, JsonResponse, Http404
 from django.template import loader
 from django.views.generic import TemplateView
 from apps.utils import apcd_database
@@ -27,12 +27,6 @@ class EntitiesView(TemplateView):
     def get_submitter_info_json(self, submitters):
         context = {}
 
-        def _get_applicable_data_period(value):
-            try:
-                return datetime.strptime(str(value), '%Y%m').strftime('%Y-%m')
-            except Exception:
-                return None
-
         def _set_submitter(sub, data_periods):
             return {
                 "submitter_id": sub[0],
@@ -46,23 +40,18 @@ class EntitiesView(TemplateView):
         context["submitters"] = []
 
         for submitter in submitters:
-            data_periods = []
-            submitter_id = submitter[0]
-            applicable_data_periods = apcd_database.get_applicable_data_periods(submitter[0])
-            for data_period_tuple in applicable_data_periods:
-                for data_period in data_period_tuple:
-                    data_period = _get_applicable_data_period(data_period)
-                    expected_dates = apcd_database.get_current_exp_date(submitter_id=submitter_id, applicable_data_period=data_period.replace('-', ''))
-                    data_periods.append({
-                        'data_period': data_period,
-                        'expected_date': expected_dates[0][0] if expected_dates else ''
-                    })
-            data_periods = sorted(data_periods, key=lambda x: x['data_period'], reverse=True)
+            data_periods = _getApplicableDataPeriods(submitter[0])
             context["submitters"].append(_set_submitter(submitter, data_periods))
 
         return context
 
+
 class cdlsView(TemplateView):
+    def dispatch(self, request, *args, **kwargs):
+        if not request.user.is_authenticated or not has_apcd_group(request.user):
+            return HttpResponseRedirect('/')
+        return super(cdlsView, self).dispatch(request, *args, **kwargs)
+
     def get(self, request, *args, **kwargs):
         file_type = kwargs.get('file_type')
         
@@ -81,3 +70,39 @@ class cdlsView(TemplateView):
             cdls_response.append(_set_cdls(cdl))
 
         return JsonResponse({"cdls": cdls_response})
+
+
+class DataPeriodsView(TemplateView):
+    def dispatch(self, request, *args, **kwargs):
+        if not request.user.is_authenticated or not has_apcd_group(request.user):
+            return HttpResponseRedirect('/')
+        return super(DataPeriodsView, self).dispatch(request, *args, **kwargs)
+
+    def get(self, request, *args, **kwargs):
+        submitter_id = request.GET.get('submitter_id', None)
+        if submitter_id is None:
+            raise Http404("Submitter Id not provided")
+        applicable_data_periods = _getApplicableDataPeriods(submitter_id)
+
+        return JsonResponse({'response': {"data_periods": applicable_data_periods}})
+
+
+def _getApplicableDataPeriods(submitter_id):
+    def _get_applicable_data_period(value):
+        try:
+            return datetime.strptime(str(value), '%Y%m').strftime('%Y-%m')
+        except Exception:
+            return None
+
+    data_periods = []
+    applicable_data_periods = apcd_database.get_applicable_data_periods(submitter_id)
+    for data_period_tuple in applicable_data_periods:
+        for data_period in data_period_tuple:
+            data_period = _get_applicable_data_period(data_period)
+            expected_dates = apcd_database.get_current_exp_date(submitter_id=submitter_id, applicable_data_period=data_period.replace('-', ''))
+            data_periods.append({
+                'data_period': data_period,
+                'expected_date': expected_dates[0][0] if expected_dates else ''
+            })
+    data_periods = sorted(data_periods, key=lambda x: x['data_period'], reverse=True)
+    return data_periods

--- a/apcd_cms/src/apps/common_api/views.py
+++ b/apcd_cms/src/apps/common_api/views.py
@@ -1,14 +1,13 @@
-from django.http import HttpResponse, HttpResponseRedirect, JsonResponse, Http404
-from django.template import loader
+from django.http import HttpResponseRedirect, JsonResponse, Http404
 from django.views.generic import TemplateView
 from apps.utils import apcd_database
-from apps.utils.apcd_groups import has_apcd_group
+from apps.utils.apcd_groups import has_apcd_group, is_apcd_admin
 from apps.utils.utils import title_case
 from datetime import datetime
 import logging
-import json
 
 logger = logging.getLogger(__name__)
+
 
 class EntitiesView(TemplateView):
     def get(self, request, *args, **kwargs):
@@ -74,7 +73,7 @@ class cdlsView(TemplateView):
 
 class DataPeriodsView(TemplateView):
     def dispatch(self, request, *args, **kwargs):
-        if not request.user.is_authenticated or not has_apcd_group(request.user):
+        if not request.user.is_authenticated or not is_apcd_admin(request.user):
             return HttpResponseRedirect('/')
         return super(DataPeriodsView, self).dispatch(request, *args, **kwargs)
 

--- a/apcd_cms/src/apps/utils/apcd_database.py
+++ b/apcd_cms/src/apps/utils/apcd_database.py
@@ -1134,6 +1134,7 @@ def update_extension(form):
         if cur is not None:
             cur.close()
 
+
 def get_submitter_info(user):
     cur = None
     conn = None

--- a/apcd_cms/src/apps/utils/apcd_database.py
+++ b/apcd_cms/src/apps/utils/apcd_database.py
@@ -1111,7 +1111,6 @@ def update_extension(form):
         
         for field, column_name in columns.items():
             value = form.get(field)
-            print(value)
             if value not in (None, ""):
                 # to make sure applicable data period field is an int to insert to DB
                 if column_name == 'applicable_data_period':

--- a/apcd_cms/src/apps/utils/apcd_database.py
+++ b/apcd_cms/src/apps/utils/apcd_database.py
@@ -1070,62 +1070,47 @@ def create_extension(form, extension, sub_data):
         if conn is not None:
             conn.close()
 
+
 def update_extension(form):
     cur = None
     conn = None
     try:
-        conn = psycopg.connect(
-            host=APCD_DB['host'],
-            dbname=APCD_DB['database'],
-            user=APCD_DB['user'],
-            password=APCD_DB['password'],
-            port=APCD_DB['port'],
-            sslmode='require'
-        )
-        cur = conn.cursor()
-        operation = """UPDATE extensions
-            SET
-            updated_at= %s,"""
-        
-        set_values = []
-        # to set column names for query to the correct DB name
-        columns = {
-            'applicable_data_period': 'applicable_data_period',
-            'status': 'status',
-            'outcome': 'outcome',
-            'approved_expiration_date': 'approved_expiration_date'
-        }
-        # To make sure fields are not blank. 
-        # If they aren't, add column to update set operation
-        for field, column_name in columns.items():
-            value = form.get(field)
-            if value not in (None, ""):
-                set_values.append(f"{column_name} = %s")
+        with db_connect() as conn:
+            cur = conn.cursor()
+            query = "UPDATE extensions SET updated_at = %s"
+            values = [datetime.now()]  # Timestamp for updated_at
 
-        # to allow notes to be cleared, need to move notes out of the loop that ignores none
-        operation += ", ".join(set_values) + ", notes = %s WHERE extension_id = %s"
-        ## add last update time to all extension updates
-        values = [
-            datetime.now(),
-        ]
-        
-        for field, column_name in columns.items():
-            value = form.get(field)
-            if value not in (None, ""):
-                # to make sure applicable data period field is an int to insert to DB
-                if column_name == 'applicable_data_period':
-                    values.append(int(value.replace('-', '')))
-                # else server side clean values
-                else:
-                    values.append(_clean_value(value))
+            # Map form fields to DB columns
+            columns = {
+                'applicable_data_period': 'applicable_data_period',
+                'status': 'status',
+                'outcome': 'outcome',
+                'approved_expiration_date': 'approved_expiration_date'
+            }
 
-        # to allow notes to be cleared, need to move notes out of the loop that ignores none
-        values.append(_clean_value(form['notes']))
-        ## to make sure extension id is last in query to match with WHERE statement
-        values.append(_clean_value(form['extension_id']))
+            # Build the SET clause dynamically
+            set_clauses = []
+            for field, column_name in columns.items():
+                value = form.get(field)
+                if value not in (None, "", "None"):
+                    set_clauses.append(f"{column_name} = %s")
+                    if column_name == 'applicable_data_period':
+                        values.append(int(value.replace('-', '')))
+                    elif column_name == 'approved_expiration_date':
+                        # Convert to None if the value is 'None' (string)
+                        values.append(None if value == 'None' else _clean_value(value))
+                    else:
+                        values.append(_clean_value(value))
 
-        cur.execute(operation, values)
-        conn.commit()
+            # Include 'notes' field, allowing it to be cleared
+            set_clauses.append("notes = %s")
+            values.append(_clean_value(form.get('notes', "")))
+
+            query += ", " + ", ".join(set_clauses) + " WHERE extension_id = %s"
+            values.append(_clean_value(form['extension_id']))
+
+            cur.execute(query, values)
+            conn.commit()
     except Exception as error:
         logger.error(error)
         return error

--- a/apcd_cms/src/client/src/hooks/entities/index.ts
+++ b/apcd_cms/src/client/src/hooks/entities/index.ts
@@ -16,4 +16,8 @@ export type ApplicableDataPeriod = {
   expected_date: string;
 };
 
-export { useEntities } from './useEntities';
+export type SubmitterDataPeriods = {
+  data_periods: ApplicableDataPeriod[];
+};
+
+export { useEntities, useSubmitterDataPeriods } from './useEntities';

--- a/apcd_cms/src/client/src/hooks/entities/useEntities.ts
+++ b/apcd_cms/src/client/src/hooks/entities/useEntities.ts
@@ -1,6 +1,6 @@
 import { useQuery, UseQueryResult } from 'react-query';
 import { fetchUtil } from 'utils/fetchUtil';
-import { SubmitterEntityData } from '.';
+import { SubmitterEntityData, SubmitterDataPeriods } from '.';
 
 const getEntities = async () => {
   const url = `common_api/entities/`;
@@ -14,6 +14,27 @@ export const useEntities = (): UseQueryResult<SubmitterEntityData> => {
   const query = useQuery(['entities'], () =>
     getEntities()
   ) as UseQueryResult<SubmitterEntityData>;
+
+  return { ...query };
+};
+
+const getSubmitterDataPeriods = async (params: any) => {
+  const url = `common_api/data_periods/`;
+  const response = await fetchUtil({ url, params });
+  return response.response;
+};
+
+export const useSubmitterDataPeriods = (
+  submitter_id: string | undefined
+): UseQueryResult<SubmitterDataPeriods> => {
+  const params: { submitter_id?: string } = { submitter_id };
+  const query = useQuery(
+    ['submitterDataPeriods'],
+    () => getSubmitterDataPeriods(params),
+    {
+      enabled: submitter_id !== undefined && submitter_id !== null, // Allow `0` as valid
+    }
+  ) as UseQueryResult<SubmitterDataPeriods>;
 
   return { ...query };
 };


### PR DESCRIPTION
## Overview
Fixes the following issues:
1. Remove references to `Exception` and `Users` in the labels and code.
2. After error, clear it when re-submitted
3. Disable submit when nothing is edited
4. Date periods are previously retrieved based on what the user has access to, instead get it for the submitter_id - this is admin page, so it should retrieve all available.

## Related

[WP-789](https://tacc-main.atlassian.net/browse/WP-789)

## Changes
1. One significant change is to add new api to retrieve available date period for submitter id.

## Testing

1. Go to http://localhost:8000/administration/list-extensions
2. Use the edit modal and try the following
     * labels are accurate
     * submit with bad date and error should go away on resubmit
     * submit is disabled if there is no edit
     * date periods for extensions that current user did not submit should still retrieve date periods and populate in UI.
