### PR TITLE
feat(ecep): RT-32428 list external news article

### DIFF
--- a/ecep_assets/html/snippets/js-news-open-external-articles-in-new-window.html
+++ b/ecep_assets/html/snippets/js-news-open-external-articles-in-new-window.html
@@ -1,6 +1,6 @@
 <script id="js-news-open-external-articles-in-new-window" type="module">
 /* To open external article URL, instead of internal one, on news listing */
-import getArticleExternalURL from '{% static "site_cms/js/modules/getArticleExternalURL.js" %}';
+import getArticleExternalURL from 'https://cdn.jsdelivr.net/gh/TACC/tup-ui@v1.1.13/apps/tup-cms/src/taccsite_cms/static/site_cms/js/modules/getArticleExternalURL.js';
 
 // The `{{html}}` is whatever user entered into snippet "HTML:" field
 // XXX: This feature requires this file is actually served as a snippet

--- a/ecep_assets/html/snippets/js-news-open-external-articles-in-new-window.html
+++ b/ecep_assets/html/snippets/js-news-open-external-articles-in-new-window.html
@@ -1,0 +1,32 @@
+<script id="js-news-open-external-articles-in-new-window" type="module">
+/* To open external article URL, instead of internal one, on news listing */
+import getArticleExternalURL from '{% static "site_cms/js/modules/getArticleExternalURL.js" %}';
+
+// The `{{html}}` is whatever user entered into snippet "HTML:" field
+// XXX: This feature requires this file is actually served as a snippet
+// const parameter = '{{html}}';
+const parameter = undefined;
+
+// Only certain articles should support this feature
+const extTagName = parameter ? parameter : `external`;
+
+// Only care about articles with the given tag
+const articles = document.querySelectorAll(
+  `.blog-list article.has-blog-tag-${extTagName}`
+);
+[ ...articles ].forEach( article => {
+  const externalLinkUrl = getArticleExternalURL( article );
+
+  if ( externalLinkUrl ) {
+    const postLinks = article.querySelectorAll(':is(h3, footer) a');
+
+    // All links to the post should open external URL in new window
+    [ ...postLinks ].forEach( postLink => {
+      console.debug(`Swap post link with "${externalLinkUrl}"`, postLink );
+
+      postLink.href = externalLinkUrl;
+      postLink.setAttribute('target', '_blank');
+    });
+  }
+});
+</script>


### PR DESCRIPTION
## Overview

Allow an external news article to be shown on news page.

## Changes

- **adds** a copy of the HTML from [ECEP website snippet #35](https://ecepalliance.org/admin/djangocms_snippet/snippet/35/change/)

## Testing

1. Add article to [ECEP News](https://ecepalliance.org/news).
2. Tag the article `external`.
3. Add a hidden link at the end of the abstract:
    ```html
    <p><a hidden="" href="https://ecepalliance.org/news/2023/11/01/2023-state-of-computer-science-education-report-released/">External link.</a></p>
    ```
4. Click the article on [ECEP News (published view)](https://ecepalliance.org/news/?preview).
5. **Verify it opens a different website in a new window.**
6. Click the article on [ECEP News (edit view)](https://ecepalliance.org/news/?edit).
7. **Verify it opens a different website in a new window.**

## UI

https://github.com/user-attachments/assets/1a75fdf7-9eb9-467d-841e-4eb9c400e47f

https://github.com/user-attachments/assets/db8f0e1c-611a-4ab5-adb0-d03d76598e32