### PR TITLE
Bug: Duplicate applicable data periods in extensions form

### DIFF
--- a/apcd_cms/src/apps/extension/templates/extension_submission_form/extension_submission_form.html
+++ b/apcd_cms/src/apps/extension/templates/extension_submission_form/extension_submission_form.html
@@ -69,7 +69,7 @@
                       name="extension-date-asterisk"><span class="asterisk">*</span></label></label>
                   <select name='applicable-data-period_1' required='required' id='applicable-data-period_1'>
                     <option class="dropdown-text" value=''>-- Select period --</option>
-                    {% for data_period in applicable_data_periods %}
+                    {% for data_period in submitters.0.applicable_data_periods %}
                     <option class="dropdown-text" value={{data_period}}>{{data_period}}</option>
                     {% endfor %}
                   </select>
@@ -295,7 +295,7 @@
                   name="extension-date-asterisk"><span class="asterisk">*</span></label></label>
                   <select name='applicable-data-period_${extensions}' required='required' id='applicable-data-period_${extensions}'>
                     <option class="dropdown-text" value=''>-- Select period --</option>
-                    {% for data_period in applicable_data_periods %}
+                    {% for data_period in submitter.0.applicable_data_periods %}
                     <option class="dropdown-text" value={{data_period}}>{{data_period}}</option>
                     {% endfor %}
                   </select>
@@ -344,12 +344,31 @@
       };
       return extensions
     };
+    // To populate applicable data periods dropdown on choosing submitter (only used when user has >1 submitter)
+    function setApplicablePeriods(submitter_id, extensions) {
+      let submitterList = JSON.parse("{{ submitters | safe }}".replaceAll(`'`, `\"`).replaceAll('None', null));
+      let dataPeriodsList = submitterList.find(submitter => submitter.submitter_id == submitter_id).applicable_data_periods;
+      let applicableDataDropdown = $(`#applicable-data-period_${extensions}`);
+      let expectedDate = $(`#current-expected-date_${extensions}`); // also need to clear out expected date
+      let hiddenDate = $(`#hidden-current-expected-date_${extensions}`);
+
+      applicableDataDropdown.find('option').not(':first').remove(); // remove all data period options, prep for repopulating
+      expectedDate.val('');
+      hiddenDate.val('');
+
+      for (var i = 0; i < dataPeriodsList.length; i++) {
+        var dataPeriod = dataPeriodsList[i];
+        var dataPeriodOption = new Option(dataPeriod, dataPeriod)
+        applicableDataDropdown.append(dataPeriodOption)
+      }
+    }
+
     // To access previously hidden extension blocks and populate with info from AJAX call.
     function setExpectedDate(applicable_data_period, extensions) {
       let expectedDate = $(`#current-expected-date_${extensions}`);
       let hiddenDate = $(`#hidden-current-expected-date_${extensions}`);
+      const submitter_id = $(`#business-name_${extensions}`).val();
       // Gets submitter id from view context to pass to db call
-      const submitter_id = "{{ submitters.0.submitter_id}}"
       $.ajax({
         url: "{% url 'extension:get-expected-date' %}",
         type: 'GET',
@@ -371,6 +390,10 @@
     $(document).ready(function() {
       let extensions = 1;
       btnStatus(extensions);
+      $('[id^="business-name"]').change(function() {
+        let subId = $(this).val();
+        setApplicablePeriods(subId, extensions);
+      })
       $('[id^="requested-target-date"]').click(function() {
         let field = $(this).attr('id');
         restrictExpirationDate(field, extensions);

--- a/apcd_cms/src/apps/extension/templates/extension_submission_form/extension_submission_form.html
+++ b/apcd_cms/src/apps/extension/templates/extension_submission_form/extension_submission_form.html
@@ -295,7 +295,7 @@
                   name="extension-date-asterisk"><span class="asterisk">*</span></label></label>
                   <select name='applicable-data-period_${extensions}' required='required' id='applicable-data-period_${extensions}'>
                     <option class="dropdown-text" value=''>-- Select period --</option>
-                    {% for data_period in submitter.0.applicable_data_periods %}
+                    {% for data_period in submitters.0.applicable_data_periods %}
                     <option class="dropdown-text" value={{data_period}}>{{data_period}}</option>
                     {% endfor %}
                   </select>
@@ -390,10 +390,11 @@
     $(document).ready(function() {
       let extensions = 1;
       btnStatus(extensions);
-      $('[id^="business-name"]').change(function() {
+      $('[id="business-name"]').change(function() {
         let subId = $(this).val();
-        setApplicablePeriods(subId, extensions);
-      })
+        let extensionsNum = $(this).attr('id').slice(-1);
+        setApplicablePeriods(subId, extensionsNum);
+      });
       $('[id^="requested-target-date"]').click(function() {
         let field = $(this).attr('id');
         restrictExpirationDate(field, extensions);
@@ -413,6 +414,11 @@
       // To track how many extension blocks there are for button logic
         extensions = addExtension(extensions);
         btnStatus(extensions);
+        $('[id^="business-name"]').change(function() {
+          let subId = $(this).val();
+          let extensionsNum = $(this).attr('id').slice(-1);
+          setApplicablePeriods(subId, extensionsNum);
+        });
       // Gets applicable data period for additional added blocks
         $('[id^="applicable-data-period"]').change(function() {
           let appDataValue = $(this).val();

--- a/apcd_cms/src/apps/extension/views.py
+++ b/apcd_cms/src/apps/extension/views.py
@@ -26,24 +26,27 @@ class ExtensionFormView(TemplateView):
 
         self.request.session['submitters'] = submitters
 
-        def _set_submitter(sub):
+        def _set_submitter(sub, applicable_data_periods):
             return {
                 "submitter_id": sub[0],
                 "submitter_code": sub[1],
                 "payor_code": sub[2],
                 "user_name": sub[3],
-                "entity_name": title_case(sub[4])
+                "entity_name": title_case(sub[4]),
+                "applicable_data_periods": applicable_data_periods
             }
         context["submitters"] = []
         context["applicable_data_periods"] = []
 
-        for submitter in submitters: 
-            context['submitters'].append(_set_submitter(submitter))
+        for submitter in submitters:
             applicable_data_periods = apcd_database.get_applicable_data_periods(submitter[0])
+            data_periods = []
             for data_period_tuple in applicable_data_periods:
                 for data_period in data_period_tuple:
                     data_period = _get_applicable_data_period(data_period)
-                    context['applicable_data_periods'].append(data_period)
+                    data_periods.append(data_period)
+            data_periods = sorted(data_periods, reverse=True)
+            context['submitters'].append(_set_submitter(submitter, data_periods))
 
         context['applicable_data_periods'] = sorted(context['applicable_data_periods'], reverse=True)
         return context


### PR DESCRIPTION
## Overview
Addresses bug where a user with multiple submitters will see duplicate applicable data period options on the extensions form
…

## Related

<!--
- [WP-123](https://tacc-main.atlassian.net/browse/WP-123)
- requires https://github.com/TACC/Core-CMS/pull/117
-->…

## Changes
- Factors out the applicable data periods db query from collating the list of user's submitters, now keeps this list of data periods separate for each submitter
- Adds listener to business name dropdown to update list of applicable period options when business name (read: submitter) is changed
…

## Testing

1. Go to http://localhost:8000/submissions/extension-request/
  - If you only have one submitter available in the dropdown, Carrie can help add other submitters for you in our dev db
2. Check the 'Applicable Data Period' dropdown and confirm a sorted list of year-month entries are there, then select one and confirm the 'Current Expected Date' box populates with a date
3. Choose a different option under 'Business Name' and confirm that the above options change + the 'Current Expected Date' box updates with the default `mm/dd/yyyy`
4. Test with additional extensions entries and confirm they work the same + do not conflict with each other

## UI

…

<!--
## Notes

…
-->
