### PR TITLE
deps(apcd): cms v4.26.1

### DIFF
--- a/apcd_cms/Dockerfile
+++ b/apcd_cms/Dockerfile
@@ -1,4 +1,4 @@
-FROM taccwma/core-cms:v4.26.0
+FROM taccwma/core-cms:v4.26.1
 
 WORKDIR /code
 


### PR DESCRIPTION
## Overview

Bump Core-CMS (for parity with A2CPS). No effect.

## Changes

- **Irrelevant**: Fixes UI bugs in header that only affect `TACC_CORE_STYLES_VERSION = 0` sites.
- **Unused**: Adds CMS update to System Monitor plugin (used on very few CMS's).