### PR TITLE
task/Points v1.0.19 (prod cms tag) to TACC CMS image v4.26.1

### DIFF
--- a/apcd_cms/Dockerfile
+++ b/apcd_cms/Dockerfile
@@ -1,7 +1,8 @@
-FROM taccwma/core-cms:v4.12.0
+FROM taccwma/core-cms:v4.26.1
 
 WORKDIR /code
 
 COPY /src/apps /code/apps
+COPY /src/client /code/client
 COPY /src/taccsite_custom /code/taccsite_custom
 COPY /src/taccsite_cms /code/taccsite_cms


### PR DESCRIPTION
## Overview

Updates prod CMS to keep everything the same as v1.0.19 (prod CMS) with no react client but points base image to CoreCMS v4.26.1

## Related


## Changes

…

## Testing

1. Make build / make start
2. Ensure it looks like https://txapcd.org/ 

## UI

…

<!--
## Notes

…
-->
