### PR TITLE
Bugs/WP-795: clear selection button uniformity

### DIFF
--- a/apcd_cms/src/client/src/components/Admin/Exceptions/AdminExceptions.tsx
+++ b/apcd_cms/src/client/src/components/Admin/Exceptions/AdminExceptions.tsx
@@ -6,6 +6,7 @@ import ViewExceptionModal from '../ViewExceptionModal/ViewExceptionModal';
 import EditExceptionModal from '../EditExceptionModal/EditExceptionModal';
 import styles from './AdminExceptions.module.css';
 import { formatDate } from 'utils/dateUtil';
+import { ClearOptionsButton } from 'apcd-components/ClearOptionsButton';
 
 export const AdminExceptions: React.FC = () => {
   const [status, setStatus] = useState('Pending');
@@ -106,7 +107,7 @@ export const AdminExceptions: React.FC = () => {
               ))}
             </select>
             {status !== 'Pending' || org !== 'All' ? (
-              <button onClick={clearSelections}>Clear Options</button>
+              <ClearOptionsButton onClick={clearSelections} />
             ) : null}
           </div>
         </div>

--- a/apcd_cms/src/client/src/components/Admin/Extensions/AdminExtensions.tsx
+++ b/apcd_cms/src/client/src/components/Admin/Extensions/AdminExtensions.tsx
@@ -7,6 +7,7 @@ import styles from './ExtensionList.module.css';
 import ViewExtensionModal from 'apcd-components/Extensions/ViewExtensionModal/ViewExtensionModal';
 import EditExtensionModal from 'apcd-components/Extensions/EditExtensionModal/EditExtensionModal';
 import { formatDate } from 'utils/dateUtil';
+import { ClearOptionsButton } from 'apcd-components/ClearOptionsButton';
 
 export const AdminExtensions: React.FC = () => {
   const [status, setStatus] = useState('Pending');
@@ -111,7 +112,7 @@ export const AdminExtensions: React.FC = () => {
             ))}
           </select>
           {data?.selected_status !== 'Pending' || data?.selected_org ? (
-            <button onClick={clearSelections}>Clear Options</button>
+            <ClearOptionsButton onClick={clearSelections} />
           ) : null}
         </div>
       </div>

--- a/apcd_cms/src/client/src/components/Admin/Submissions/AdminSubmissions.tsx
+++ b/apcd_cms/src/client/src/components/Admin/Submissions/AdminSubmissions.tsx
@@ -13,6 +13,7 @@ import { Link } from 'react-router-dom';
 import styles from './AdminSubmissions.module.css';
 import { formatDate } from 'utils/dateUtil';
 import { titleCase } from 'utils/stringUtil';
+import { ClearOptionsButton } from 'apcd-components/ClearOptionsButton';
 
 export const AdminSubmissions: React.FC = () => {
   const header = [
@@ -119,7 +120,7 @@ export const AdminSubmissions: React.FC = () => {
             ))}
           </select>
           {status !== 'All' || sort !== 'Newest Received' ? (
-            <button onClick={clearSelections}>Clear Options</button>
+            <ClearOptionsButton onClick={clearSelections} />
           ) : null}
         </div>
       </div>

--- a/apcd_cms/src/client/src/components/Admin/ViewUsers/ViewUsers.tsx
+++ b/apcd_cms/src/client/src/components/Admin/ViewUsers/ViewUsers.tsx
@@ -5,7 +5,7 @@ import EditRecordModal from './EditRecordModal';
 import LoadingSpinner from 'core-components/LoadingSpinner';
 import Paginator from 'core-components/Paginator';
 import styles from './ViewUsers.module.scss';
-import Button from 'core-components/Button';
+import { ClearOptionsButton } from 'apcd-components/ClearOptionsButton';
 
 export const ViewUsers: React.FC = () => {
   const header = [
@@ -130,7 +130,7 @@ export const ViewUsers: React.FC = () => {
             ))}
           </select>
           {status !== 'All' || org !== 'All' ? (
-            <Button onClick={clearSelections}>Clear Options</Button>
+            <ClearOptionsButton onClick={clearSelections} />
           ) : null}
         </div>
       </div>

--- a/apcd_cms/src/client/src/components/ClearOptionsButton/ClearOptionsButton.module.css
+++ b/apcd_cms/src/client/src/components/ClearOptionsButton/ClearOptionsButton.module.css
@@ -1,6 +1,4 @@
 .clearOptions {
-  padding-top: 10px;
-  padding-bottom: 10px;
-  padding-left: 16px;
-  padding-right: 16px;
+  padding-top: 5px;
+  padding-bottom: 5px;
 }

--- a/apcd_cms/src/client/src/components/ClearOptionsButton/ClearOptionsButton.module.css
+++ b/apcd_cms/src/client/src/components/ClearOptionsButton/ClearOptionsButton.module.css
@@ -1,0 +1,6 @@
+.clearOptions {
+  padding-top: 10px;
+  padding-bottom: 10px;
+  padding-left: 16px;
+  padding-right: 16px;
+}

--- a/apcd_cms/src/client/src/components/ClearOptionsButton/ClearOptionsButton.tsx
+++ b/apcd_cms/src/client/src/components/ClearOptionsButton/ClearOptionsButton.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import Button from 'core-components/Button';
+import styles from './ClearOptionsButton.module.css';
+
+interface ClearOptionsButtonProps {
+  onClick: () => void;
+}
+
+const ClearOptionsButton: React.FC<ClearOptionsButtonProps> = ({ onClick }) => (
+  <Button className={styles.clearOptions} onClick={onClick}>
+    Clear Options
+  </Button>
+);
+
+export default ClearOptionsButton;

--- a/apcd_cms/src/client/src/components/ClearOptionsButton/index.ts
+++ b/apcd_cms/src/client/src/components/ClearOptionsButton/index.ts
@@ -1,0 +1,3 @@
+import ClearOptionsButton from './ClearOptionsButton';
+
+export { ClearOptionsButton };

--- a/apcd_cms/src/client/src/components/Registrations/RegistrationList/RegistrationList.tsx
+++ b/apcd_cms/src/client/src/components/Registrations/RegistrationList/RegistrationList.tsx
@@ -5,7 +5,7 @@ import Paginator from 'core-components/Paginator';
 import ViewRegistrationModal from 'apcd-components/Registrations/ViewRegistrationModal/ViewRegistrationModal';
 import EditRegistrationModal from 'apcd-components/Registrations/EditRegistrationModal/EditRegistrationModal';
 import styles from './RegistrationList.module.css';
-import Button from 'core-components/Button';
+import { ClearOptionsButton } from 'apcd-components/ClearOptionsButton';
 
 export const RegistrationList: React.FC<{
   useDataHook: any;
@@ -115,7 +115,7 @@ export const RegistrationList: React.FC<{
             ))}
           </select>
           {data?.selected_status !== initStateFilter || data?.selected_org ? (
-            <Button onClick={clearSelections}>Clear Options</Button>
+            <ClearOptionsButton onClick={clearSelections} />
           ) : null}
         </div>
       </div>

--- a/apcd_cms/src/client/src/components/Submissions/ViewFileSubmissions/ViewSubmissions.tsx
+++ b/apcd_cms/src/client/src/components/Submissions/ViewFileSubmissions/ViewSubmissions.tsx
@@ -15,6 +15,7 @@ import { Link } from 'react-router-dom';
 import { ViewSubmissionLogsModal } from './ViewSubmissionsModal';
 import { formatDate } from 'utils/dateUtil';
 import { titleCase } from 'utils/stringUtil';
+import { ClearOptionsButton } from 'apcd-components/ClearOptionsButton';
 
 export const ViewFileSubmissions: React.FC = () => {
   const header = [
@@ -166,7 +167,7 @@ export const ViewFileSubmissions: React.FC = () => {
           sort !== 'Newest Received' ||
           submitterId !== 'All' ||
           payorCode !== 'All' ? (
-            <button onClick={clearSelections}>Clear Options</button>
+            <ClearOptionsButton onClick={clearSelections} />
           ) : null}
         </div>
       </div>


### PR DESCRIPTION
## Overview

1) make a custom component and use it in all pages.

## Related

[WP-795](https://tacc-main.atlassian.net/browse/WP-795)

## Changes

1) Custom component
2) core component Button
3) use a style to match filter.

## Testing

1. Go to all admin pages, submission listing and check for clear filter.

## UI
![Screenshot 2024-12-04 at 5 48 51 PM](https://github.com/user-attachments/assets/89c59155-b846-43cc-84ed-9f3e7ddc1285)
