### PR TITLE
Add h5 and h6 CSS styling.

### DIFF
--- a/apcd_cms/src/client/src/components/Registrations/ViewRegistrationModal/ViewRegistrationModal.module.css
+++ b/apcd_cms/src/client/src/components/Registrations/ViewRegistrationModal/ViewRegistrationModal.module.css
@@ -24,3 +24,9 @@
 .verticalDataValue {
   padding-left: 2.5em;
 }
+
+h5,
+h6 {
+  font-size: var(--global-font-size--medium);
+  font-weight: var(--bold);
+}


### PR DESCRIPTION
## Overview

View Registration Modal: h5 and h6 headers are not formatted <del>right</del> <ins>as they were on production as of 2025-03</ins>.

## Related

[WP-900](https://tacc-main.atlassian.net/browse/WP-900)

## Changes

Add h5 and h6 CSS styling

## Testing

1. Open View Registration modal, make sure the <del>right</del> <ins>production 2025-03</ins> CSS styling is applied to h5 and h6 tags

## UI

![Screenshot 2025-04-11 at 3 31 15 PM](https://github.com/user-attachments/assets/87a01c5f-3cba-4361-a876-8041e978c04f)


<!--
## Notes

…
-->
