### PR TITLE
fix(ctrn): hide gap when article lacks image

### DIFF
--- a/ctrn_assets/snippets/css-news-page.html
+++ b/ctrn_assets/snippets/css-news-page.html
@@ -12,4 +12,12 @@
         "head attr"
         "subh tags";
 }
+/* To hide missing gap when article lacks visual */
+{# TODO: Update Core-CMS to use `:has` logic, then remove this #}
+.blog-list article:not(:has(.blog-visual > *)) {
+    grid-template-areas:
+        "head"
+        "desc";
+    column-gap: unset;
+}
 </style>


### PR DESCRIPTION
## Overview

Hide gap in news when article lacks image.

## Related

- **should instead** update TACC/Core-CMS to **not** assume media is present:
    - [in `grid-area`](https://github.com/TACC/Core-CMS/blob/v4.35.1/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.item.css#L60-L71)
    - [needing `column-gap`](https://github.com/TACC/Core-CMS/blob/v4.35.1/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.item.css#L47)

## Testing / UI

| before | after |
| - | - |
| <img width="960" height="535" alt="before" src="https://github.com/user-attachments/assets/8996ed52-e205-48ad-98b0-7f86f8c38439" /> | <img width="960" height="535" alt="after" src="https://github.com/user-attachments/assets/f30363f8-9073-480b-9e0f-fa90ff8970d5" /> |