### PR TITLE
Removed the json log link in the file submissions modal

### DIFF
--- a/apcd_cms/src/client/src/components/Submissions/ViewFileSubmissions/ViewSubmissionsModal.tsx
+++ b/apcd_cms/src/client/src/components/Submissions/ViewFileSubmissions/ViewSubmissionsModal.tsx
@@ -70,20 +70,6 @@ export const ViewSubmissionLogsModal: React.FC<
                           </Link>
                         )}
                       </dd>
-                      <dt className="c-data-list__key">JSON Log</dt>
-                      <dd className="c-data-list__value">
-                        {log.has_json_log === 1 && (
-                          <Link
-                            to={`${
-                              isAdminUser ? 'administration' : 'submissions'
-                            }/view_log?log_type=json&log_id=${log.log_id}`}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                          >
-                            Download
-                          </Link>
-                        )}
-                      </dd>
                     </dl>
                     <hr />
                   </div>


### PR DESCRIPTION
## Overview

UTH request, the JSON logs are for internal use only. Removed from both Admin and User modals, since I assume internal use means it should not be displayed in the portal in general. 

## Related

- [WP-914](https://tacc-main.atlassian.net/browse/WP-914)

## Changes

Removed JSON link from the modal template. 

## Testing

1. Open http://localhost:8000/submissions/list-submissions/ and verify the JSON link is no longer displayed 
2. Do the same on http://localhost:8000/administration/list-submissions/ 
