### PR TITLE
deps(a2cps, apcd, example): cms v4.26.0

### DIFF
--- a/a2cps_cms/Dockerfile
+++ b/a2cps_cms/Dockerfile
@@ -1,4 +1,4 @@
-FROM taccwma/core-cms:v4.25.4
+FROM taccwma/core-cms:v4.26.0
 
 WORKDIR /code
 

--- a/apcd_cms/Dockerfile
+++ b/apcd_cms/Dockerfile
@@ -1,4 +1,4 @@
-FROM taccwma/core-cms:v4.25.4
+FROM taccwma/core-cms:v4.26.0
 
 WORKDIR /code
 

--- a/example_cms/Dockerfile
+++ b/example_cms/Dockerfile
@@ -1,4 +1,4 @@
-FROM taccwma/core-cms:v4.25.4
+FROM taccwma/core-cms:v4.26.0
 
 WORKDIR /code
 


### PR DESCRIPTION
## Overview

Update `…_cms` projects to use Core-CMS v4.26.0.

## Related

- similar to #451

## Changes

- **changed** `Dockerfile`'s CMS image

## Testing

1. Update https://github.com/TACC/Core-Portal-Deployments.
2. Deploy.

## UI

Buried and piecemeal within [internal testing doc](https://tacc-main.atlassian.net/wiki/x/5oAmJQ).

## Notes

Goal is to avoid migration issues that will arise from a deploy of Core-CMS image from Core-CMS branches **after** https://github.com/TACC/Core-CMS/pull/908, but **before** https://github.com/TACC/Core-CMS/pull/927, https://github.com/TACC/Core-CMS/pull/928, https://github.com/TACC/Core-CMS/pull/929. Such migration issues occurred on APCD.