### PR TITLE
Task/WP-822: Improve Submitter Users Page

### DIFF
--- a/apcd_cms/src/apps/utils/apcd_database.py
+++ b/apcd_cms/src/apps/utils/apcd_database.py
@@ -168,7 +168,8 @@ def get_submitter_users():
         submissions.payor_code,
         users.role_id,
         users.user_email,
-        users.notes
+        users.notes,
+        submitters.org_name
         FROM submitter_users
         JOIN users
             ON submitter_users.user_id = users.user_id
@@ -177,6 +178,8 @@ def get_submitter_users():
             ON submitter_users.submitter_id = submissions.submitter_id
         JOIN roles 
             ON roles.role_id = users.role_id
+        JOIN submitters
+            ON submitter_users.submitter_id = submitters.submitter_id
         ORDER BY submitter_users.user_id;
         """
         cur = conn.cursor()

--- a/apcd_cms/src/apps/utils/apcd_database.py
+++ b/apcd_cms/src/apps/utils/apcd_database.py
@@ -167,7 +167,8 @@ def get_submitter_users():
         users.user_number,
         submissions.payor_code,
         users.role_id,
-        users.user_email
+        users.user_email,
+        users.notes
         FROM submitter_users
         JOIN users
             ON submitter_users.user_id = users.user_id

--- a/apcd_cms/src/apps/utils/apcd_database.py
+++ b/apcd_cms/src/apps/utils/apcd_database.py
@@ -166,7 +166,8 @@ def get_submitter_users():
         users.active,
         users.user_number,
         submissions.payor_code,
-        users.role_id
+        users.role_id,
+        users.user_email
         FROM submitter_users
         JOIN users
             ON submitter_users.user_id = users.user_id

--- a/apcd_cms/src/apps/utils/apcd_database.py
+++ b/apcd_cms/src/apps/utils/apcd_database.py
@@ -160,17 +160,22 @@ def get_submitter_users():
         query = """
         SELECT DISTINCT submitter_users.submitter_id,
         submitter_users.user_id,
-        submitter_users.user_number,
-        users.user_email,
         users.user_name,
-        submissions.payor_code
+        users.org_name,
+        roles.role_name,
+        users.active,
+        users.user_number,
+        submissions.payor_code,
+        users.role_id
         FROM submitter_users
         JOIN users
-           ON submitter_users.user_id = users.user_id
-           AND submitter_users.user_number = users.user_number
+            ON submitter_users.user_id = users.user_id
+            AND submitter_users.user_number = users.user_number
         JOIN submissions
             ON submitter_users.submitter_id = submissions.submitter_id
-            ORDER BY submitter_users.user_id;
+        JOIN roles 
+            ON roles.role_id = users.role_id
+        ORDER BY submitter_users.user_id;
         """
         cur = conn.cursor()
         cur.execute(query)

--- a/apcd_cms/src/apps/view_submitter_users/templates/view_submitter_users.html
+++ b/apcd_cms/src/apps/view_submitter_users/templates/view_submitter_users.html
@@ -3,6 +3,7 @@
 
 {% block content %}
 <link rel="stylesheet" href="{% static 'apcd_cms/css/modal.css' %}">
+<link rel="stylesheet" href="{% static 'apcd_cms/css/table.css' %}">
 <div class="container">
     {% include "nav_cms_breadcrumbs.html" %}
     <div id="view-submitter-users-root"></div>

--- a/apcd_cms/src/apps/view_submitter_users/urls.py
+++ b/apcd_cms/src/apps/view_submitter_users/urls.py
@@ -6,6 +6,7 @@ app_name = 'administration'
 urlpatterns = [
     path('view-submitter-users/', TemplateView.as_view(template_name='view_submitter_users.html'), name='view_submitter_users'),
     path('view-submitter-users/api/', ViewSubmitterUsersTable.as_view(), name='view_submitter_users_api'),
+    path('view-submitter-users/api/options', ViewSubmitterUsersTable.as_view(), name='view_submitter_users_api_options'),
     path('view-submitter-users/api/modal/<str:modal_type>/', ViewSubmitterUsersTable.as_view(), name='view_submitter_users_modal'),
     path('submitter-users/<int:user_number>/', UpdateSubmitterUserView.as_view(), name='update_submitter_user'),
 ]

--- a/apcd_cms/src/apps/view_submitter_users/views.py
+++ b/apcd_cms/src/apps/view_submitter_users/views.py
@@ -120,6 +120,7 @@ class ViewSubmitterUsersTable(TemplateView):
                 'user_number': usr[6],
                 'payor_code': usr[7],
                 'role_id': usr[8],
+                'user_email': usr[9],
             }
 
         user_list = [_set_submitter_user(user) for user in users]
@@ -150,6 +151,7 @@ class ViewSubmitterUsersTable(TemplateView):
                 'user_number': usr['user_number'],
                 'payor_code': usr['payor_code'],
                 'role_id': usr['role_id'],
+                'user_email': usr['user_email'],
                 'view_link': f"/administration/view-user-details/{usr['user_id']}",
                 'edit_link': f"/administration/edit-user/{usr['user_id']}",
             }

--- a/apcd_cms/src/apps/view_submitter_users/views.py
+++ b/apcd_cms/src/apps/view_submitter_users/views.py
@@ -97,10 +97,13 @@ class ViewSubmitterUsersTable(TemplateView):
             return {
                 'submitter_id': usr[0],
                 'user_id': usr[1],
-                'user_number': usr[2],
-                'user_email': usr[3],
-                'user_name': usr[4],
-                'payor_code': usr[5],
+                'user_name': usr[2],
+                'entity_name': usr[3] if usr[3] else 'None',
+                'role_name': usr[4],
+                'status': 'Active' if usr[5] else 'Inactive',
+                'user_number': usr[6],
+                'payor_code': usr[7],
+                'role_id': usr[8],
             }
 
         user_list = [_set_submitter_user(user) for user in users]
@@ -118,10 +121,13 @@ class ViewSubmitterUsersTable(TemplateView):
             return {
                 'submitter_id': usr['submitter_id'],
                 'user_id': usr['user_id'],
-                'user_number': usr['user_number'],
-                'user_email': usr['user_email'],
                 'user_name': usr['user_name'],
+                'entity_name': usr['entity_name'],
+                'role_name': usr['role_name'],
+                'status': usr['status'],
+                'user_number': usr['user_number'],
                 'payor_code': usr['payor_code'],
+                'role_id': usr['role_id'],
                 'view_link': f"/administration/view-user-details/{usr['user_id']}",
                 'edit_link': f"/administration/edit-user/{usr['user_id']}",
             }

--- a/apcd_cms/src/apps/view_submitter_users/views.py
+++ b/apcd_cms/src/apps/view_submitter_users/views.py
@@ -27,12 +27,14 @@ class ViewSubmitterUsersTable(TemplateView):
         if 'modal' in request.path:
             return self.get_modals(request, kwargs['modal_type'])
         
+        status = request.GET.get('status', 'Active')
+        payor_code = request.GET.get('payor_code', 'All')
         page_number = int(request.GET.get('page', 1))
         items_per_page = int(request.GET.get('limit', 50))
 
         try:
             user_content = get_submitter_users()
-            filtered_users = self.filter_submitter_users(user_content)
+            filtered_users = self.filter_submitter_users(user_content, status, payor_code)
 
             paginator = Paginator(filtered_users, items_per_page)
             page_info = paginator.get_page(page_number)
@@ -51,6 +53,20 @@ class ViewSubmitterUsersTable(TemplateView):
         context = super().get_context_data(**kwargs)
         context.update(self.get_view_users_json(get_submitter_users()))
         return context
+    
+    def get_options(self, request):
+        try:
+            status_options = ['All', 'Active', 'Inactive']
+            user_content = get_submitter_users()
+            user_list = sorted(list(set(user[7] if user[7] else 'None' for user in user_content)))
+            payor_code_options = ['All'] + user_list
+            return JsonResponse({
+                'status_options': status_options,
+                'payor_code_options': payor_code_options,
+            })
+        except Exception as e:
+            logger.error("Error fetching options data: %s", e)
+            return JsonResponse({'error': str(e)}, status=500)
 
     # Retrieves both the View and Edit modals for getting/changing data
     def get_modals(self, request, modal_type):
@@ -92,7 +108,7 @@ class ViewSubmitterUsersTable(TemplateView):
         return HttpResponse(template.render({}, request))
     
     # Filters users based on status and organization
-    def filter_submitter_users(self, users):
+    def filter_submitter_users(self, users, status, payor_code):
         def _set_submitter_user(usr):
             return {
                 'submitter_id': usr[0],
@@ -107,6 +123,12 @@ class ViewSubmitterUsersTable(TemplateView):
             }
 
         user_list = [_set_submitter_user(user) for user in users]
+
+        if status != 'All':
+            user_list = [user for user in user_list if user['status'] == status]
+
+        if payor_code != 'All':
+            user_list = [user for user in user_list if user['payor_code'] == payor_code]
 
         return user_list
     

--- a/apcd_cms/src/apps/view_submitter_users/views.py
+++ b/apcd_cms/src/apps/view_submitter_users/views.py
@@ -122,6 +122,7 @@ class ViewSubmitterUsersTable(TemplateView):
                 'role_id': usr[8],
                 'user_email': usr[9],
                 'notes': usr[10],
+                'org_name': usr[11],
             }
 
         user_list = [_set_submitter_user(user) for user in users]
@@ -150,10 +151,11 @@ class ViewSubmitterUsersTable(TemplateView):
                 'role_name': usr['role_name'],
                 'status': usr['status'],
                 'user_number': usr['user_number'],
-                'payor_code': usr['payor_code'],
+                'payor_code': usr['org_name'], # Show payor_code as org_name
                 'role_id': usr['role_id'],
                 'user_email': usr['user_email'],
                 'notes': usr['notes'],
+                'org_name': usr['org_name'],
                 'view_link': f"/administration/view-user-details/{usr['user_id']}",
                 'edit_link': f"/administration/edit-user/{usr['user_id']}",
             }

--- a/apcd_cms/src/apps/view_submitter_users/views.py
+++ b/apcd_cms/src/apps/view_submitter_users/views.py
@@ -121,6 +121,7 @@ class ViewSubmitterUsersTable(TemplateView):
                 'payor_code': usr[7],
                 'role_id': usr[8],
                 'user_email': usr[9],
+                'notes': usr[10],
             }
 
         user_list = [_set_submitter_user(user) for user in users]
@@ -152,6 +153,7 @@ class ViewSubmitterUsersTable(TemplateView):
                 'payor_code': usr['payor_code'],
                 'role_id': usr['role_id'],
                 'user_email': usr['user_email'],
+                'notes': usr['notes'],
                 'view_link': f"/administration/view-user-details/{usr['user_id']}",
                 'edit_link': f"/administration/edit-user/{usr['user_id']}",
             }

--- a/apcd_cms/src/apps/view_submitter_users/views.py
+++ b/apcd_cms/src/apps/view_submitter_users/views.py
@@ -130,7 +130,6 @@ class ViewSubmitterUsersTable(TemplateView):
         if status != 'All':
             user_list = [user for user in user_list if user['status'] == status]
 
-        logger.error(user_list, status)
         if payor_code != 'All':
             user_list = [user for user in user_list if user['org_name'] == payor_code]
 

--- a/apcd_cms/src/apps/view_submitter_users/views.py
+++ b/apcd_cms/src/apps/view_submitter_users/views.py
@@ -130,8 +130,9 @@ class ViewSubmitterUsersTable(TemplateView):
         if status != 'All':
             user_list = [user for user in user_list if user['status'] == status]
 
+        logger.error(user_list, status)
         if payor_code != 'All':
-            user_list = [user for user in user_list if user['payor_code'] == payor_code]
+            user_list = [user for user in user_list if user['org_name'] == payor_code]
 
         return user_list
     

--- a/apcd_cms/src/apps/view_submitter_users/views.py
+++ b/apcd_cms/src/apps/view_submitter_users/views.py
@@ -58,11 +58,11 @@ class ViewSubmitterUsersTable(TemplateView):
         try:
             status_options = ['All', 'Active', 'Inactive']
             user_content = get_submitter_users()
-            user_list = sorted(list(set(user[7] if user[7] else 'None' for user in user_content)))
-            payor_code_options = ['All'] + user_list
+            user_list = sorted(list(set(user[11] if user[11] else 'None' for user in user_content)))
+            org_options = ['All'] + user_list
             return JsonResponse({
                 'status_options': status_options,
-                'payor_code_options': payor_code_options,
+                'org_options': org_options,
             })
         except Exception as e:
             logger.error("Error fetching options data: %s", e)
@@ -151,7 +151,8 @@ class ViewSubmitterUsersTable(TemplateView):
                 'role_name': usr['role_name'],
                 'status': usr['status'],
                 'user_number': usr['user_number'],
-                'payor_code': usr['org_name'], # Show payor_code as org_name
+                # Show payor_code as org_name
+                'payor_code': usr['org_name'],
                 'role_id': usr['role_id'],
                 'user_email': usr['user_email'],
                 'notes': usr['notes'],

--- a/apcd_cms/src/client/src/components/Submitter/ViewSubmitterUsers/EditRecordModal.tsx
+++ b/apcd_cms/src/client/src/components/Submitter/ViewSubmitterUsers/EditRecordModal.tsx
@@ -64,8 +64,6 @@ const EditRecordModal: React.FC<EditRecordModalProps> = ({
 
       setSuccessModalOpen(true);
     } catch (error: any) {
-      console.error('Error saving data:', error);
-      console.log(url);
       if (error.response && error.response.data) {
         // Use error message from the server response
         setErrorMessage(

--- a/apcd_cms/src/client/src/components/Submitter/ViewSubmitterUsers/EditRecordModal.tsx
+++ b/apcd_cms/src/client/src/components/Submitter/ViewSubmitterUsers/EditRecordModal.tsx
@@ -177,7 +177,7 @@ const EditRecordModal: React.FC<EditRecordModalProps> = ({
                   </Col>
                 </Row>
                 <Row>
-                <Col md={12}>
+                  <Col md={12}>
                     <FormGroup>
                       <Label for="notes" className={styles.customLabel}>
                         <strong>Notes</strong>

--- a/apcd_cms/src/client/src/components/Submitter/ViewSubmitterUsers/EditRecordModal.tsx
+++ b/apcd_cms/src/client/src/components/Submitter/ViewSubmitterUsers/EditRecordModal.tsx
@@ -3,12 +3,13 @@ import {
   Modal,
   ModalBody,
   ModalHeader,
-  Button,
   Label,
   FormGroup,
   Row,
   Col,
+  Alert
 } from 'reactstrap';
+import Button from 'core-components/Button';
 import { Formik, Field, Form, ErrorMessage } from 'formik';
 import { fetchUtil } from 'utils/fetchUtil';
 import * as Yup from 'yup';
@@ -28,8 +29,8 @@ const EditRecordModal: React.FC<EditRecordModalProps> = ({
   user,
   onEditSuccess,
 }) => {
-  const [successModalOpen, setSuccessModalOpen] = useState(false);
-  const [errorModalOpen, setErrorModalOpen] = useState(false);
+  const [showSuccessMessage, setShowSuccessMessage] = useState(false);
+  const [showErrorMessage, setShowErrorMessage] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
 
   if (!user) return null;
@@ -52,6 +53,8 @@ const EditRecordModal: React.FC<EditRecordModalProps> = ({
     const { user_number } = values;
     const url = `administration/users/${user_number}/`;
     try {
+      setShowSuccessMessage(false);
+      setShowErrorMessage(false);
       const response = await fetchUtil({
         url,
         method: 'PUT',
@@ -62,7 +65,7 @@ const EditRecordModal: React.FC<EditRecordModalProps> = ({
         onEditSuccess(response);
       }
 
-      setSuccessModalOpen(true);
+      setShowSuccessMessage(true);
     } catch (error: any) {
       if (error.response && error.response.data) {
         // Use error message from the server response
@@ -76,7 +79,7 @@ const EditRecordModal: React.FC<EditRecordModalProps> = ({
           'An error occurred while saving the data. Please try again.'
         );
       }
-      setErrorModalOpen(true);
+      setShowErrorMessage(true);
     } finally {
       setSubmitting(false);
     }
@@ -195,11 +198,16 @@ const EditRecordModal: React.FC<EditRecordModalProps> = ({
                   </Col>
                 </Row>
                 <br />
+                <Alert color="success" isOpen={showSuccessMessage}>
+                  Success: The user data has been successfully updated.
+                </Alert>
+                <Alert color="danger" isOpen={showErrorMessage}>
+                  Error: {errorMessage}
+                </Alert>
                 <Button
-                  type="submit"
-                  color="primary"
+                  type="primary"
+                  attr="submit"
                   disabled={isSubmitting}
-                  className={styles.customSubmitButton}
                 >
                   Submit
                 </Button>
@@ -220,44 +228,6 @@ const EditRecordModal: React.FC<EditRecordModalProps> = ({
             ))}
           </div>
         </ModalBody>
-      </Modal>
-
-      <Modal
-        isOpen={successModalOpen}
-        toggle={() => setSuccessModalOpen(false)}
-        className={styles.customModal}
-      >
-        <div className={`modal-header ${styles.modalHeader}`}>
-          <Label className={styles.customModalTitle}>Success</Label>
-          <button
-            type="button"
-            className={`close ${styles.customCloseButton}`}
-            onClick={toggle}
-          >
-            <span aria-hidden="true">&#xe912;</span>
-          </button>
-        </div>
-        <ModalBody>
-          The submitter user data has been successfully updated.
-        </ModalBody>
-      </Modal>
-
-      <Modal
-        isOpen={errorModalOpen}
-        toggle={() => setErrorModalOpen(false)}
-        className={styles.customModal}
-      >
-        <div className={`modal-header ${styles.modalHeader}`}>
-          <Label className={styles.customModalTitle}>Error</Label>
-          <button
-            type="button"
-            className={`close ${styles.customCloseButton}`}
-            onClick={toggle}
-          >
-            <span aria-hidden="true">&#xe912;</span>
-          </button>
-        </div>
-        <ModalBody>{errorMessage}</ModalBody>
       </Modal>
     </>
   );

--- a/apcd_cms/src/client/src/components/Submitter/ViewSubmitterUsers/EditRecordModal.tsx
+++ b/apcd_cms/src/client/src/components/Submitter/ViewSubmitterUsers/EditRecordModal.tsx
@@ -87,10 +87,14 @@ const EditRecordModal: React.FC<EditRecordModalProps> = ({
   const userFields = [
     { label: 'Submitter ID', value: user.submitter_id },
     { label: 'User ID', value: user.user_id },
-    { label: 'User Number', value: user.user_number },
-    { label: 'Email', value: user.user_email },
     { label: 'Name', value: user.user_name },
+    { label: 'Email', value: user.user_email },
+    { label: 'Entity Organization', value: user.entity_name },
+    { label: 'Role', value: user.role_name },
+    { label: 'Status', value: user.status },
+    { label: 'User Number', value: user.user_number },
     { label: 'Payor Code', value: user.payor_code },
+    { label: 'Notes', value: user.notes },
   ];
 
   const closeBtn = (
@@ -148,6 +152,44 @@ const EditRecordModal: React.FC<EditRecordModalProps> = ({
                       />
                       <ErrorMessage
                         name="user_email"
+                        component="div"
+                        className="text-danger"
+                      />
+                    </FormGroup>
+                  </Col>
+                  <Col md={2}>
+                    <FormGroup>
+                      <Label for="payor_code" className={styles.customLabel}>
+                        <strong>Payor Code</strong>
+                      </Label>
+                      <Field
+                        type="text"
+                        name="payor_code"
+                        id="payor_code"
+                        className={`form-control ${styles.viewRecord}`}
+                      />
+                      <ErrorMessage
+                        name="payor_code"
+                        component="div"
+                        className="text-danger"
+                      />
+                    </FormGroup>
+                  </Col>
+                </Row>
+                <Row>
+                <Col md={12}>
+                    <FormGroup>
+                      <Label for="notes" className={styles.customLabel}>
+                        <strong>Notes</strong>
+                      </Label>
+                      <Field
+                        type="text"
+                        name="notes"
+                        id="notes"
+                        className={`form-control ${styles.viewRecord}`}
+                      />
+                      <ErrorMessage
+                        name="notes"
                         component="div"
                         className="text-danger"
                       />

--- a/apcd_cms/src/client/src/components/Submitter/ViewSubmitterUsers/ViewRecordModal.tsx
+++ b/apcd_cms/src/client/src/components/Submitter/ViewSubmitterUsers/ViewRecordModal.tsx
@@ -83,6 +83,12 @@ const UserDetailsModal: React.FC<UserDetailsModalProps> = ({
             </Col>
             <Col sm="9">{user.payor_code}</Col>
           </Row>
+          <Row className={styles.userRow}>
+            <Col sm="3" className={styles.userkey}>
+              Notes:
+            </Col>
+            <Col sm="9">{user.notes ? user.notes : 'None'}</Col>
+          </Row>
         </div>
       </ModalBody>
     </Modal>

--- a/apcd_cms/src/client/src/components/Submitter/ViewSubmitterUsers/ViewRecordModal.tsx
+++ b/apcd_cms/src/client/src/components/Submitter/ViewSubmitterUsers/ViewRecordModal.tsx
@@ -43,9 +43,9 @@ const UserDetailsModal: React.FC<UserDetailsModalProps> = ({
           </Row>
           <Row className={styles.SubmitterUserRow}>
             <Col sm="3" className={styles.userkey}>
-              User Number:
+              Name:
             </Col>
-            <Col sm="9">{user.user_number}</Col>
+            <Col sm="9">{user.user_name}</Col>
           </Row>
           <Row className={styles.SubmitterUserRow}>
             <Col sm="3" className={styles.userkey}>
@@ -53,11 +53,29 @@ const UserDetailsModal: React.FC<UserDetailsModalProps> = ({
             </Col>
             <Col sm="9">{user.user_email}</Col>
           </Row>
+          <Row className={styles.userRow}>
+            <Col sm="3" className={styles.userkey}>
+              Entity Organization:
+            </Col>
+            <Col sm="9">{user.entity_name}</Col>
+          </Row>
+          <Row className={styles.userRow}>
+            <Col sm="3" className={styles.userkey}>
+              Role:
+            </Col>
+            <Col sm="9">{user.role_name}</Col>
+          </Row>
+          <Row className={styles.userRow}>
+            <Col sm="3" className={styles.userkey}>
+              Status:
+            </Col>
+            <Col sm="9">{user.status}</Col>
+          </Row>
           <Row className={styles.SubmitterUserRow}>
             <Col sm="3" className={styles.userkey}>
-              Name:
+              User Number:
             </Col>
-            <Col sm="9">{user.user_name}</Col>
+            <Col sm="9">{user.user_number}</Col>
           </Row>
           <Row className={styles.SubmitterUserRow}>
             <Col sm="3" className={styles.userkey}>

--- a/apcd_cms/src/client/src/components/Submitter/ViewSubmitterUsers/ViewSubmitterUsers.tsx
+++ b/apcd_cms/src/client/src/components/Submitter/ViewSubmitterUsers/ViewSubmitterUsers.tsx
@@ -80,7 +80,6 @@ export const ViewSubmitterUsers: React.FC = () => {
   const handleEditSuccess = (updatedUser: SubmitterUserRow) => {
     // Refresh user data after editing is successful
     refetch();
-    setEditModalOpen(false);
   };
 
   const closeModal = () => {
@@ -186,7 +185,7 @@ export const ViewSubmitterUsers: React.FC = () => {
               )
             ) : (
               <tr>
-                <td colSpan={7} style={{ textAlign: 'center' }}>
+                <td colSpan={9} style={{ textAlign: 'center' }}>
                   No Data available
                 </td>
               </tr>

--- a/apcd_cms/src/client/src/components/Submitter/ViewSubmitterUsers/ViewSubmitterUsers.tsx
+++ b/apcd_cms/src/client/src/components/Submitter/ViewSubmitterUsers/ViewSubmitterUsers.tsx
@@ -1,5 +1,9 @@
 import React, { useState } from 'react';
-import { SubmitterUserRow, useSubmitterUsers, useSubmitterUserFilters } from 'hooks/admin';
+import {
+  SubmitterUserRow,
+  useSubmitterUsers,
+  useSubmitterUserFilters,
+} from 'hooks/admin';
 import ViewRecordModal from './ViewRecordModal';
 import EditRecordModal from './EditRecordModal';
 import LoadingSpinner from 'core-components/LoadingSpinner';

--- a/apcd_cms/src/client/src/components/Submitter/ViewSubmitterUsers/ViewSubmitterUsers.tsx
+++ b/apcd_cms/src/client/src/components/Submitter/ViewSubmitterUsers/ViewSubmitterUsers.tsx
@@ -32,6 +32,7 @@ export const ViewSubmitterUsers: React.FC = () => {
 
   const [status, setStatus] = useState('Active');
   const [payor_code, setPayorCode] = useState('All');
+  // const [org, setOrg] = useState('All');
   const [page, setPage] = useState(1);
 
   const {

--- a/apcd_cms/src/client/src/components/Submitter/ViewSubmitterUsers/ViewSubmitterUsers.tsx
+++ b/apcd_cms/src/client/src/components/Submitter/ViewSubmitterUsers/ViewSubmitterUsers.tsx
@@ -29,7 +29,6 @@ export const ViewSubmitterUsers: React.FC = () => {
     isLoading: isFilterLoading,
     isError: isFilterError,
   } = useSubmitterUserFilters();
-  console.log(filterData);
 
   const [status, setStatus] = useState('Active');
   const [org, setOrg] = useState('All');

--- a/apcd_cms/src/client/src/components/Submitter/ViewSubmitterUsers/ViewSubmitterUsers.tsx
+++ b/apcd_cms/src/client/src/components/Submitter/ViewSubmitterUsers/ViewSubmitterUsers.tsx
@@ -29,10 +29,10 @@ export const ViewSubmitterUsers: React.FC = () => {
     isLoading: isFilterLoading,
     isError: isFilterError,
   } = useSubmitterUserFilters();
+  console.log(filterData);
 
   const [status, setStatus] = useState('Active');
-  const [payor_code, setPayorCode] = useState('All');
-  // const [org, setOrg] = useState('All');
+  const [org, setOrg] = useState('All');
   const [page, setPage] = useState(1);
 
   const {
@@ -40,7 +40,7 @@ export const ViewSubmitterUsers: React.FC = () => {
     isLoading,
     isError,
     refetch,
-  } = useSubmitterUsers(status, payor_code, page);
+  } = useSubmitterUsers(status, org, page);
 
   const [viewModalOpen, setViewModalOpen] = useState(false);
   const [editModalOpen, setEditModalOpen] = useState(false);
@@ -51,7 +51,7 @@ export const ViewSubmitterUsers: React.FC = () => {
 
   const clearSelections = () => {
     setStatus('Active');
-    setPayorCode('All');
+    setOrg('All');
     setPage(1);
   };
 
@@ -134,16 +134,16 @@ export const ViewSubmitterUsers: React.FC = () => {
           <select
             id="payorCodeFilter"
             className="payor-code-filter"
-            value={payor_code}
-            onChange={(e) => setPayorCode(e.target.value)}
+            value={org}
+            onChange={(e) => setOrg(e.target.value)}
           >
-            {filterData?.payor_code_options.map((payor_code, index) => (
-              <option className="dropdown-text" key={index} value={payor_code}>
-                {payor_code}
+            {filterData?.org_options.map((org, index) => (
+              <option className="dropdown-text" key={index} value={org}>
+                {org}
               </option>
             ))}
           </select>
-          {status !== 'Active' || payor_code !== 'All' ? (
+          {status !== 'Active' || org !== 'All' ? (
             <ClearOptionsButton onClick={clearSelections} />
           ) : null}
         </div>

--- a/apcd_cms/src/client/src/components/Submitter/ViewSubmitterUsers/ViewSubmitterUsers.tsx
+++ b/apcd_cms/src/client/src/components/Submitter/ViewSubmitterUsers/ViewSubmitterUsers.tsx
@@ -10,9 +10,11 @@ export const ViewSubmitterUsers: React.FC = () => {
   const header = [
     'Submitter ID',
     'User ID',
-    'User Number',
-    'User Email',
     'User Name',
+    'Entity Organization',
+    'Role',
+    'Status',
+    'User Number',
     'Payor Code',
     'Actions',
   ];
@@ -106,9 +108,11 @@ export const ViewSubmitterUsers: React.FC = () => {
                   <tr key={rowIndex}>
                     <td>{user.submitter_id}</td>
                     <td>{user.user_id}</td>
-                    <td>{user.user_number}</td>
-                    <td>{user.user_email}</td>
                     <td>{user.user_name}</td>
+                    <td>{user.entity_name}</td>
+                    <td>{user.role_name}</td>
+                    <td>{user.status}</td>
+                    <td>{user.user_number}</td>
                     <td>{user.payor_code}</td>
                     <td>
                       <select

--- a/apcd_cms/src/client/src/components/Submitter/ViewSubmitterUsers/ViewSubmitterUsers.tsx
+++ b/apcd_cms/src/client/src/components/Submitter/ViewSubmitterUsers/ViewSubmitterUsers.tsx
@@ -1,10 +1,11 @@
 import React, { useState } from 'react';
-import { SubmitterUserRow, useSubmitterUsers } from 'hooks/admin';
+import { SubmitterUserRow, useSubmitterUsers, useSubmitterUserFilters } from 'hooks/admin';
 import ViewRecordModal from './ViewRecordModal';
 import EditRecordModal from './EditRecordModal';
 import LoadingSpinner from 'core-components/LoadingSpinner';
 import Paginator from 'core-components/Paginator';
 import styles from './ViewSubmitterUsers.module.scss';
+import { ClearOptionsButton } from 'apcd-components/ClearOptionsButton';
 
 export const ViewSubmitterUsers: React.FC = () => {
   const header = [
@@ -19,6 +20,14 @@ export const ViewSubmitterUsers: React.FC = () => {
     'Actions',
   ];
 
+  const {
+    data: filterData,
+    isLoading: isFilterLoading,
+    isError: isFilterError,
+  } = useSubmitterUserFilters();
+
+  const [status, setStatus] = useState('Active');
+  const [payor_code, setPayorCode] = useState('All');
   const [page, setPage] = useState(1);
 
   const {
@@ -26,7 +35,7 @@ export const ViewSubmitterUsers: React.FC = () => {
     isLoading,
     isError,
     refetch,
-  } = useSubmitterUsers(page);
+  } = useSubmitterUsers(status, payor_code, page);
 
   const [viewModalOpen, setViewModalOpen] = useState(false);
   const [editModalOpen, setEditModalOpen] = useState(false);
@@ -36,6 +45,8 @@ export const ViewSubmitterUsers: React.FC = () => {
   const [dropdownValue, setDropdownValue] = useState<string>('');
 
   const clearSelections = () => {
+    setStatus('Active');
+    setPayorCode('All');
     setPage(1);
   };
 
@@ -74,7 +85,7 @@ export const ViewSubmitterUsers: React.FC = () => {
     setSelectedUser(null);
   };
 
-  if (isLoading) {
+  if (isFilterLoading || isLoading) {
     return (
       <div className="loading-placeholder">
         <LoadingSpinner />
@@ -82,7 +93,7 @@ export const ViewSubmitterUsers: React.FC = () => {
     );
   }
 
-  if (isError) {
+  if (isFilterError || isError) {
     return <div>Error loading data</div>;
   }
 
@@ -92,6 +103,46 @@ export const ViewSubmitterUsers: React.FC = () => {
       <hr />
       <p style={{ marginBottom: '30px' }}>View all submitter users.</p>
       <hr />
+      <div className="filter-container">
+        <div className="filter-content">
+          {/* Filter by Status */}
+          <span>
+            <b>Filter by Status: </b>
+          </span>
+          <select
+            id="statusFilter"
+            className="status-filter"
+            value={status}
+            onChange={(e) => setStatus(e.target.value)}
+          >
+            {filterData?.status_options.map((status, index) => (
+              <option className="dropdown-text" key={index} value={status}>
+                {status}
+              </option>
+            ))}
+          </select>
+
+          {/* Filter by Payor Code */}
+          <span>
+            <b>Filter by Payor Code: </b>
+          </span>
+          <select
+            id="payorCodeFilter"
+            className="payor-code-filter"
+            value={payor_code}
+            onChange={(e) => setPayorCode(e.target.value)}
+          >
+            {filterData?.payor_code_options.map((payor_code, index) => (
+              <option className="dropdown-text" key={index} value={payor_code}>
+                {payor_code}
+              </option>
+            ))}
+          </select>
+          {status !== 'Active' || payor_code !== 'All' ? (
+            <ClearOptionsButton onClick={clearSelections} />
+          ) : null}
+        </div>
+      </div>
       <div>
         <table id="viewSubmitterUserTable" className="submitter-users-table">
           <thead>

--- a/apcd_cms/src/client/src/hooks/admin/index.ts
+++ b/apcd_cms/src/client/src/hooks/admin/index.ts
@@ -18,6 +18,7 @@ export type FilterOptions = {
   org_options: string[];
   sort_options: string[];
   role_options: string[];
+  payor_code_options: string[];
 };
 
 export type UserResult = {
@@ -129,6 +130,8 @@ export type SubmitterUserRow = {
 };
 
 export type SubmitterUserResult = {
+  selected_status: string;
+  selected_payor_code: string;
   pagination_url_namespaces: string;
   page: SubmitterUserRow[];
   page_num: number;
@@ -143,4 +146,5 @@ export {
   useUserFilters,
   useSubmissionFilters,
   useSubmitterUsers,
+  useSubmitterUserFilters,
 } from './useAdmin';

--- a/apcd_cms/src/client/src/hooks/admin/index.ts
+++ b/apcd_cms/src/client/src/hooks/admin/index.ts
@@ -128,6 +128,7 @@ export type SubmitterUserRow = {
   created_at: string;
   updated_at: string;
   notes: string;
+  org_name: string;
 };
 
 export type SubmitterUserResult = {

--- a/apcd_cms/src/client/src/hooks/admin/index.ts
+++ b/apcd_cms/src/client/src/hooks/admin/index.ts
@@ -117,12 +117,15 @@ export type ExceptionResult = {
 export type SubmitterUserRow = {
   submitter_id: string;
   user_id: string;
+  user_name: string;
+  entity_name: string;
+  role_name: string;
+  status: string;
   user_number: string;
+  payor_code: string;
+  user_email: string;
   created_at: string;
   updated_at: string;
-  user_email: string;
-  user_name: string;
-  payor_code: string;
 };
 
 export type SubmitterUserResult = {

--- a/apcd_cms/src/client/src/hooks/admin/index.ts
+++ b/apcd_cms/src/client/src/hooks/admin/index.ts
@@ -127,6 +127,7 @@ export type SubmitterUserRow = {
   user_email: string;
   created_at: string;
   updated_at: string;
+  notes: string;
 };
 
 export type SubmitterUserResult = {

--- a/apcd_cms/src/client/src/hooks/admin/useAdmin.ts
+++ b/apcd_cms/src/client/src/hooks/admin/useAdmin.ts
@@ -58,11 +58,11 @@ const getSubmitterUsers = async (params: any) => {
 export const useSubmitterUsers = (
   status?: string,
   payor_code?: string,
-  page?: number,
+  page?: number
 ): UseQueryResult<SubmitterUserResult> => {
-  const params: { status?: string, payor_code?: string, page?: number } = {
-    status, 
-    payor_code, 
+  const params: { status?: string; payor_code?: string; page?: number } = {
+    status,
+    payor_code,
     page,
   };
   const query = useQuery(['submitterUsers', params], () =>
@@ -79,11 +79,15 @@ const getSubmitterUsersFilters = async () => {
 };
 
 export const useSubmitterUserFilters = (): UseQueryResult<FilterOptions> => {
-  const query = useQuery(['submitteruserfilters'], () => getSubmitterUsersFilters(), {
-    staleTime: 5 * 60 * 1000,
-    cacheTime: 10 * 60 * 1000,
-    refetchOnWindowFocus: false,
-  }) as UseQueryResult<FilterOptions>;
+  const query = useQuery(
+    ['submitteruserfilters'],
+    () => getSubmitterUsersFilters(),
+    {
+      staleTime: 5 * 60 * 1000,
+      cacheTime: 10 * 60 * 1000,
+      refetchOnWindowFocus: false,
+    }
+  ) as UseQueryResult<FilterOptions>;
 
   return { ...query };
 };

--- a/apcd_cms/src/client/src/hooks/admin/useAdmin.ts
+++ b/apcd_cms/src/client/src/hooks/admin/useAdmin.ts
@@ -56,14 +56,34 @@ const getSubmitterUsers = async (params: any) => {
 };
 
 export const useSubmitterUsers = (
-  page?: number
+  status?: string,
+  payor_code?: string,
+  page?: number,
 ): UseQueryResult<SubmitterUserResult> => {
-  const params: { page?: number } = {
+  const params: { status?: string, payor_code?: string, page?: number } = {
+    status, 
+    payor_code, 
     page,
   };
   const query = useQuery(['submitterUsers', params], () =>
     getSubmitterUsers(params)
   ) as UseQueryResult<SubmitterUserResult>;
+
+  return { ...query };
+};
+
+const getSubmitterUsersFilters = async () => {
+  const url = `/administration/view-submitter-users/api/options`;
+  const response = await fetchUtil({ url });
+  return response;
+};
+
+export const useSubmitterUserFilters = (): UseQueryResult<FilterOptions> => {
+  const query = useQuery(['submitteruserfilters'], () => getSubmitterUsersFilters(), {
+    staleTime: 5 * 60 * 1000,
+    cacheTime: 10 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  }) as UseQueryResult<FilterOptions>;
 
   return { ...query };
 };


### PR DESCRIPTION
## Overview

The Submitter Users Page shows records of all submitter users and allows admin to view and edit records accordingly.

## Related

- [WP-822](https://tacc-main.atlassian.net/browse/WP-822?isEligibleForUserSurvey=true)

## Changes

I added necessary information including payor codes (shown as organization names), necessary filters, and added functionality to edit users' payor codes and notes.

## Testing

1. Go to [the VIew Submitter Users page](http://localhost:8000/administration/view-submitter-users/).
2. Use the filters to sort users by status and payor codes.
3. Select a user and choose View Record under Actions to view that user's information.
4. Choose Edit Record under Actions for that user to edit that user's name, email, payor code, and notes.

## UI

![image](https://github.com/user-attachments/assets/705d2a1a-6c80-4531-a308-fefb1e672d3c)

<!--
## Notes

…
-->
