### PR TITLE
task/WP-951 Revert workflow to update develop-apcd to main (#486)

### DIFF
--- a/.github/workflows/apcd-cms.yml
+++ b/.github/workflows/apcd-cms.yml
@@ -5,7 +5,6 @@ on:
     branches: [main]
     paths:
       - "apcd_cms/**"
-permissions: write-all
 
 jobs:
   build_commit:
@@ -38,18 +37,3 @@ jobs:
           context: apcd_cms
           push: true
           tags: taccwma/apcd-cms:${{ steps.vars.outputs.SHORT_SHA }},taccwma/apcd-cms:${{ steps.vars.outputs.BRANCH_NAME }}
-  sync:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with: 
-          fetch-depth: 0
-
-      - name: Update develop-apcd Branch when changes to main are made
-        run: |
-          git checkout develop-apcd
-          git merge origin/main
-          git push origin develop-apcd
-
-


### PR DESCRIPTION
## Overview

This reverts commit 033f72dccfbe1bdeb253691591616d8eac524a33 - workflow to update develop-apcd to main (#486)

## Related

- [WP-951](https://tacc-main.atlassian.net/browse/WP-951)

## Changes

…

## Testing

1.

## UI

…

<!--
## Notes

…
-->
