### PR TITLE
WP-885 Duplicate Users in View Submitter Users table

### DIFF
--- a/apcd_cms/src/apps/utils/apcd_database.py
+++ b/apcd_cms/src/apps/utils/apcd_database.py
@@ -165,7 +165,7 @@ def get_submitter_users():
         roles.role_name,
         users.active,
         users.user_number,
-        submissions.payor_code,
+        submitters.payor_code,
         users.role_id,
         users.user_email,
         users.notes,
@@ -174,8 +174,6 @@ def get_submitter_users():
         JOIN users
             ON submitter_users.user_id = users.user_id
             AND submitter_users.user_number = users.user_number
-        JOIN submissions
-            ON submitter_users.submitter_id = submissions.submitter_id
         JOIN roles 
             ON roles.role_id = users.role_id
         JOIN submitters


### PR DESCRIPTION
## Overview

View Submitter Users table had multiple duplicate records, fixed query so that it no longer joins on submissions table. 

## Related


- [WP-885](https://tacc-main.atlassian.net/browse/WP-885)


## Changes

removed join to submissions table

## Testing

1. navigate to administration/view-submitter-users/ and verify table does not have multiple duplicate rows for each user

