### PR TITLE
chore(wtcs): add icon - handle error, clear variables, save snippet

### DIFF
--- a/wtcs_assets/scripts/add-shopping-cart-icon.js
+++ b/wtcs_assets/scripts/add-shopping-cart-icon.js
@@ -1,6 +1,6 @@
 const alt = 'Register';
 const url = 'https://professionaled.utexas.edu/s/checkout-TACC';
-const icon = 'https://cdn.jsdelivr.net/gh/TACC/Core-CMS-Custom@feat/wtcs-shopping-cart-icon/wtcs_assets/icons/shopping-cart.png';
+const icon = '../icons/shopping-cart.png';
 
 // To mimic the login nav icon HTML, but as a shopping cart icon
 // https://github.com/TACC/Core-CMS/blob/v4.25.4/taccsite_cms/templates/nav_portal.html#L5-L10

--- a/wtcs_assets/scripts/add-shopping-cart-icon.js
+++ b/wtcs_assets/scripts/add-shopping-cart-icon.js
@@ -1,6 +1,9 @@
+const scriptUrl = document.currentScript.src;
+function getIconUrl(icon) { return new URL(icon, scriptUrl).href; }
+
 const alt = 'Register';
 const url = 'https://professionaled.utexas.edu/s/checkout-TACC';
-const icon = '../icons/shopping-cart.png';
+const icon = getIconUrl('../icons/shopping-cart.png');
 
 // To mimic the login nav icon HTML, but as a shopping cart icon
 // https://github.com/TACC/Core-CMS/blob/v4.25.4/taccsite_cms/templates/nav_portal.html#L5-L10

--- a/wtcs_assets/scripts/add-shopping-cart-icon.js
+++ b/wtcs_assets/scripts/add-shopping-cart-icon.js
@@ -1,9 +1,11 @@
 const scriptUrl = document.currentScript.src;
 function getIconUrl(icon) { return new URL(icon, scriptUrl).href; }
 
-const alt = 'Register';
-const url = 'https://professionaled.utexas.edu/s/checkout-TACC';
-const icon = getIconUrl('../icons/shopping-cart.png');
+const iconAlt = 'Register';
+const linkHref = 'https://professionaled.utexas.edu/s/checkout-TACC';
+const iconPath = '../icons/shopping-cart.png';
+
+const iconSrc = getIconUrl(iconPath);
 
 // To mimic the login nav icon HTML, but as a shopping cart icon
 // https://github.com/TACC/Core-CMS/blob/v4.25.4/taccsite_cms/templates/nav_portal.html#L5-L10
@@ -11,8 +13,8 @@ const icon = getIconUrl('../icons/shopping-cart.png');
 const html = `
   <ul class="navbar-nav s-portal-nav">
     <li class="nav-item">
-      <a href="${url}" class="nav-link" target="_blank">
-        <img role="button" alt="${alt}" class="icon" src="${icon}">
+      <a href="${linkHref}" class="nav-link" target="_blank">
+        <img role="button" alt="${iconAlt}" class="icon" src="${iconSrc}">
       </a>
     </li>
   </ul>

--- a/wtcs_assets/scripts/add-shopping-cart-icon.js
+++ b/wtcs_assets/scripts/add-shopping-cart-icon.js
@@ -1,11 +1,6 @@
-const scriptUrl = document.currentScript.src;
-function getIconUrl(icon) { return new URL(icon, scriptUrl).href; }
-
-const iconAlt = 'Register';
+const imgSrc = 'https://cdn.jsdelivr.net/gh/TACC/Core-CMS-Custom@afbbae/wtcs_assets/icons/shopping-cart.png';
 const linkHref = 'https://professionaled.utexas.edu/s/checkout-TACC';
-const iconPath = '../icons/shopping-cart.png';
-
-const iconSrc = getIconUrl(iconPath);
+const imgAlt = 'Register';
 
 // To mimic the login nav icon HTML, but as a shopping cart icon
 // https://github.com/TACC/Core-CMS/blob/v4.25.4/taccsite_cms/templates/nav_portal.html#L5-L10
@@ -13,11 +8,20 @@ const iconSrc = getIconUrl(iconPath);
 const html = `
   <ul class="navbar-nav s-portal-nav">
     <li class="nav-item">
-      <a href="${linkHref}" class="nav-link" target="_blank">
-        <img role="button" alt="${iconAlt}" class="icon" src="${iconSrc}">
+      <a
+        class="nav-link"
+        href="${linkHref}"
+        target="_blank"
+      >
+        <img class="icon" alt="${imgAlt}" src="${imgSrc}" role="button">
       </a>
     </li>
   </ul>
 `;
 
-document.getElementById('s-search-bar').parentElement.insertAdjacentHTML('beforeend', html);
+const searchBar = document.getElementById('s-cms-nav');
+if (searchBar) {
+  searchBar.parentElement.insertAdjacentHTML('beforeend', html);
+} else {
+  console.error('No `.s-cms-nav` found, so uncertain where to render icon');
+}

--- a/wtcs_assets/scripts/add-shopping-cart-icon.js
+++ b/wtcs_assets/scripts/add-shopping-cart-icon.js
@@ -15,9 +15,9 @@ const html = `
   </ul>
 `;
 
-const searchBar = document.getElementById('s-cms-nav');
-if (searchBar) {
-  searchBar.parentElement.insertAdjacentHTML('beforeend', html);
+const cmsNav = document.querySelector('.s-cms-nav');
+if (cmsNav) {
+  cmsNav.parentElement.insertAdjacentHTML('beforeend', html);
 } else {
   console.error('No `.s-cms-nav` found, so uncertain where to render icon');
 }

--- a/wtcs_assets/scripts/add-shopping-cart-icon.js
+++ b/wtcs_assets/scripts/add-shopping-cart-icon.js
@@ -8,11 +8,7 @@ const imgAlt = 'Register';
 const html = `
   <ul class="navbar-nav s-portal-nav">
     <li class="nav-item">
-      <a
-        class="nav-link"
-        href="${linkHref}"
-        target="_blank"
-      >
+      <a class="nav-link" href="${linkHref}" target="_blank">
         <img class="icon" alt="${imgAlt}" src="${imgSrc}" role="button">
       </a>
     </li>

--- a/wtcs_assets/snippets/add-shopping-cart-icon.html
+++ b/wtcs_assets/snippets/add-shopping-cart-icon.html
@@ -1,0 +1,1 @@
+<script id="js-add-shopping-cart-icon" src="https://cdn.jsdelivr.net/gh/TACC/Core-CMS-Custom@e3ecde2a/wtcs_assets/scripts/add-shopping-cart-icon.js"></script>

--- a/wtcs_assets/snippets/add-shopping-cart-icon.html
+++ b/wtcs_assets/snippets/add-shopping-cart-icon.html
@@ -1,1 +1,1 @@
-<script id="js-add-shopping-cart-icon" src="https://cdn.jsdelivr.net/gh/TACC/Core-CMS-Custom@e3ecde2a/wtcs_assets/scripts/add-shopping-cart-icon.js"></script>
+<script id="js-add-shopping-cart-icon" src="https://cdn.jsdelivr.net/gh/TACC/Core-CMS-Custom@eb68c879/wtcs_assets/scripts/add-shopping-cart-icon.js"></script>


### PR DESCRIPTION
## Overview

- Clean up shopping cart icon script.
- Save snippet used to execute script.

## Related

- improves #448

## Changes

- **refactored** script to add icon
- **added** new snippet

## Testing

1. Open https://weteachcs.org/.
2. Verify icon renders at size of Portal login icon.
3. Verify link opens Registration in new window.

## UI

https://github.com/user-attachments/assets/87c31cf6-ab08-43f6-b63f-c8e7eba3c63c

## Notes

I thought about dynamic image path, so icon can be served from same CDN parent path that loads the script, which would allow icon to be updated without updating script, but it opened up security holes I'd need to close and test. Easier to just update as necessary which is probably never.