### PR TITLE
bug/WP-820-exp-date-exception-edit-modal

### DIFF
--- a/apcd_cms/src/client/src/components/Admin/EditExceptionModal/EditExceptionModal.tsx
+++ b/apcd_cms/src/client/src/components/Admin/EditExceptionModal/EditExceptionModal.tsx
@@ -1,31 +1,14 @@
 import React, { useState, useEffect } from 'react';
-import {
-  Modal,
-  ModalBody,
-  ModalHeader,
-  Label,
-  FormGroup,
-  Row,
-  Col,
-  Alert,
-} from 'reactstrap';
-import {
-  Field,
-  ErrorMessage,
-  useFormik,
-  FormikHelpers,
-  FormikProvider,
-} from 'formik';
+import { Modal, ModalBody, ModalHeader, Row, Col, Alert } from 'reactstrap';
+import { Field, useFormik, FormikHelpers, FormikProvider } from 'formik';
 import { fetchUtil } from 'utils/fetchUtil';
 import * as Yup from 'yup';
 import { ExceptionRow } from 'hooks/admin';
 import { formatDate } from 'utils/dateUtil';
 import styles from './EditExceptionModal.module.css';
-
 import QueryWrapper from 'core-wrappers/QueryWrapper';
 import FieldWrapper from 'core-wrappers/FieldWrapperFormik';
 import Button from 'core-components/Button';
-import Message from 'core-components/Message';
 
 interface EditRecordModalProps {
   isOpen: boolean;
@@ -306,10 +289,10 @@ const EditExceptionModal: React.FC<EditRecordModalProps> = ({
                         className="form-text text-muted"
                         style={{ fontStyle: 'italic' }}
                       >
-                        Current:{' '}
-                        {exception.approved_expiration_date
+                        Requested Expy Date:{' '}
+                        {exception.view_modal_content.requested_expiration_date
                           ? new Date(
-                              exception.approved_expiration_date
+                              exception.view_modal_content.requested_expiration_date
                             ).toLocaleDateString()
                           : 'None'}
                       </small>

--- a/apcd_cms/src/client/src/components/Admin/EditExceptionModal/EditExceptionModal.tsx
+++ b/apcd_cms/src/client/src/components/Admin/EditExceptionModal/EditExceptionModal.tsx
@@ -270,7 +270,7 @@ const EditExceptionModal: React.FC<EditRecordModalProps> = ({
                   <Col md={3}>
                     <FieldWrapper
                       name="approved_expiration_date"
-                      label="Expiration Date"
+                      label="Approved Expiration Date"
                       required={false}
                     >
                       <Field


### PR DESCRIPTION
## Overview

Fixes bug so that the help text and label for Approved Expiration Date are pulling the right fields from DB and are more clear
## Related


- [WP-820](https://tacc-main.atlassian.net/browse/WP-820)


## Changes

…

## Testing

1. Go to [http://localhost:8000/administration/list-exceptions/](http://localhost:8000/administration/list-exceptions/) and click edit record from actions
2. Make sure requested expiration date in the help text matches the requested expiration date in the listing at the bottom of the modal
3. Make sure, if there is an accepted expiration date, it auto populates in the field. Otherwise if there is no approved expiration date, it should show MM/DD/YYYY

## UI

…

<!--
## Notes

…
-->
