### PR TITLE
WP-793: When log is null, handle issue gracefully instead of 500

### DIFF
--- a/apcd_cms/src/apps/utils/apcd_database.py
+++ b/apcd_cms/src/apps/utils/apcd_database.py
@@ -854,7 +854,7 @@ def get_user_submission_log(log_id, log_type, user=None):
             FROM submission_logs
             JOIN submissions ON submissions.submission_id = submission_logs.submission_id
             JOIN submitter_users ON submissions.submitter_id = submitter_users.submitter_id
-            WHERE submission_logs.log_id = %s
+            WHERE submission_logs.log_id = %s AND {log_column_name} IS NOT NULL
         """
 
         params = [log_id]


### PR DESCRIPTION
## Overview
1) Provide 404 error when log is null.
2) Also, currently the download log link is not available if log is null.

## Related
[WP-793](https://tacc-main.atlassian.net/browse/WP-793)

## Changes
1. Update sql to do null check.

## Testing

1. Go to http://localhost:8000/administration/view_log?log_type=html&log_id=290 to see 404.
2. Download a valid log at http://localhost:8000/administration/list-submissions/ to check for regressions

## UI
<img width="1395" alt="Screenshot 2024-12-04 at 9 59 11 AM" src="https://github.com/user-attachments/assets/e4f99e6b-7089-410b-ac90-b60d1b8cbdac">


