### PR TITLE
feat(generic): hide-news-main-image.css

### DIFF
--- a/ctrn_assets/snippets/news-hide-article-main-image.html
+++ b/ctrn_assets/snippets/news-hide-article-main-image.html
@@ -1,6 +1,4 @@
 {% load sekizai_tags %}
 {% addtoblock "css" %}
-<style id="news-hide-article-main-image">
-article.post-detail .blog-visual { display: none }
-</style>
+<link href="https://cdn.jsdelivr.net/gh/TACC/Core-CMS-Custom@e7e4bf18/generic_assets/css/hide-news-main-image.css" rel="stylesheet" />
 {% endaddtoblock %}

--- a/ecep_assets/css/hide-article-main-image.css
+++ b/ecep_assets/css/hide-article-main-image.css
@@ -1,3 +1,0 @@
-/* https://github.com/TACC/Core-CMS/blob/v4.35.15/taccsite_cms/templates/snippets/news/hide-article-main-image.html */
-/* https://github.com/TACC/Core-CMS-Custom/blob/ce94648e/wtcs_assets/css/hide-article-main-image.css */
-article.post-detail .blog-visual { display: none }

--- a/ecep_assets/html/snippets/css-GLOBAL-ad-hoc.html
+++ b/ecep_assets/html/snippets/css-GLOBAL-ad-hoc.html
@@ -10,6 +10,7 @@ Many <link>s is faster than one <link> with many '@import's.
 <style>
     @import url("https://cdn.jsdelivr.net/gh/TACC/Core-Styles@v2.57.0-rc1/dist/elements/headings--cms.css") layer(base);
     @import url("https://cdn.jsdelivr.net/gh/TACC/Core-CMS-Custom@main/generic_assets/css/core-cms-fixes.css") layer(base);
+    @import url("https://cdn.jsdelivr.net/gh/TACC/Core-CMS-Custom@e7e4bf18/generic_assets/css/hide-news-main-image.css") layer(base);
 </style>
 
 {% with CDN_URL="https://cdn.jsdelivr.net/gh/TACC/Core-CMS-Custom@166ca8df/ecep_assets/css" %}
@@ -31,7 +32,6 @@ Many <link>s is faster than one <link> with many '@import's.
 <!-- Ad Hoc Styles: (COMPONENTS) News -->
 <link href="{{CDN_URL}}/adjust-news-feed-layout.css" rel="stylesheet" />
 <link href="{{CDN_URL}}/hide-news-byline.css" rel="stylesheet" />
-<link href="{{CDN_URL}}/hide-article-main-image.css" rel="stylesheet" />
 
 <!-- Ad Hoc Styles: (MISC.) Buttons & Links -->
 <link href="{{CDN_URL}}/bootstrap/btn-center.css" rel="stylesheet" />

--- a/generic_assets/css/hide-news-main-image.css
+++ b/generic_assets/css/hide-news-main-image.css
@@ -1,0 +1,7 @@
+/* Will be replaced by:
+   new TACC/Core-CMS setting `PORTAL_BLOG_SHOW_MAIN_IMAGE`
+*/
+/* Originally came from:
+   https://github.com/TACC/Core-CMS/blob/v4.35.15/taccsite_cms/templates/snippets/news/hide-article-main-image.html
+*/
+article.post-detail .blog-visual { display: none }

--- a/wtcs_assets/css/hide-article-main-image.css
+++ b/wtcs_assets/css/hide-article-main-image.css
@@ -1,3 +1,0 @@
-/* https://github.com/TACC/Core-CMS/blob/v4.35.15/taccsite_cms/templates/snippets/news/hide-article-main-image.html */
-/* https://github.com/TACC/Core-CMS-Custom/blob/ce94648e/ecep_assets/css/hide-article-main-image.css */
-article.post-detail .blog-visual { display: none }

--- a/wtcs_assets/snippets/css-ad-hoc.html
+++ b/wtcs_assets/snippets/css-ad-hoc.html
@@ -6,6 +6,6 @@ Many <link>s is faster than one <link> with many '@import's.
 
 {% addtoblock "css" %}
 <link href="https://cdn.jsdelivr.net/gh/TACC/Core-CMS-Custom@3ecf278a/wtcs_assets/css/captions.css" rel="stylesheet" />
-<link href="https://cdn.jsdelivr.net/gh/TACC/Core-CMS-Custom@3ecf278a/wtcs_assets/css/hide-article-main-image.css" rel="stylesheet" />
+<link href="https://cdn.jsdelivr.net/gh/TACC/Core-CMS-Custom@e7e4bf18/generic_assets/css/hide-news-main-image.css" rel="stylesheet" />
 <link href="https://cdn.jsdelivr.net/gh/TACC/Core-Styles@v2/dist/components/c-island.css" rel="stylesheet" />
 {% endaddtoblock %}


### PR DESCRIPTION
## Overview

Consolidate instances of CSS to hide news articles' main image.

## Related

- (2026-Q2) giving CFDE a News feed
- to be replaced by https://github.com/TACC/Core-CMS/pull/1154

## Changes

- **added** one stylesheet for the job
- **deleted** stylesheets now defunct
- **updated** references

## Testing

1. On CTRN, verify **some** `.blog-visual`s are hidden.
2. On ECEP, verify **all** `.blog-visual`s are hidden.
3. On WTCS, verify **all** `.blog-visual`s are hidden.

## UI

| Site | Hidden | Visible |
| - | - | - |
| CTRN | <img width="900" height="470" alt="ctrn hidden" src="https://github.com/user-attachments/assets/edaff3f3-1298-45da-9edc-0d473eae0430" /> | <img width="900" height="470" alt="ctrn visible" src="https://github.com/user-attachments/assets/a983ead2-1a19-47af-9dd2-8901ad209c9b" /> |
| ECEP | <img width="900" height="470" alt="ecep" src="https://github.com/user-attachments/assets/3dd93c8f-57a3-4cb4-af08-d8e862591a3d" /> | always hidden, cuz loaded globally |
| WTCS | <img width="900" height="470" alt="wtcs" src="https://github.com/user-attachments/assets/56bd6824-1e74-44a2-9074-6732fda71a0d" /> | always hidden, cuz loaded globally |

