### PR TITLE
bug/extension-edit-modal-approved-date

### DIFF
--- a/apcd_cms/src/client/src/components/Extensions/EditExtensionModal/EditExtensionModal.tsx
+++ b/apcd_cms/src/client/src/components/Extensions/EditExtensionModal/EditExtensionModal.tsx
@@ -116,7 +116,7 @@ const EditExtensionModal: React.FC<EditExtensionModalProps> = ({
         currentExtension?.approved_expiration_date &&
         currentExtension?.approved_expiration_date !== 'None'
           ? formatUTCDate(currentExtension?.approved_expiration_date)
-          : 'None' + 'currentExtension?.approved_expiration_date',
+          : 'None',
     },
     {
       label: 'Extension Justification',

--- a/apcd_cms/src/client/src/components/Extensions/ViewExtensionModal/ViewExtensionModal.tsx
+++ b/apcd_cms/src/client/src/components/Extensions/ViewExtensionModal/ViewExtensionModal.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Modal, ModalHeader, ModalBody, Row, Col } from 'reactstrap';
-import { formatUTCDate } from 'utils/dateUtil';
+import { formatDate, formatUTCDate } from 'utils/dateUtil';
 import { ExtensionRow } from 'hooks/admin';
 
 const ViewExtensionModal: React.FC<{
@@ -92,7 +92,11 @@ const ViewExtensionModal: React.FC<{
             </Row>
             <Row>
               <Col md={{ size: 4, offset: 1 }}>Last Updated</Col>
-              <Col md={7}>{extension.updated_at}</Col>
+              <Col md={7}>
+                {extension.updated_at
+                  ? formatDate(extension.updated_at)
+                  : 'None'}
+              </Col>
             </Row>
             <hr />
           </div>

--- a/apcd_cms/src/client/src/utils/dateUtil.ts
+++ b/apcd_cms/src/client/src/utils/dateUtil.ts
@@ -1,7 +1,7 @@
 export const formatDate = (dateString: string | number | Date): string => {
   const date = new Date(dateString);
   if (isNaN(date.getTime())) {
-    return '';
+    return 'None';
   }
 
   return new Intl.DateTimeFormat('en-US', {
@@ -18,7 +18,7 @@ export const formatUTCDate = (dateString: string | number | Date): string => {
   const date = new Date(dateString);
 
   if (isNaN(date.getTime())) {
-    return '';
+    return 'None';
   }
 
   return new Intl.DateTimeFormat('en-US', {


### PR DESCRIPTION
## Overview

…

## Related


## Changes
- Removes string of logic checking for approved expiry date from value returned to modal for display
- Updates formatDate and formatDateUTC utils in front end to return 'None' instead of '' to fix issue with displaying 'Invalid date' when attempting to format ''
- Updates logic of displaying last updated date in View Extension Modal to match above util changes
…

## Testing

1. Go to http://localhost:8000/administration/list-extensions/
** For below steps, also check that 'Updated At:" field displays either 'None' or a date + timestamp **
2. Click through to 'Edit Record' on a record with no listed approved expiration date and confirm that only 'None' is displayed in the 'Approved Expiration Date' below the form in the modal
3. Repeat for a record with an approved expiration date and confirm date + timestamp show in the same field
4. Repeat (2) and (3) but for the 'View Record' modal

_Extra thorough step_: Check all other listing pages' 'Last Updated' column and/or View & Edit record modals to confirm either 'None' or a date+timestamp display (all listing pages but List Registration Requests and View Submitter Users display this field)

## UI
Before:
![image](https://github.com/user-attachments/assets/c05f0cc1-0ea7-4cb7-8c17-b665db196719)

After:
![image](https://github.com/user-attachments/assets/e6efe3ce-410d-4d1c-802a-646485ed675a)

…

<!--
## Notes

…
-->
