### PR TITLE
fix: (bandaid) tapis styles not loading

### DIFF
--- a/tapisproject_assets/snippets/css-patch-missing-tapis-styles.html
+++ b/tapisproject_assets/snippets/css-patch-missing-tapis-styles.html
@@ -1,0 +1,1 @@
+<link id="css-patch-missing-tapis-styles" rel="stylesheet" href="https://cdn.jsdelivr.net/gh/TACC/Core-CMS-Custom@4d0ac2b/tapisproject_assets/migrate.to-core-cms-v3.css" />


### PR DESCRIPTION
## Overview

https://tapis-project.org/ not loading Tapis-specific styles, because the setting that would trigger that is not loaded into container.

<details><summary>Background</summary>

Occurs on [attempt to deploy new version without being able to test on staging site](https://github.com/TACC/Core-Portal-Deployments/commit/08c8828a).

</details>

## Related

- https://github.com/TACC/Core-Portal-Deployments/commit/08c8828a
- similar to https://github.com/TACC/Core-CMS-Custom/pull/499

## Changes

- **adds** snippet that loads missing styles

## Testing

1. Open https://tapis-project.org/training/.
2. See thin table border with brighter link color.
3. Other tests may be available but are not recorded.

## UI

| before | after |
| - | - |
| <img width="960" height="465" alt="before" src="https://github.com/user-attachments/assets/6a1b9859-ed2c-441d-a457-7e704843cd6c" /> | <img width="960" height="465" alt="after" src="https://github.com/user-attachments/assets/0da2b6fd-b39d-464a-a200-0458ae80faac" /> |