### PR TITLE
fix: modal title and close button not vertically-aligned

### DIFF
--- a/apcd_cms/src/taccsite_custom/apcd_cms/static/apcd_cms/css/modal--conflicts-with-core.css
+++ b/apcd_cms/src/taccsite_custom/apcd_cms/static/apcd_cms/css/modal--conflicts-with-core.css
@@ -16,8 +16,7 @@
     border-radius: 0.3rem;
 }
 
-/* TODO: Determine how to integrate this into Core */
 .modal-title {
-    margin-top: unset; /* overwrite site.css h4 */
+    margin-block: unset; /* IMPORTANT: Not necessary after v1.1.N-apcd */
     font-size: var(--global-font-size--large); /* revert to site.css h4 */
 }


### PR DESCRIPTION
## Overview

Vertically-align modal title and modal close button.

## Related

- similar to #466

## Changes

- **changed** CSS property
- **documented** CSS style

## Testing

1. Open http://localhost:8000/administration/view-users/.
2. Open modal.
3. Verify modal close "X" is vertically centered with modal title text.

## UI

### Isolated Test

| http://localhost:8000/administration/view-users/ |
| - |
| <img width="1130" alt="actual test on branch" src="https://github.com/user-attachments/assets/e4598308-0bf3-45fe-b8f2-693c7fb35e94" /> |

> [!NOTE]
> See #466 for fix to modal icon.

### Testing with #466

https://github.com/user-attachments/assets/16b10ef3-ce85-4884-b706-e208cdff461d
