### PR TITLE
[APCD] Exception, Submission and navigation bugs

### DIFF
--- a/apcd_cms/src/apps/submissions/views.py
+++ b/apcd_cms/src/apps/submissions/views.py
@@ -107,6 +107,7 @@ class SubmissionsTable(TemplateView):
             'received_timestamp': submission['received_timestamp'],
             'updated_at': submission['updated_at'],
             'payor_code': submission['payor_code'],
+            'entity_name': submission['entity_name'],
             'view_modal_content': submission['view_modal_content'],
             }
         for submission in submission_content:

--- a/apcd_cms/src/client/src/components/Admin/EditExceptionModal/EditExceptionModal.tsx
+++ b/apcd_cms/src/client/src/components/Admin/EditExceptionModal/EditExceptionModal.tsx
@@ -287,7 +287,7 @@ const EditExceptionModal: React.FC<EditRecordModalProps> = ({
                   <Col md={3}>
                     <FieldWrapper
                       name="approved_expiration_date"
-                      label="Expiration Date"
+                      label="Approved Expiration Date"
                       required={false}
                     >
                       <Field

--- a/apcd_cms/src/client/src/components/Admin/Extensions/AdminExtensions.tsx
+++ b/apcd_cms/src/client/src/components/Admin/Extensions/AdminExtensions.tsx
@@ -49,7 +49,7 @@ export const AdminExtensions: React.FC = () => {
     return (
       <SectionMessage type="error">
         There was an error loading the page.{''}
-        <a href="https://txapcd.org/workbench/dashboard/tickets/create">
+        <a href="/workbench/dashboard/tickets/create" className="wb-link">
           Please submit a ticket.
         </a>
       </SectionMessage>

--- a/apcd_cms/src/client/src/components/Admin/Submissions/AdminSubmissions.tsx
+++ b/apcd_cms/src/client/src/components/Admin/Submissions/AdminSubmissions.tsx
@@ -9,7 +9,6 @@ import LoadingSpinner from 'core-components/LoadingSpinner';
 import SectionMessage from 'core-components/SectionMessage';
 import Button from 'core-components/Button';
 import Paginator from 'core-components/Paginator';
-import { Link } from 'react-router-dom';
 import styles from './AdminSubmissions.module.css';
 import { formatDate } from 'utils/dateUtil';
 import { titleCase } from 'utils/stringUtil';
@@ -62,13 +61,13 @@ export const AdminSubmissions: React.FC = () => {
     return <LoadingSpinner />;
   }
 
-  if (isSubmissionsError) {
+  if (!isSubmissionsError) {
     return (
       <SectionMessage type="error">
         There was an error loading the page.{' '}
-        <Link to="/workbench/dashboard/tickets/create" className="wb-link">
+        <a href="/workbench/dashboard/tickets/create" className="wb-link">
           Please submit a ticket.
-        </Link>
+        </a>
       </SectionMessage>
     );
   }

--- a/apcd_cms/src/client/src/components/Admin/Submissions/AdminSubmissions.tsx
+++ b/apcd_cms/src/client/src/components/Admin/Submissions/AdminSubmissions.tsx
@@ -61,7 +61,7 @@ export const AdminSubmissions: React.FC = () => {
     return <LoadingSpinner />;
   }
 
-  if (!isSubmissionsError) {
+  if (isSubmissionsError) {
     return (
       <SectionMessage type="error">
         There was an error loading the page.{' '}

--- a/apcd_cms/src/client/src/components/Admin/ViewExceptionModal/ViewExceptionModal.tsx
+++ b/apcd_cms/src/client/src/components/Admin/ViewExceptionModal/ViewExceptionModal.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Modal, ModalHeader, ModalBody, Row, Col } from 'reactstrap';
-import { ExceptionModalContent, ExceptionRow } from 'hooks/admin';
+import { ExceptionRow } from 'hooks/admin';
 import { formatModalDate } from 'utils/dateUtil';
 import styles from './ViewExceptionModal.module.css';
 

--- a/apcd_cms/src/client/src/components/Admin/ViewUsers/ViewUsers.tsx
+++ b/apcd_cms/src/client/src/components/Admin/ViewUsers/ViewUsers.tsx
@@ -92,7 +92,9 @@ export const ViewUsers: React.FC = () => {
     <div>
       <h1>List Users</h1>
       <hr />
-      <p style={{ marginBottom: '30px' }}>List of all system users attached to a submitter.</p>
+      <p style={{ marginBottom: '30px' }}>
+        List of all system users attached to a submitter.
+      </p>
       <hr />
       <div className="filter-container">
         <div className="filter-content">

--- a/apcd_cms/src/client/src/components/Forms/Registrations/RegistrationForm.tsx
+++ b/apcd_cms/src/client/src/components/Forms/Registrations/RegistrationForm.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
-import { Formik, Form, Field, ErrorMessage } from 'formik';
+import { Formik, Form, Field } from 'formik';
 import * as Yup from 'yup';
-import { FormGroup, Label, FormFeedback } from 'reactstrap';
+import { FormGroup, Label } from 'reactstrap';
 import Button from 'core-components/Button';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import {
@@ -215,9 +215,8 @@ export const RegistrationForm: React.FC<{
       : `register/request-to-submit/api/`;
     submitForm({ url, body: values });
   };
-  const navigate = useNavigate();
   const handleClick = () => {
-    navigate('/workbench/dashboard');
+    window.location.href = '/workbench/dashboard';
   };
 
   if (isLoading) {

--- a/apcd_cms/src/client/src/components/Registrations/RegistrationList/RegistrationList.tsx
+++ b/apcd_cms/src/client/src/components/Registrations/RegistrationList/RegistrationList.tsx
@@ -45,7 +45,9 @@ export const RegistrationList: React.FC<{
       <>
         <p className="c-message c-message--error">
           An error occurred loading your registrations. For help,{' '}
-          <a href="/workbench/dashboard">submit a ticket</a>.
+          <a href="/workbench/dashboard/tickets/create" className="wb-link">
+            Please submit a ticket.
+          </a>
         </p>
         <a className="c-button c-button--primary" href="/">
           Back to Home

--- a/apcd_cms/src/client/src/components/Submissions/ViewFileSubmissions/ViewSubmissions.tsx
+++ b/apcd_cms/src/client/src/components/Submissions/ViewFileSubmissions/ViewSubmissions.tsx
@@ -85,9 +85,9 @@ export const ViewFileSubmissions: React.FC = () => {
     return (
       <SectionMessage type="error">
         There was an error loading the page.{' '}
-        <Link to="/workbench/dashboard/tickets/create" className="wb-link">
+        <a href="/workbench/dashboard/tickets/create" className="wb-link">
           Please submit a ticket.
-        </Link>
+        </a>
       </SectionMessage>
     );
   }

--- a/apcd_cms/src/client/src/components/Submitter/Exceptions/ExceptionForm.tsx
+++ b/apcd_cms/src/client/src/components/Submitter/Exceptions/ExceptionForm.tsx
@@ -90,9 +90,9 @@ export const ExceptionForm: React.FC<{ index: number }> = ({ index }) => {
         {entitiesError && (
           <SectionMessage type="error">
             There was an error finding your associated businesses.{' '}
-            <Link to="/workbench/dashboard/tickets/create" className="wb-link">
+            <a href="/workbench/dashboard/tickets/create" className="wb-link">
               Please submit a ticket.
-            </Link>
+            </a>
           </SectionMessage>
         )}
       </FieldWrapper>

--- a/apcd_cms/src/client/src/components/Submitter/Exceptions/ExceptionFormPage.tsx
+++ b/apcd_cms/src/client/src/components/Submitter/Exceptions/ExceptionFormPage.tsx
@@ -60,7 +60,8 @@ export const ExceptionFormPage: React.FC = () => {
         .required('Business name is required'),
       fileType: Yup.string().required('File type is required'),
       fieldCode: Yup.string().required('Field code is required'),
-      expiration_date: Yup.date().required('Expiration date is required')
+      expiration_date: Yup.date()
+        .required('Expiration date is required')
         .max('9999-12-31', 'Expiration date must be MM/DD/YYYY')
         .min('0001-01-01', 'Expiration date must be MM/DD/YYYY'),
       requested_threshold: Yup.number().required(
@@ -81,9 +82,11 @@ export const ExceptionFormPage: React.FC = () => {
     }),
     expirationDateOther: Yup.mixed().when('exceptionType', {
       is: 'other',
-      then: (schema) => Yup.date().required('Required')
-        .max('9999-12-31', 'Date must be MM/DD/YYYY')
-        .min('0001-01-01', 'Date must be MM/DD/YYYY'),
+      then: (schema) =>
+        Yup.date()
+          .required('Required')
+          .max('9999-12-31', 'Date must be MM/DD/YYYY')
+          .min('0001-01-01', 'Date must be MM/DD/YYYY'),
       otherwise: (schema) => schema.strip(),
     }),
     otherExceptionBusinessName: Yup.mixed().when('exceptionType', {

--- a/apcd_cms/src/client/src/components/Submitter/Extensions/ExtensionFormInfo.tsx
+++ b/apcd_cms/src/client/src/components/Submitter/Extensions/ExtensionFormInfo.tsx
@@ -7,7 +7,6 @@ import {
   ApplicableDataPeriod,
 } from 'hooks/entities';
 import SectionMessage from 'core-components/SectionMessage';
-import { Link } from 'react-router-dom';
 import FieldWrapper from 'core-wrappers/FieldWrapperFormik';
 
 const maxDate = new Date();
@@ -79,9 +78,9 @@ const ExtensionFormInfo: React.FC<{
         {!submitterData && (
           <SectionMessage type="error">
             There was an error finding your associated businesses.{' '}
-            <Link to="/workbench/dashboard/tickets/create" className="wb-link">
+            <a href="/workbench/dashboard/tickets/create" className="wb-link">
               Please submit a ticket.
-            </Link>
+            </a>
           </SectionMessage>
         )}
       </FieldWrapper>


### PR DESCRIPTION
## Overview
1. Submitter submission is missing entity name
2. Exception edit modal should show approved expiration date label (matching with prod)
3. <Link> and navigate do not work with routes outside the app

## Related

[WP-816](https://tacc-main.atlassian.net/browse/WP-816)
[WP-815](https://tacc-main.atlassian.net/browse/WP-815)
[WP-817](https://tacc-main.atlassian.net/browse/WP-817)

## Testing

1. Go to http://localhost:8000/submissions/list-submissions/ and see if entity name is populated
2. Go to http://localhost:8000/administration/list-exceptions/ - edit modal and see that the label - 'Approved Exception Date' is seen. This is not Requested Exception Date
3. On registration submission, the link navigation works

## UI
ticket navigation on failure rightly went to the page
<img width="928" alt="Screenshot 2024-12-11 at 4 09 36 PM" src="https://github.com/user-attachments/assets/3faf461c-45e0-4a5d-94c5-bec30e18c0f2" />




