### PR TITLE
fix(lccf): cms menu .nav-link alignment

### DIFF
--- a/lccf_assets/header.css
+++ b/lccf_assets/header.css
@@ -2,6 +2,8 @@
 .portal-logo {
     height: 80px;
 }
+
+/* To increase vertical space of header*/
 .s-header.navbar {
     --nav-padding-vert: 10px;
 }
@@ -13,20 +15,27 @@
     }
 }
 
-/* To fix position (given header resize code that does not consider everything) */
-.s-header .nav-link {
-    top: unset;
-}
-
-/* To accomodate dark logo */
-/*
+/* To fix nav link which does not vertically align if logo is larger */
+/* TODO: Fix this in Core-Styles instead */
 :root {
-  --header-text-color: var(--global-color-primary--x-dark);
-  --header-bkgd-color: var(--global-color-primary--x-light);
-  --header-minor-border-color: var(--global-color-primary--normal);
-  --header-major-border-color: var(--global-color-primary--normal);
-  --header-search-brdr-color: #D8D8D8;
-  --header-search-bkgd-color: var(--global-color-primary--xx-light);
-  --menu-toggle-icon: invert(100%);
+    /* NOTE: Use this in Core-Styles `.s-header { … border-bottom: … }` */
+    --header-major-border-width: 1px;
 }
-*/
+.s-header .nav-link {
+    --move-text-back-to-middle: var(--nav-padding-vert);
+    --move-underline-to-bottom: calc( var(--nav-padding-vert) + var(--header-major-border-width) );
+    border-color: var(--header-bkgd-color);
+    border-style: solid;
+    border-width: 0 0 var(--border-width);
+    /* HACK: To overwrite pseudo states use !important (not needed once in Core-Styles) */
+    margin-bottom: calc(var(--move-underline-to-bottom) * -1) !important;
+    height: calc( 100% + var(--move-underline-to-bottom) + var(--move-text-back-to-middle) );
+    top: calc( var(--move-text-back-to-middle) * -1 );
+    line-height: unset;
+}
+.s-header .nav-item.active .nav-link,
+.s-header .nav-link:active,
+.s-header .nav-link:focus,
+.s-header .nav-link:hover {
+    border-color: var(--global-color-secondary--light);
+}

--- a/lccf_assets/header.css
+++ b/lccf_assets/header.css
@@ -3,7 +3,7 @@
     height: 80px;
 }
 
-/* To increase vertical space of header*/
+/* To increase vertical space of header */
 .s-header.navbar {
     --nav-padding-vert: 10px;
 }
@@ -15,7 +15,7 @@
     }
 }
 
-/* To fix nav link which does not vertically align if logo is larger */
+/* To fix nav link alignment regardless the nav padding */
 /* TODO: Fix this in Core-Styles instead */
 :root {
     /* NOTE: Use this in Core-Styles `.s-header { … border-bottom: … }` */


### PR DESCRIPTION
## Overview

<details><summary>For LCCF, fix vertical alignment of <code>.nav-links</code> in CMS menu.</summary>

This is a problem on all sites using `TACC_CORE_STYLES_VERSION = 2` but is most-noticeable on LCCF, because LCCF sets `.s-header.navbar { --nav-padding-vert: 10px; }` (and `.s-header .nav-link { top: unset; }` to partially resolve alignment.)

</details>

## Related

- fixes #325

## Changes

- **fixes** `.s-header .nav-link` styles
    <sup>(in a way that should be applied to Core-Styles instead)</sup>

## Testing & UI

### LCCF Custom Styles

1. Replace the content of LCCF's `header.css` with the new content.
2. Verify .nav-link` underline is at bottom of header.
3. Verify `.nav-link` text is vertically aligned center with search bar.

https://github.com/user-attachments/assets/6a525c8a-1436-4a55-84f4-9a3b7c57e56b

### Default CMS & Styles

1. Add styles `/* To fix nav link alignment regardless the nav padding */`
2. Verify .nav-link` underline is at bottom of header.
3. Verify `.nav-link` text is vertically aligned center with search bar. larger */`.

https://github.com/user-attachments/assets/125829c6-994d-4093-a1ab-236efb120ad5