### PR TITLE
chore(lccf): delete unused commented snippet CSS

### DIFF
--- a/lccf_assets/snippets/css-header-and-logo.html
+++ b/lccf_assets/snippets/css-header-and-logo.html
@@ -11,14 +11,6 @@
 <!-- Before v4.24.0 -->
 <!--
 <style id="css-header-and-logo">
-/* To resize logo */
-.portal-logo {
-    height: 80px;
-}
-.s-header.navbar {
-    --nav-padding-vert: 10px;
-}
-
 /* To vertically align center if #s-header is .navbar-expand-md */
 @media (min-width: 768px) {
     .s-header .nav-item {
@@ -30,18 +22,5 @@
 .s-header .nav-link {
     top: unset;
 }
-
-/* To accomodate dark logo */
-/*
-:root {
-  --header-text-color: var(--global-color-primary--x-dark);
-  --header-bkgd-color: var(--global-color-primary--x-light);
-  --header-minor-border-color: var(--global-color-primary--normal);
-  --header-major-border-color: var(--global-color-primary--normal);
-  --header-search-brdr-color: #D8D8D8;
-  --header-search-bkgd-color: var(--global-color-primary--xx-light);
-  --menu-toggle-icon: invert(100%);
-}
-*/
 </style>
 -->


### PR DESCRIPTION
## Overview

Delete unused, commented CSS code from a snippet.

## Testing & UI

N/A

## Notes

- First block of deleted code is already in `header.css`.
- Second block of deleted code is outdated.