### PR TITLE
bug/WP-788-Exception-Modal-Success-Exit-Icon-Missing

### DIFF
--- a/apcd_cms/src/client/src/components/Admin/EditExceptionModal/EditExceptionModal.tsx
+++ b/apcd_cms/src/client/src/components/Admin/EditExceptionModal/EditExceptionModal.tsx
@@ -379,18 +379,10 @@ const EditExceptionModal: React.FC<EditRecordModalProps> = ({
                 </Col>
               </Row>
               <br />
-              <Alert
-                color="success"
-                isOpen={showSuccessMessage}
-                toggle={dismissMessages}
-              >
+              <Alert color="success" isOpen={showSuccessMessage}>
                 Success: The exception data has been successfully updated.
               </Alert>
-              <Alert
-                color="danger"
-                isOpen={showErrorMessage}
-                toggle={dismissMessages}
-              >
+              <Alert color="danger" isOpen={showErrorMessage}>
                 Error: {errorMessage}
               </Alert>
               <Button


### PR DESCRIPTION
- Removes toggle from success and error message to mimic behavior in other edit modals
- Will revisit handling of success messages after React initial release

## Overview
Unwanted and unmarked button appearing next to text in success and error messages on editing an exception

## Related

- [WP-788](https://tacc-main.atlassian.net/browse/WP-788)

## Changes

Removed toggle property of the alert on submit. Though this Alert is using the toggle prop correctly, we may have a broken asset link in Bootstrap, a conflict with our custom CSS fro close-btn, or mismatched Reactstrap and Bootstrap versions that can be revisited when we decide how we want to handle success and error messages on submit.

## Testing

1. Go to [http://localhost:8000/administration/list-exceptions/](http://localhost:8000/administration/list-exceptions/) and select edit record from actions dropdown
2. Submit a change and make sure an icon before the text no longer appears
3. In the code in EditExceptionModal.tsx, set  line 386 to `<Alert color="danger" isOpen={!showErrorMessage}>` to make sure the erroneous button doesn't appear

## UI
Success alert
<img width="826" alt="Screenshot 2024-12-06 at 3 56 07 PM" src="https://github.com/user-attachments/assets/c48e84a5-a754-4e2e-a6b8-30572852e007">

Error alert
<img width="888" alt="Screenshot 2024-12-06 at 3 56 27 PM" src="https://github.com/user-attachments/assets/75ceae82-0b3f-4b91-8006-f819df6f2bf2">


<!--
## Notes

…
-->
