### PR TITLE
feat: TUP-706 Scripts & Styles for LCCF News

### DIFF
--- a/lccf_assets/snippets/news-styles-scripts.html
+++ b/lccf_assets/snippets/news-styles-scripts.html
@@ -1,0 +1,27 @@
+{% load static %}
+<style id="news-styles-scripts--css">
+@import url("{% static "site_cms/css/build/app.blog.css" %}") layer(project);
+
+/* to hide "Back" link (which opens all TACC news) */
+.blog-back {
+    display: none;
+}
+
+/* to remove bottom border of last article if no pagination */
+.blog-list:not(
+    :has(.pagination)
+) article:last-of-type {
+    border-bottom: unset;
+}
+
+/* to hide the "— Lccf" in news list title */
+:is(.blog-list) h1 > strong::after, /* the "—" */
+:is(.blog-list) h1 > em /* the "Lccf" */ {
+    display: none;
+}
+</style>
+<script id="news-styles-scripts--js" type="module">
+import { changeHowExternalArticleOpens } from '{% static "site_cms/js/modules/manageExternalArticles.js" %}';
+
+changeHowExternalArticleOpens('external');
+</script>


### PR DESCRIPTION
## Overview

Save scripts and styles (from a snippet) for LCCF News (loaded from TACC).

## Related

- [TUP-706](https://tacc-main.atlassian.net/browse/TUP-706)
- supports https://github.com/TACC/Core-CMS/pull/868

## Changes

- **added** snippet

## Testing

### News Styles

1. Open https://pprd.lccf.tacc.utexas.edu/news/latest-news/ .
2. Verify news is styled like https://tacc.utexas.edu/news/latest-news/tag/lccf, except:
   - no "— Lccf" in title
   - no border underneath last article in list
   - no "Back" link at bottom of list

### TACC Article

1. Open https://pprd.lccf.tacc.utexas.edu/news/latest-news/ .
2. Scroll to any article (authored by CMD staff).
3. Click article title or image.
4. Verify article opens in **TACC** site in **new** tab.

### External Article

1. Open https://pprd.lccf.tacc.utexas.edu/news/latest-news/ .
2. Edit "Remote Content" block.
3. Change path to `/news/latest-news/?template=plain.html` .
4. Save.
6. Open https://pprd.lccf.tacc.utexas.edu/news/latest-news/?page=4&edit .
7. Scroll to any article by "TACC Communications".
8. Click article title or image.
9. Verify article opens in **non**-TACC site in **new** tab.

## UI

Skipped.