### PR TITLE
hotfix/modal-close-button

### DIFF
--- a/apcd_cms/src/apps/admin_exception/templates/edit_exception_modal.html
+++ b/apcd_cms/src/apps/admin_exception/templates/edit_exception_modal.html
@@ -9,7 +9,7 @@
       <div class="modal-header">
         <h4 class="modal-title">Edit Exception ID {{r.exception_id}} for {{r.entity_name}}</h4>
         <button type="button" class="close" data-dismiss="modal">
-          <span aria-hidden="true">&#xe912;</span>
+          <span aria-hidden="true">&times;</span>
         </button>
       </div>
       <div class="modal-body">

--- a/apcd_cms/src/apps/admin_exception/templates/view_admin_exception_modal.html
+++ b/apcd_cms/src/apps/admin_exception/templates/view_admin_exception_modal.html
@@ -9,7 +9,7 @@
         <div class="modal-header">
           <h4 class="modal-title">Exception Details</h4>
           <button type="button" class="close" data-dismiss="modal">
-            <span aria-hidden="true">&#xe912;</span>
+            <span aria-hidden="true">&times;</span>
           </button>
         </div>
         <div class="modal-body">

--- a/apcd_cms/src/apps/admin_extension/templates/edit_extension_modal.html
+++ b/apcd_cms/src/apps/admin_extension/templates/edit_extension_modal.html
@@ -9,7 +9,7 @@
       <div class="modal-header">
         <h4 class="modal-title">Edit Extension ID {{r.extension_id}} for {{r.entity_name}}</h4>
         <button type="button" class="close" data-dismiss="modal">
-          <span aria-hidden="true">&#xe912;</span>
+          <span aria-hidden="true">&times;</span>
         </button>
       </div>
       <div class="modal-body">

--- a/apcd_cms/src/apps/admin_extension/templates/view_admin_extension_modal.html
+++ b/apcd_cms/src/apps/admin_extension/templates/view_admin_extension_modal.html
@@ -9,7 +9,7 @@
         <div class="modal-header">
           <h4 class="modal-title">Extension Details ID {{r.extension_id}} for {{r.entity_name}}</h4>
           <button type="button" class="close" data-dismiss="modal">
-            <span aria-hidden="true">&#xe912;</span>
+            <span aria-hidden="true">&times;</span>
           </button>
         </div>
         <div class="modal-body">

--- a/apcd_cms/src/apps/admin_regis_table/templates/create_submitter_modal.html
+++ b/apcd_cms/src/apps/admin_regis_table/templates/create_submitter_modal.html
@@ -4,7 +4,7 @@
       <div class="modal-header">
         <h4 class="modal-title">Create New Submitter</h4>
         <button type="button" class="close" data-dismiss="modal">
-          <span aria-hidden="true">&#xe912;</span>
+          <span aria-hidden="true">&times;</span>
         </button>
       </div>
       <div class="modal-body" style="height: auto;">

--- a/apcd_cms/src/apps/admin_regis_table/templates/edit_registration_modal.html
+++ b/apcd_cms/src/apps/admin_regis_table/templates/edit_registration_modal.html
@@ -10,7 +10,7 @@
       <div class="modal-header">
         <h4 class="modal-title">Edit Registration</h4>
         <button type="button" class="close" data-dismiss="modal">
-          <span aria-hidden="true">&#xe912;</span>
+          <span aria-hidden="true">&times;</span>
         </button>
       </div>
       <div class="modal-body">

--- a/apcd_cms/src/apps/admin_regis_table/templates/view_registration_modal.html
+++ b/apcd_cms/src/apps/admin_regis_table/templates/view_registration_modal.html
@@ -6,7 +6,7 @@
       <div class="modal-header">
         <h4 class="modal-title">View Registration</h4>
         <button type="button" class="close" data-dismiss="modal">
-          <span aria-hidden="true">&#xe912;</span>
+          <span aria-hidden="true">&times;</span>
         </button>
       </div>
       <div class="modal-body">

--- a/apcd_cms/src/apps/admin_submissions/templates/view_admin_submission_logs_modal.html
+++ b/apcd_cms/src/apps/admin_submissions/templates/view_admin_submission_logs_modal.html
@@ -6,7 +6,7 @@
         <div class="modal-header">
           <h4 class="modal-title">View Logs</h4>
           <button type="button" class="close" data-dismiss="modal">
-            <span aria-hidden="true">&#xe912;</span>
+            <span aria-hidden="true">&times;</span>
           </button>
         </div>
         <div class="modal-body">

--- a/apcd_cms/src/apps/submissions/templates/view_submission_logs_modal.html
+++ b/apcd_cms/src/apps/submissions/templates/view_submission_logs_modal.html
@@ -6,7 +6,7 @@
         <div class="modal-header">
           <h4 class="modal-title">View Logs</h4>
           <button type="button" class="close" data-dismiss="modal">
-            <span aria-hidden="true">&#xe912;</span>
+            <span aria-hidden="true">&times;</span>
           </button>
         </div>
         <div class="modal-body">

--- a/apcd_cms/src/apps/view_users/templates/view_user_edit_modal.html
+++ b/apcd_cms/src/apps/view_users/templates/view_user_edit_modal.html
@@ -9,7 +9,7 @@
       <div class="modal-header">
         <h4 class="modal-title">Edit User ID: {{r.user_id}} for {{r.user_name}}</h4>
         <button type="button" class="close" data-dismiss="modal">
-          <span aria-hidden="true">&#xe912;</span>
+          <span aria-hidden="true">&times;</span>
         </button>
       </div>
       <div class="modal-body">

--- a/apcd_cms/src/apps/view_users/templates/view_user_modal.html
+++ b/apcd_cms/src/apps/view_users/templates/view_user_modal.html
@@ -9,7 +9,7 @@
       <div class="modal-header">
         <h4 class="modal-title">Details for User: {{r.user_name}} ({{r.user_id}})</h4>
         <button type="button" class="close" data-dismiss="modal">
-          <span aria-hidden="true">&#xe912;</span>
+          <span aria-hidden="true">&times;</span>
         </button>
       </div>
       


### PR DESCRIPTION
## Overview

…

## Related

<!--
- [WP-123](https://tacc-main.atlassian.net/browse/WP-123)
- requires https://github.com/TACC/Core-CMS/pull/117
-->…

## Changes

…

## Testing

1. Checkout feature/v1.0.19-apcd-current-prod-cms then checkout this PR
2. In local settings, Set TACC_CORE_STYLES_VERSION = 0.
3. Bash into core_cms and collectstatic
4. Go to each admin page
5. Open view modal
6. Open edit modal
7. Check that x button appears correctly to close modal

## UI

…

<!--
## Notes

…
-->
