### PR TITLE
fix(generic,cfde): core-styles bugs

### DIFF
--- a/cfde-cms/html/css-global-ad-hoc.html
+++ b/cfde-cms/html/css-global-ad-hoc.html
@@ -1,5 +1,5 @@
 {% load sekizai_tags %}
 {% addtoblock "css" %}
 {# Many <link>s is faster than one <link> with many '@import's. #}
-<link href="https://cdn.jsdelivr.net/gh/TACC/Core-CMS-Custom@<commit_hash>/generic_assets/css/core-styles-fixes.css" rel="stylesheet" />
+<link href="https://cdn.jsdelivr.net/gh/TACC/Core-CMS-Custom@fix/cfde-styles/generic_assets/css/core-styles-fixes.css" rel="stylesheet" />
 {% endaddtoblock %}

--- a/cfde-cms/html/css-global-ad-hoc.html
+++ b/cfde-cms/html/css-global-ad-hoc.html
@@ -1,0 +1,5 @@
+{% load sekizai_tags %}
+{% addtoblock "css" %}
+{# Many <link>s is faster than one <link> with many '@import's. #}
+<link href="https://cdn.jsdelivr.net/gh/TACC/Core-CMS-Custom@<commit_hash>/generic_assets/css/core-styles-fixes.css" rel="stylesheet" />
+{% endaddtoblock %}

--- a/generic_assets/css/core-styles-fixes.css
+++ b/generic_assets/css/core-styles-fixes.css
@@ -1,0 +1,14 @@
+/* TODO: Integrate into Core-Styles */
+/* to make space between list and heading match space between paragraph and heading */
+/* FAQ: added for coument pages, like original version of /about/ */
+:where(:is([role=main],main)) :is(dl,ol,ul,menu) {
+    margin-bottom: 2rem;
+}
+
+/* TODO: Integrate into Core-Styles */
+/* to remove extra space between breadcrumbs and section */
+.s-breadcrumbs + script + .o-section,
+/* FAQ: if in future, breadrcumb script is moved or absent */
+.s-breadcrumbs + .o-section {
+    margin-top: 0;
+}


### PR DESCRIPTION
## Overview

Add common Core-Styles bug fixes.

## Related

None

## Changes

- adds CFDE global ad-hoc styles snippet
- adds generic core-styles fixes stylesheet

## Testing

1. Open https://pprd.netsage.tacc.utexas.edu/.
    <sup>(Will later be https://pprd.cfde-cms.tacc.utexas.edu/.)</sup>
2. Verify space after a `<ul>` matches that after a `<p>`.

Tested on https://pprd.netsage.tacc.utexas.edu/ [^1] via [snippet #4](https://pprd.netsage.tacc.utexas.edu/admin/djangocms_snippet/snippet/4/change/).

[^1]: Will become https://cfde-cms.netsage.tacc.utexas.edu/.

## UI

<img width="960" height="506" alt="Screenshot 2025-10-02 at 16 29 54" src="https://github.com/user-attachments/assets/2e796414-9263-4154-88c7-de7826274712" />
