### PR TITLE
WP-854 Updating Applicable Period Fetch Business Logic

### DIFF
--- a/apcd_cms/src/apps/utils/apcd_database.py
+++ b/apcd_cms/src/apps/utils/apcd_database.py
@@ -1219,7 +1219,7 @@ def get_applicable_data_periods(submitter_id):
             sslmode='require',
         )
         cur = conn.cursor()
-        query = """ SELECT distinct data_period_start FROM submitter_calendar WHERE submitter_id = (%s) AND cancelled = 'FALSE' AND granted_reprieve='FALSE' AND submission_id is Null """
+        query = """ SELECT distinct data_period_start FROM submitter_calendar WHERE submitter_id = (%s) AND cancelled = 'FALSE' AND granted_reprieve='FALSE' AND submission_id is NOT null """
         cur.execute(query, (submitter_id,))
         return cur.fetchall()
 

--- a/apcd_cms/src/apps/utils/apcd_database.py
+++ b/apcd_cms/src/apps/utils/apcd_database.py
@@ -1219,7 +1219,7 @@ def get_applicable_data_periods(submitter_id):
             sslmode='require',
         )
         cur = conn.cursor()
-        query = """ SELECT distinct data_period_start FROM submitter_calendar WHERE submitter_id = (%s) AND cancelled = 'FALSE' AND granted_reprieve='FALSE' AND submission_id is NOT null """
+        query = """ SELECT distinct data_period_start FROM submitter_calendar WHERE submitter_id = (%s) AND cancelled = 'FALSE' AND granted_reprieve='FALSE' AND submission_id is NOT NULL """
         cur.execute(query, (submitter_id,))
         return cur.fetchall()
 


### PR DESCRIPTION
## Overview

Very minor update to the query that pulls applicable data periods from the submitter calendar, as described in a call with UTH where business logic was explained. See ticket referenced below for more detailed information. 

## Related

- [WP-854](https://tacc-main.atlassian.net/browse/WP-854)


## Changes

Query is updated so that it is selecting records where there is a submission id (no longer null as before), as well as cancelled = FALSE and granted_reprieve = FALSE



