### PR TITLE
Bug/WP-792: disable submit if form is not modified.

### DIFF
--- a/apcd_cms/src/client/src/components/Admin/EditExceptionModal/EditExceptionModal.tsx
+++ b/apcd_cms/src/client/src/components/Admin/EditExceptionModal/EditExceptionModal.tsx
@@ -396,7 +396,7 @@ const EditExceptionModal: React.FC<EditRecordModalProps> = ({
               <Button
                 type="primary"
                 attr="submit"
-                disabled={formik.isSubmitting}
+                disabled={!formik.dirty || formik.isSubmitting}
               >
                 Submit
               </Button>

--- a/apcd_cms/src/client/src/components/Admin/ViewUsers/EditRecordModal.tsx
+++ b/apcd_cms/src/client/src/components/Admin/ViewUsers/EditRecordModal.tsx
@@ -3,7 +3,6 @@ import {
   Modal,
   ModalBody,
   ModalHeader,
-  Button,
   Label,
   FormGroup,
   Row,
@@ -15,6 +14,7 @@ import * as Yup from 'yup';
 import { UserRow } from 'hooks/admin';
 import styles from './ViewUsers.module.scss';
 import { formatDate } from 'utils/dateUtil';
+import Button from 'core-components/Button';
 
 interface EditRecordModalProps {
   isOpen: boolean;
@@ -123,7 +123,7 @@ const EditRecordModal: React.FC<EditRecordModalProps> = ({
             validationSchema={validationSchema}
             onSubmit={handleSave}
           >
-            {({ isSubmitting }) => (
+            {({ isSubmitting, dirty }) => (
               <Form>
                 <Row>
                   <Col md={3}>
@@ -236,10 +236,9 @@ const EditRecordModal: React.FC<EditRecordModalProps> = ({
                 </Row>
                 <br />
                 <Button
-                  type="submit"
-                  color="primary"
-                  disabled={isSubmitting}
-                  className={styles.customSubmitButton}
+                  type="primary"
+                  attr="submit"
+                  disabled={isSubmitting || !dirty}
                 >
                   Submit
                 </Button>

--- a/apcd_cms/src/client/src/components/Forms/Registrations/RegistrationForm.tsx
+++ b/apcd_cms/src/client/src/components/Forms/Registrations/RegistrationForm.tsx
@@ -268,7 +268,7 @@ export const RegistrationForm: React.FC<{
           validationSchema={validationSchema}
           onSubmit={handleSubmit}
         >
-          {({ values, setFieldValue, resetForm }) => (
+          {({ values, setFieldValue, resetForm, dirty }) => (
             useEffect(() => {
               if (isSuccess) {
                 resetForm();
@@ -499,7 +499,7 @@ export const RegistrationForm: React.FC<{
                     type="submit"
                     color="primary"
                     className="form-button"
-                    disabled={registrationSubmissionPending}
+                    disabled={registrationSubmissionPending || !dirty}
                   >
                     Submit
                   </Button>

--- a/apcd_cms/src/client/src/components/Submitter/Exceptions/ExceptionFormPage.tsx
+++ b/apcd_cms/src/client/src/components/Submitter/Exceptions/ExceptionFormPage.tsx
@@ -201,6 +201,7 @@ export const ExceptionFormPage: React.FC = () => {
           isValid,
           submitCount,
           handleSubmit,
+          dirty,
         }) => {
           // To reset values to initial values if the form submits successfully
           useEffect(() => {
@@ -420,6 +421,7 @@ export const ExceptionFormPage: React.FC = () => {
                       <Button
                         type="primary"
                         attr="submit"
+                        disabled={isSubmitting || !dirty}
                         isLoading={isSubmitting}
                         onClick={() => setIsSuccess(false)}
                       >
@@ -439,6 +441,7 @@ export const ExceptionFormPage: React.FC = () => {
                     <Button
                       type="primary"
                       attr="submit"
+                      disabled={isSubmitting || !dirty}
                       isLoading={isSubmitting}
                       onClick={() => setIsSuccess(false)}
                     >

--- a/apcd_cms/src/client/src/components/Submitter/Extensions/ExtensionsForm.tsx
+++ b/apcd_cms/src/client/src/components/Submitter/Extensions/ExtensionsForm.tsx
@@ -129,7 +129,7 @@ export const ExtensionRequestForm: React.FC = () => {
         validationSchema={validationSchema}
         onSubmit={handleSubmit}
       >
-        {({ values, isSubmitting, setFieldValue, resetForm }) => {
+        {({ values, isSubmitting, setFieldValue, resetForm, dirty }) => {
           useEffect(() => {
             if (isSuccess) {
               resetForm();
@@ -269,6 +269,7 @@ export const ExtensionRequestForm: React.FC = () => {
                       <Button
                         type="primary"
                         attr="submit"
+                        disabled={isSubmitting || !dirty}
                         isLoading={isSubmitting}
                         onClick={() => setIsSuccess(false)}
                       >
@@ -288,6 +289,7 @@ export const ExtensionRequestForm: React.FC = () => {
                     <Button
                       type="primary"
                       attr="submit"
+                      disabled={isSubmitting || !dirty}
                       isLoading={isSubmitting}
                       onClick={() => setIsSuccess(false)}
                     >


### PR DESCRIPTION
## Overview

1. Use formik dirty flag to disable submit unless it is edited.
2. Exception form needs a bit of refactor (the type selection sets the dirty flag to form).

## Related

[WP-792](https://tacc-main.atlassian.net/browse/WP-792)

## Changes

1. Use formik dirty.
2. Clean up user edit modal

## Testing

Test submit is disabled by default and enabled on edit in these forms:

Administration:
1. Test registration edit modal
2. Test user edit modal
3. Test exception edit modal

Others:
1. Test new registation: http://localhost:8000/register/request-to-submit/
2. Extension: http://localhost:8000/submissions/extension-request/ 


## UI

Example UI for registration 

Before changing a field:
<img width="490" alt="Screenshot 2024-12-04 at 10 14 53 AM" src="https://github.com/user-attachments/assets/8e2b991e-fad0-4e27-917b-998855230a5b">


After changing a field
<img width="527" alt="Screenshot 2024-12-04 at 10 14 57 AM" src="https://github.com/user-attachments/assets/69c7b049-d7e3-4b35-bc7e-1b7346d60cf0">

