### PR TITLE
task/WP-951 Adds workflow to update develop-apcd to main

### DIFF
--- a/.github/workflows/apcd-cms.yml
+++ b/.github/workflows/apcd-cms.yml
@@ -40,9 +40,6 @@ jobs:
           tags: taccwma/apcd-cms:${{ steps.vars.outputs.SHORT_SHA }},taccwma/apcd-cms:${{ steps.vars.outputs.BRANCH_NAME }}
   sync:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: apcd_cms
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/apcd-cms.yml
+++ b/.github/workflows/apcd-cms.yml
@@ -40,6 +40,9 @@ jobs:
           tags: taccwma/apcd-cms:${{ steps.vars.outputs.SHORT_SHA }},taccwma/apcd-cms:${{ steps.vars.outputs.BRANCH_NAME }}
   sync:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apcd_cms
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/apcd-cms.yml
+++ b/.github/workflows/apcd-cms.yml
@@ -46,11 +46,6 @@ jobs:
         with: 
           fetch-depth: 0
 
-      - name: Setup Git User
-        run: |
-          git config user.name "GitHub Action"
-          git config user.email "<EMAIL>"
-
       - name: Update develop-apcd Branch when changes to main are made
         run: |
           git checkout main

--- a/.github/workflows/apcd-cms.yml
+++ b/.github/workflows/apcd-cms.yml
@@ -51,10 +51,7 @@ jobs:
 
       - name: Update develop-apcd Branch when changes to main are made
         run: |
-          git checkout main
-          git fetch origin
           git checkout develop-apcd
-          git pull
           git merge origin/main
           git push origin develop-apcd
 

--- a/.github/workflows/apcd-cms.yml
+++ b/.github/workflows/apcd-cms.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - "apcd_cms/**"
+permissions: write-all
 
 jobs:
   build_commit:
@@ -37,3 +38,26 @@ jobs:
           context: apcd_cms
           push: true
           tags: taccwma/apcd-cms:${{ steps.vars.outputs.SHORT_SHA }},taccwma/apcd-cms:${{ steps.vars.outputs.BRANCH_NAME }}
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with: 
+          fetch-depth: 0
+
+      - name: Setup Git User
+        run: |
+          git config user.name "GitHub Action"
+          git config user.email "<EMAIL>"
+
+      - name: Update develop-apcd Branch when changes to main are made
+        run: |
+          git checkout main
+          git fetch origin
+          git checkout develop-apcd
+          git pull
+          git merge origin/main
+          git push origin develop-apcd
+
+


### PR DESCRIPTION
## Overview
Github workflow to auto-update `develop-apcd `when changes are pushed to main

## Related

- [WP-951](https://tacc-main.atlassian.net/browse/WP-951)

## Changes

- Adds permissions: write-all to yaml
- Adds `sync` job to fetch latest main, checkout develop-apcd, and pull and merge main into develop-apcd [using this as a reference 
](https://stackoverflow.com/questions/76509304/running-github-action-to-keep-a-branch-up-to-date-with-main)
## Testing

1. Need to check that the branch protections and [rulesets here](https://github.com/TACC/Core-CMS-Custom/rules/5328423?ref=refs%2Fheads%2Fdevelop-apcd) don't prohibit this action. Current rules throw this error when trying to merge main into develop-apcd
```
remote: error: GH013: Repository rule violations found for refs/heads/develop-apcd.
remote: Review all repository rules at https://github.com/TACC/Core-CMS-Custom/rules?ref=refs%2Fheads%2Fdevelop-apcd
remote: 
remote: - Cannot update this protected ref.
remote: 
remote: - Changes must be made through a pull request.
remote: 
To github.com:TACC/Core-CMS-Custom.git
 ! [remote rejected]   develop-apcd -> develop-apcd (push declined due to repository rule violations)
error: failed to push some refs to 'github.com:TACC/Core-CMS-Custom.git'
```
2. Need to check that the github user is setup correctly. DIdn't see an instance in Core-Portal or other repos that reference a Github user config
3. Need a way to test locally. Just got this PR as a place to start and discuss.


<!--
## Notes

…
-->
