### PR TITLE
enhance(dpm): add new metrics-table class

### DIFF
--- a/digitalrocks_assets/css/browse-datasets.css
+++ b/digitalrocks_assets/css/browse-datasets.css
@@ -1,5 +1,5 @@
 @import url('https://cdn.jsdelivr.net/npm/@tacc/core-styles@2/dist/components/bootstrap.pagination.css');
 
 /* https://github.com/TACC/Core-CMS-Custom/pull/494 */
-@import url('https://cdn.jsdelivr.net/gh/TACC/Core-Portal@aef0da5/client/src/components/DataFiles/DataFilesForDPM/styles/components.global.css');
-@import url('https://cdn.jsdelivr.net/gh/TACC/Core-Portal@aef0da5/client/src/components/DataFiles/DataFilesForDPM/styles/customize-core-styles.global.css');
+@import url('https://cdn.jsdelivr.net/gh/TACC/Core-Portal@803bc8ad/client/src/components/DataFiles/DataFilesForDPM/styles/components.global.css');
+@import url('https://cdn.jsdelivr.net/gh/TACC/Core-Portal@803bc8ad/client/src/components/DataFiles/DataFilesForDPM/styles/customize-core-styles.global.css');

--- a/digitalrocks_assets/snippets/projects-000--citation-modal.html
+++ b/digitalrocks_assets/snippets/projects-000--citation-modal.html
@@ -10,7 +10,7 @@
       </div>
       <div class="modal-body">
         <div class="metrics-tableset">
-          <table>
+          <table class="metrics-table">
             <thead>
               <tr>
                 <th>Aggregated Usage</th>
@@ -49,7 +49,7 @@
               </tr>
             </tbody>
           </table>
-          <table>
+          <table class="metrics-table">
             <thead>
               <tr>
                 <th>


### PR DESCRIPTION
## Overview

To sync pre-prod CMS with https://github.com/TACC/Core-Portal/pull/1127.

## Related

- [WC-274](https://tacc-main.atlassian.net/browse/WC-274)

## Changes

- add `metrics-table` class
- load latest DPM styles from [TACC/Core-Portal#1127](https://github.com/TACC/Core-Portal/pull/1127)

## Testing

### `metrics-table`

1. Open
    - https://pprd.digitalrocks.tacc.utexas.edu/datasets/317/#files
    - https://pprd.digitalrocks.tacc.utexas.edu/datasets/218/#files
2. Click "Details" link in "Cite this Dataset".
3. Open
    - https://pprd.digitalrocks.tacc.utexas.edu/datasets/218/origin-data/826/
4. Verify [No Data] dropdown is to taller than "Quarter" text

## UI

**Skipped.**