### PR TITLE
File Submissions title update

### DIFF
--- a/apcd_cms/src/client/src/components/Admin/Submissions/AdminSubmissions.tsx
+++ b/apcd_cms/src/client/src/components/Admin/Submissions/AdminSubmissions.tsx
@@ -81,7 +81,7 @@ export const AdminSubmissions: React.FC = () => {
 
   return (
     <div>
-      <h1>All Submissions</h1>
+      <h1>View File Submissions</h1>
       <hr />
       <p>All submissions by organizations</p>
       <hr />


### PR DESCRIPTION
## Overview

Page title should match Nav and say “View File Submissions” then can still have the line of “All submissions by organizations“.

## Related

[WP-806](https://tacc-main.atlassian.net/browse/WP-806)

## Changes

File Submissions title update

## Testing

1. Navigate to http://localhost:8000/administration/list-submissions/
2. Make sure page title shows 'View File Submissions'

## UI

![Screenshot 2024-12-10 at 8 26 35 AM](https://github.com/user-attachments/assets/15047760-9f9c-4472-961f-0556336fe583)


<!--
## Notes

…
-->
