### PR TITLE
task/WP-859-860-861 Admin Extension Listing

### DIFF
--- a/apcd_cms/src/apps/admin_extension/templates/list_admin_extension.html
+++ b/apcd_cms/src/apps/admin_extension/templates/list_admin_extension.html
@@ -5,7 +5,6 @@
 <link rel="stylesheet" href="{% static 'apcd_cms/css/table.css' %}">
 <link rel="stylesheet" href="{% static 'apcd_cms/css/modal.css' %}">
 <link rel="stylesheet" href="{% static 'admin_extension/css/table.css' %}">
-<link rel="stylesheet" href="{% static 'admin_extension/css/modal.css' %}">
 
 <div class="container">
   {% include "nav_cms_breadcrumbs.html" %}

--- a/apcd_cms/src/apps/admin_extension/templates/view_admin_extension_modal.html
+++ b/apcd_cms/src/apps/admin_extension/templates/view_admin_extension_modal.html
@@ -5,54 +5,6 @@
     <div class="modal-dialog modal-lg">
   
       <!-- Modal content-->
-      <div class="modal-content">
-        <div class="modal-header">
-          <h4 class="modal-title">Extension Details ID {{r.extension_id}} for {{r.entity_name}}</h4>
-          <button type="button" class="close" data-dismiss="modal">
-            <span aria-hidden="true">&#xe912;</span>
-          </button>
-        </div>
-        <div class="modal-body">
-          <div>
-            <dl>
-              <h4>Details</h4>
-                <div class="modal-section">
-                    <dl class="c-data-list--is-vert c-data-list--is-wide">
-                        <dt class="c-data-list__key">Created</dt>
-                        <dd class="c-data-list__value">{{r.created_at}}</dd>
-                        <dt class="c-data-list__key">Entity Organization</dt>
-                        <dd class="c-data-list__value">{{r.entity_name}}</dd>
-                        <dt class="c-data-list__key">Requestor</dt>
-                        <dd class="c-data-list__value">{{r.requestor_name}}</dd>
-                        <dt class="c-data-list__key">Requestor Email</dt>
-                        <dd class="c-data-list__value">{{r.requestor_email}}</dd> 
-                        <dt class="c-data-list__key">Extension Type</dt>
-                        <dd class="c-data-list__value">{{r.extension_type}}</dd>
-                        <dt class="c-data-list__key">Status</dt>
-                        <dd class="c-data-list__value">{{r.status}}</dd>
-                        <dt class="c-data-list__key">Outcome</dt>
-                        <dd class="c-data-list__value">{{r.outcome}}</dd> 
-                        <dt class="c-data-list__key">Applicable Data Period</dt>                
-                        <dd class="c-data-list__value">{{r.applicable_data_period}}</dd>
-                        <dt class="c-data-list__key">Current Expected Date</dt>                
-                        <dd class="c-data-list__value">{{r.current_expected_date}}</dd>
-                        <dt class="c-data-list__key">Requested Target Date</dt>                
-                        <dd class="c-data-list__value">{{r.requested_target_date}}</dd>
-                        <dt class="c-data-list__key">Approved Expiration Date</dt>                
-                        <dd class="c-data-list__value">{{r.approved_expiration_date}}</dd>
-                        <dt class="c-data-list__key">Extension Justification</dt>
-                        <dd class="c-data-list__value">{{r.explanation_justification}}</dd>
-                        <dt class="c-data-list__key">Extension Notes</dt>
-                        <dd class="c-data-list__value">{{r.notes}}</dd>
-                        <dt class="c-data-list__key">Last Updated</dt>
-                        <dd class="c-data-list__value">{{r.updated_at}}</dd>  
-                    </dl> 
-                    <hr>
-                </div>
-              </dd>
-            </dl>
-          </div>
-        </div>
-      </div>
+      <div id="view-extension-modal-root"></div>
     </div>
   </div>

--- a/apcd_cms/src/apps/admin_extension/views.py
+++ b/apcd_cms/src/apps/admin_extension/views.py
@@ -44,7 +44,7 @@ class AdminExtensionsApi(APCDAdminAccessAPIMixin, BaseAPIView):
             page_num = 1
 
         def getDate(row):
-            date = row[2]
+            date = row[9]
             return date if date is not None else datetimeDate(1,1,1) # put 'None' date entries all together at end of listing w/ date 1-1-0001
 
         extensions = sorted(extensions, key=lambda row:getDate(row), reverse=True)

--- a/apcd_cms/src/client/src/components/Extensions/EditExtensionModal/EditExtensionModal.tsx
+++ b/apcd_cms/src/client/src/components/Extensions/EditExtensionModal/EditExtensionModal.tsx
@@ -296,7 +296,7 @@ const EditExtensionModal: React.FC<EditExtensionModalProps> = ({
                         onBlur={formik.handleBlur}
                       />
                       <div className="help-text">
-                        Requested Expy Date:{' '}
+                        Requested Target Date:{' '}
                         {currentExtension.requested_target_date
                           ? new Date(
                               currentExtension.requested_target_date

--- a/apcd_cms/src/client/src/components/Extensions/ViewExtensionModal/ViewExtensionModal.tsx
+++ b/apcd_cms/src/client/src/components/Extensions/ViewExtensionModal/ViewExtensionModal.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { Modal, ModalHeader, ModalBody } from 'reactstrap';
+import { Modal, ModalHeader, ModalBody, Row, Col } from 'reactstrap';
 import { ExtensionRow } from 'hooks/admin';
-import styles from './ViewExtensionModal.module.css';
 
 const ViewExtensionModal: React.FC<{
   extension: ExtensionRow;
@@ -18,53 +17,89 @@ const ViewExtensionModal: React.FC<{
       <ModalHeader close={closeBtn}>
         Extension Details ID {extension.ext_id} for {extension.org_name}
       </ModalHeader>
-
       <ModalBody className="modal-body">
         <div>
           <h4>Details</h4>
           <div className="modal-section">
-            <dl className="c-data-list--is-vert c-data-list--is-wide">
-              <dt className="c-data-list__key">Created</dt>
-              <dd className="c-data-list__value">{extension.created}</dd>
-              <dt className="c-data-list__key">Entity Organization</dt>
-              <dd className="c-data-list__value">{extension.org_name}</dd>
-              <dt className="c-data-list__key">Requestor</dt>
-              <dd className="c-data-list__value">{extension.requestor}</dd>
-              <dt className="c-data-list__key">Requestor Email</dt>
-              <dd className="c-data-list__value">
-                {extension.requestor_email}
-              </dd>
-              <dt className="c-data-list__key">Extension Type</dt>
-              <dd className="c-data-list__value">{extension.type}</dd>
-              <dt className="c-data-list__key">Status</dt>
-              <dd className="c-data-list__value">{extension.ext_status}</dd>
-              <dt className="c-data-list__key">Outcome</dt>
-              <dd className="c-data-list__value">{extension.ext_outcome}</dd>
-              <dt className="c-data-list__key">Applicable Data Period</dt>
-              <dd className="c-data-list__value">
-                {extension.applicable_data_period}
-              </dd>
-              <dt className="c-data-list__key">Current Expected Date</dt>
-              <dd className="c-data-list__value">
-                {extension.current_expected_date}
-              </dd>
-              <dt className="c-data-list__key">Requested Target Date</dt>
-              <dd className="c-data-list__value">
-                {extension.requested_target_date}
-              </dd>
-              <dt className="c-data-list__key">Approved Expiration Date</dt>
-              <dd className="c-data-list__value">
-                {extension.approved_expiration_date}
-              </dd>
-              <dt className="c-data-list__key">Extension Justification</dt>
-              <dd className="c-data-list__value">
-                {extension.explanation_justification}
-              </dd>
-              <dt className="c-data-list__key">Extension Notes</dt>
-              <dd className="c-data-list__value">{extension.notes}</dd>
-              <dt className="c-data-list__key">Last Updated</dt>
-              <dd className="c-data-list__value">{extension.updated_at}</dd>
-            </dl>
+            <Row>
+              <Col md={{ size: 4, offset: 1 }}>Created</Col>
+              <Col md={7}>
+                {extension.created
+                  ? new Date(extension.created).toLocaleString()
+                  : 'None'}
+              </Col>
+            </Row>
+            <Row>
+              <Col md={{ size: 4, offset: 1 }}>Entity Organization</Col>
+              <Col md={7}>{extension.org_name}</Col>
+            </Row>
+            <Row>
+              <Col md={{ size: 4, offset: 1 }}>Requestor</Col>
+              <Col md={7}>{extension.requestor}</Col>
+            </Row>
+            <Row>
+              <Col md={{ size: 4, offset: 1 }}>Requestor Email</Col>
+              <Col md={7}>{extension.requestor_email}</Col>
+            </Row>
+            <Row>
+              <Col md={{ size: 4, offset: 1 }}>Extension Type</Col>
+              <Col md={7}>{extension.type}</Col>
+            </Row>
+            <Row>
+              <Col md={{ size: 4, offset: 1 }}>Status</Col>
+              <Col md={7}>{extension.ext_status}</Col>
+            </Row>
+            <Row>
+              <Col md={{ size: 4, offset: 1 }}>Outcome</Col>
+              <Col md={7}>{extension.ext_outcome}</Col>
+            </Row>
+            <Row>
+              <Col md={{ size: 4, offset: 1 }}>Applicable Data Period</Col>
+              <Col md={7}>{extension.applicable_data_period}</Col>
+            </Row>
+            <Row>
+              <Col md={{ size: 4, offset: 1 }}>Current Expected Date</Col>
+              <Col md={7}>
+                {extension.current_expected_date
+                  ? new Date(
+                      extension.current_expected_date
+                    ).toLocaleDateString()
+                  : 'None'}
+              </Col>
+            </Row>
+            <Row>
+              <Col md={{ size: 4, offset: 1 }}>Requested Target Date</Col>
+              <Col md={7}>
+                {extension.requested_target_date
+                  ? new Date(
+                      extension.requested_target_date
+                    ).toLocaleDateString()
+                  : 'None'}
+              </Col>
+            </Row>
+            <Row>
+              <Col md={{ size: 4, offset: 1 }}>Approved Expiration Date</Col>
+              <Col md={7}>
+                {extension.approved_expiration_date
+                  ? new Date(
+                      extension.approved_expiration_date
+                    ).toLocaleDateString()
+                  : 'None'}
+              </Col>
+            </Row>
+            <Row>
+              <Col md={{ size: 4, offset: 1 }}>Extension Justification</Col>
+              <Col md={7}>{extension.explanation_justification}</Col>
+            </Row>
+            <Row>
+              <Col md={{ size: 4, offset: 1 }}>Extension Notes</Col>
+              <Col md={7}>{extension.notes}</Col>
+            </Row>
+            <Row>
+              <Col md={{ size: 4, offset: 1 }}>Last Updated</Col>
+              <Col md={7}>{extension.updated_at}</Col>
+            </Row>
+            <hr />
           </div>
         </div>
       </ModalBody>


### PR DESCRIPTION
## Overview

Addresses testing bugs for the admin extension table


## Related


- [WP-859](https://tacc-main.atlassian.net/browse/WP-859)
- [WP-860](https://tacc-main.atlassian.net/browse/WP-860)
- [WP-861](https://tacc-main.atlassian.net/browse/WP-861)


## Changes

- Removes extra layers of styles effecting the size of the extension modal
- Uses state to manage fields and listing in edit modal
- Updated extension modal so that it follows the style and layout of the Exception View/Edit modals
- Sorts extension listing by created by date rather than approved expiration date

## Testing

1. Make sure to collect static since some static style sheets were changed. 
2. Go to [http://localhost:8000/administration/list-extensions/](http://localhost:8000/administration/list-extensions/) 
3. Check that listing is sorted by created by date from newest to oldest
4. Check that the extension modal now has the same styles and layout as the exception form
5. Check that on submitting the form, the listing in the modal and form update with new values. Check the extension listing page to see if it saves to the database.
6. Check that the help text under Approved Expiration Date shows Requested Target Date: and shows a valid date

## UI
![Screenshot 2025-02-10 at 6 16 04 PM](https://github.com/user-attachments/assets/656e4d25-9421-48aa-aff6-dd35e6d2c524)
![Screenshot 2025-02-10 at 6 16 33 PM](https://github.com/user-attachments/assets/1ebb2ee0-a4c8-4f38-8009-dc8167d82393)
![Screenshot 2025-02-10 at 6 16 45 PM](https://github.com/user-attachments/assets/489924c4-c7f6-4989-95ef-085235a97735)

