### PR TITLE
Bugs/WP-882: Registration for user with no apcd groups

### DIFF
--- a/apcd_cms/src/apps/base/base.py
+++ b/apcd_cms/src/apps/base/base.py
@@ -19,6 +19,14 @@ class BaseAPIView(View):
                 status=500)
 
 
+class AuthenticatedUserTemplateMixin:
+    """ API Mixin to restrict access to authenticated users only. """
+
+    def dispatch(self, request, *args, **kwargs):
+        if not request.user.is_authenticated:
+            return HttpResponseRedirect('/')
+        return super().dispatch(request, *args, **kwargs)
+    
 class APCDAdminAccessTemplateMixin:
     """ API Mixin to restrict access to authenticated APCD admins only. """
 
@@ -45,6 +53,14 @@ class APCDSubmitterAdminAccessTemplateMixin:
             return HttpResponseRedirect('/')
         return super().dispatch(request, *args, **kwargs)
 
+
+class AuthenticatedUserAPIMixin:
+    """ API Mixin to restrict access to authenticated users."""
+
+    def dispatch(self, request, *args, **kwargs):
+        if not request.user.is_authenticated:
+            return JsonResponse({'error': 'Unauthorized'}, status=403)
+        return super().dispatch(request, *args, **kwargs)
 
 class APCDAdminAccessAPIMixin:
     """ API Mixin to restrict access to authenticated APCD admins only. """

--- a/apcd_cms/src/apps/registrations/views.py
+++ b/apcd_cms/src/apps/registrations/views.py
@@ -6,7 +6,7 @@ from apps.utils.apcd_groups import has_groups
 from django.conf import settings
 from django.http import JsonResponse
 from django.views.generic import TemplateView
-from apps.base.base import BaseAPIView, APCDGroupAccessTemplateMixin, APCDGroupAccessAPIMixin
+from apps.base.base import BaseAPIView, AuthenticatedUserTemplateMixin, AuthenticatedUserAPIMixin
 from requests.auth import HTTPBasicAuth
 import logging
 import rt
@@ -20,11 +20,11 @@ RT_PW = getattr(settings, 'RT_PW', '')
 RT_QUEUE = getattr(settings, 'RT_QUEUE', '')
 
 
-class RegistrationFormTemplate(APCDGroupAccessTemplateMixin, TemplateView):
+class RegistrationFormTemplate(AuthenticatedUserTemplateMixin, TemplateView):
     template_name = 'registration_form.html'
 
 
-class RegistrationFormApi(APCDGroupAccessAPIMixin, BaseAPIView):
+class RegistrationFormApi(AuthenticatedUserAPIMixin, BaseAPIView):
 
     def get(self, request):
         formatted_reg_data = []
@@ -44,6 +44,8 @@ class RegistrationFormApi(APCDGroupAccessAPIMixin, BaseAPIView):
         if (request.user.is_authenticated and has_apcd_group(request.user)):
             context = {'registration_data': formatted_reg_data, 'renew': renew}
             return JsonResponse({'response': context})
+        else: 
+            return JsonResponse({'error': 'Unauthorized'}, status=403)
 
     def post(self, request):
         form = json.loads(request.body)


### PR DESCRIPTION
## Overview
A authenticated user with no groups should be able to submit registration request.

## Related

- [WP-882](https://tacc-main.atlassian.net/browse/WP-882)

## Changes

1. Remove groups check
2. Add authenticated check

## Testing

1. Remove all user groups for your user
2. Go to register/request to submit and submit.
3. Go to db and run query: `select * from registrations order by created_at desc LIMIT 1;`  to see your registration
