### PR TITLE
refactor(ecep): fix nav link border color, consolidate global styles

### DIFF
--- a/ecep_assets/site.css
+++ b/ecep_assets/site.css
@@ -67,6 +67,16 @@
 
 
 
+/* ELEMENTS */
+
+figcaption {
+  font-size: small;
+}
+
+
+
+
+
 /* COMPONENTS */
 
 /* Blog */

--- a/ecep_assets/site.css
+++ b/ecep_assets/site.css
@@ -84,8 +84,11 @@ article.post-detail .byline {
 .s-header .navbar-brand {
   min-width: unset;
 }
-.s-header .nav-link {
-  --border-color--active: var(--ecep-accent-gray);
+.s-header .nav-item.active .nav-link,
+.s-header .nav-link:active,
+.s-header .nav-link:focus,
+.s-header .nav-link:hover {
+  border-color: var(--ecep-accent-gray);
 }
 
 /* https://github.com/TACC/Core-Styles/blob/v2.38.0/src/lib/_imports/trumps/s-header.css#L24 */

--- a/ecep_assets/site.css
+++ b/ecep_assets/site.css
@@ -1,3 +1,6 @@
+@import url('./css/links.css');
+@import url('./css/djangocms-picture.css');
+
 /* Organize via ITCSS */
 /* SEE: https://tacc-main.atlassian.net/wiki/x/QQhv */
 


### PR DESCRIPTION
## Overview & Changes

Consolidate global styles into one stylesheet via `@import` (so less global snippets are used on CMS). Also, fix nav link hover underline being orange instead of gray.

## Testing

0. Delete these snippets:
    - `css-djangocms-picture-bug-fix`
    - `css-fix-logo`
    - `css-fix-neutral-colors`
    - `css-links`
2. Image with captions (e.g. [this news article](https://pprd.ecep.tacc.utexas.edu/news/2024/08/22/ecep-as-a-central-hub-for-broadening-participation-in-computing-bpc-initiatives/)):
    - has small text as caption
    - is only as wide as article text area width
3. Homepage logo does not overflow header:
    - when CMS nav menu is visible by default (wide screen)
    - when CMS nav menu is collapsed (narrow screen)
    - when CMS nav menu is collapsed (narrow screen)
4. Links in body text:
    - are underlined by default
    - have dashed underline on hover
    - have dotted underline on click

## UI

Skipped.