### PR TITLE
WP-887: Fix for data periods and expected dates

### DIFF
--- a/apcd_cms/src/apps/utils/apcd_database.py
+++ b/apcd_cms/src/apps/utils/apcd_database.py
@@ -1211,6 +1211,9 @@ def get_submitter_info(user):
         if conn is not None:
             conn.close()
 
+def _get_extension_where_clause():
+    return "cancelled = 'FALSE' AND granted_reprieve='FALSE' AND submission_id is Null"
+
 def get_applicable_data_periods(submitter_id):
     cur = None
     conn = None
@@ -1223,8 +1226,9 @@ def get_applicable_data_periods(submitter_id):
             port=APCD_DB['port'],
             sslmode='require',
         )
+        where_clause = _get_extension_where_clause()
         cur = conn.cursor()
-        query = """ SELECT distinct data_period_start FROM submitter_calendar WHERE submitter_id = (%s) AND cancelled = 'FALSE' AND granted_reprieve='FALSE' AND submission_id is NOT NULL """
+        query = f""" SELECT distinct data_period_start FROM submitter_calendar WHERE submitter_id = (%s) AND {where_clause} """
         cur.execute(query, (submitter_id,))
         return cur.fetchall()
 
@@ -1249,8 +1253,9 @@ def get_current_exp_date(submitter_id, applicable_data_period):
             port=APCD_DB['port'],
             sslmode='require',
         )
+        where_clause = _get_extension_where_clause()
         cur = conn.cursor()
-        query = """ SELECT expected_submission_date FROM submitter_calendar WHERE submitter_id = (%s) AND data_period_start = (%s) AND cancelled = 'FALSE' AND granted_reprieve='FALSE' AND submission_id is Null """
+        query = f""" SELECT expected_submission_date FROM submitter_calendar WHERE submitter_id = (%s) AND data_period_start = (%s) AND {where_clause}"""
         cur.execute(query, (submitter_id, applicable_data_period,))
         return cur.fetchall()
 

--- a/apcd_cms/src/apps/utils/apcd_database.py
+++ b/apcd_cms/src/apps/utils/apcd_database.py
@@ -1212,6 +1212,7 @@ def get_submitter_info(user):
             conn.close()
 
 def _get_extension_where_clause():
+    # see wiki: https://tacc-main.atlassian.net/wiki/x/A4D4Aw?atlOrigin=eyJpIjoiNTNmNTgyZmUzMjk0NGUzZDllODVhOGQ4ZmQ3MzJmNGUiLCJwIjoiYyJ9
     return "cancelled = 'FALSE' AND granted_reprieve='FALSE' AND submission_id is Null"
 
 def get_applicable_data_periods(submitter_id):

--- a/apcd_cms/src/client/src/components/Submitter/Extensions/ExtensionsForm.tsx
+++ b/apcd_cms/src/client/src/components/Submitter/Extensions/ExtensionsForm.tsx
@@ -195,10 +195,10 @@ export const ExtensionRequestForm: React.FC = () => {
                   <hr />
                   <h4>Request and Justification</h4>
                   <p>
-                    Provide rationale for the exception request, outlining the
+                    Provide rationale for the extension request, outlining the
                     reasons why the organization is unable to comply with the
                     relevant requirements. Provide as much detail as possible
-                    regarding the exception request, indicating the specific
+                    regarding the extension request, indicating the specific
                     submission requirements for which relief is being sought. If
                     applicable, indicate how the organization plans to become
                     compliant.**


### PR DESCRIPTION
## Overview
Extension applicable data periods is using different where clause from extension expected dates resulting in periods with null expected dates.

## Related
- [WP-887](https://tacc-main.atlassian.net/browse/WP-887)

## Changes
1. Use same where in database queries for both applicable data periods and extension expected dates.
2. the api for data periods is forcing apcd admin, where as it should also allow submitter admin. Adjusted that.
3. For submitter admin, we should check whether the user has access to the submitter.
…

## Testing

1. As APCD_ADMIN, go to http://localhost:8000/submissions/extension-request/ and check all the applicable data periods
2. As SUBMITTER_ADMIN, go to http://localhost:8000/submissions/extension-request/ and check all the applicable data periods.
3. As SUBMITTER_ADMIN, open a new tab in browser and check whether you get access error when visiting this url: http://localhost:8000/common_api/data_periods/?submitter_id=0. Note: I have no access to 0, so I got `{"error": "Unauthorized for submitter id 0"}` You might have to check which submitter id you have no access to.

