### PR TITLE
task/WP-951-Removes sync job from develop-apcd branch on push

### DIFF
--- a/.github/workflows/apcd-cms.yml
+++ b/.github/workflows/apcd-cms.yml
@@ -36,8 +36,4 @@ jobs:
         with:
           context: apcd_cms
           push: true
-<<<<<<< Updated upstream
           tags: taccwma/apcd-cms:${{ steps.vars.outputs.SHORT_SHA }},taccwma/apcd-cms:${{ steps.vars.outputs.BRANCH_NAME }}
-=======
-          tags: taccwma/apcd-cms:${{ steps.vars.outputs.SHORT_SHA }},taccwma/apcd-cms:${{ steps.vars.outputs.BRANCH_NAME }}
->>>>>>> Stashed changes


### PR DESCRIPTION
## Overview
Removes broken sync job from APCD GitHub actions script. Moving to solution to put APCD custom code in new repo

## Related


- [WP-951](https://tacc-main.atlassian.net/browse/WP-951)


## Changes

…

## Testing

1.

## UI

…

<!--
## Notes

…
-->
