### PR TITLE
Remove Status 'None' from Edit Extension modal.

### DIFF
--- a/apcd_cms/src/apps/admin_extension/views.py
+++ b/apcd_cms/src/apps/admin_extension/views.py
@@ -34,7 +34,7 @@ class AdminExtensionsApi(APCDAdminAccessAPIMixin, BaseAPIView):
         context['outcome_options'] = []
         context['extensions'] = []
         context['action_options'] = ['Select Action', 'View Record', 'Edit Record']
-        context['status_edit_options'] = [{'key': 'complete', 'value': 'Complete'}, {'key': 'pending', 'value': 'Pending'}, {'key': 'none', 'value': 'None'}]
+        context['status_edit_options'] = [{'key': 'complete', 'value': 'Complete'}, {'key': 'pending', 'value': 'Pending'}]
         context['outcome_edit_options'] = [{'key': 'denied', 'value': 'Denied'}, {'key': 'granted', 'value':'Granted'}, {'key': 'none', 'value': 'None'}, {'key': 'withdrawn', 'value': 'Withdrawn'}]
 
 


### PR DESCRIPTION
## Overview

Remove Status 'None' from Edit Extensions modal
…

## Related

[WP-810](https://tacc-main.atlassian.net/browse/WP-810)

## Changes

Remove Status 'None' from Edit Extensions modal

## Testing

1. Open Edit Record modal from Extensions list
2. Make sure Status drop-down has no 'None' option.

## UI

![Screenshot 2025-03-13 at 3 21 25 PM](https://github.com/user-attachments/assets/23d2bda9-38aa-4d40-8fe8-eee3437f4e85)


…

<!--
## Notes

…
-->
