### PR TITLE
fix(wtcs): heading colors wrong

### DIFF
--- a/wtcs_assets/snippets/css-color-scheme.html
+++ b/wtcs_assets/snippets/css-color-scheme.html
@@ -1,6 +1,11 @@
 <style id="css-color-scheme">
 :root {
+    /* To change color of header and section headings */
+    /* !!!: Clashes with section bug fixes from Core-Styles */
+    /* !!!: Would cause a Dark Section (none used) to be orange */
+    /* WARNING: "primary" is a misnomer; it should have been named "neutral" */
     --global-color-primary--xx-dark: #bf5700;
+
     --global-color-accent--normal:#265e83;
     --global-color-accent--secondary: #265e83;
     --global-color-tertiary--normal: #aecb62;
@@ -15,4 +20,21 @@
 .s-header .nav-item.active .nav-link {
     --border-color: #aeca62;
 }
+
+/* To replicate buggy coloring that Core-Styles v2.42.0 fixed */
+/* FAQ: WTCS custom colors accidentally relied on Core-Styles bug */
+:is(
+    .o-section--style-light, .section--light,
+    .o-section--style-dark, .section--dark
+) :is(h1,h3,h4,h5,h6) {
+    color: inherit;
+}
+/* To replicate buggy coloring that Core-Styles v2.42.1 fixed */
+/* FAQ: WTCS custom colors accidentally relied on Core-Styles bug */
+:is(
+    .o-section--style-muted, .section--muted
+) :is(h2) {
+    color: var(--color--text-strong);
+}
+
 </style>


### PR DESCRIPTION
## Overview

Fix WeTeach_CS section headers wrong color since CMS update/deploy today.

## Related

- fixes clash with
    - https://github.com/TACC/Core-Styles/pull/492
    - https://github.com/TACC/Core-Styles/pull/495
- deployed via
    - [this config](https://github.com/TACC/Core-Portal-Deployments/commit/2f732ca)
    - [this action](https://jenkins.portals.tacc.utexas.edu/job/Core_Portal_Deploy/2290)

## Changes

- **fixed** WeTeach_CS color scheme **with bandaids**
- **documented** color scheme **flaws**

## Testing

1. Compare:

    | before | after | note |
    | - | - | - |
    | [Home (Archive)](https://web.archive.org/web/20250327141019/https://weteachcs.org/) | [Home (Production)](https://weteachcs.org/) |
    | [Courses (Archive)](https://web.archive.org/web/20250327141019/https://weteachcs.org/training-events/courses/) | [Courses (Production)](https://weteachcs.org/training-events/courses/) |
    | [Cert Prep (Archive)](https://web.archive.org/web/20250327134006/https://weteachcs.org/initiatives/teacher-certification-prep/) | [Cert Prep (Production)](https://weteachcs.org/initiatives/teacher-certification-prep/) | content slightly different |