### PR TITLE
fix(ptdatax): new tab link on Portal requires CMS nav ready

### DIFF
--- a/ptdatax_assets/js/open-certain-links-in-new-tab.js
+++ b/ptdatax_assets/js/open-certain-links-in-new-tab.js
@@ -1,9 +1,26 @@
 import findLinksAndSetTargets from 'https://cdn.jsdelivr.net/gh/TACC/Core-CMS@v4.40.0-rc3/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js';
 
-const links = document.querySelectorAll(
+const NAV_READY_ATTR  = 'navReady';
+const NAV_READY_EVENT = 'cms-nav:ready';
+
+function initLinks() {
+  const links = document.querySelectorAll(
     'a[href*="/core/internal-docs/"]'
-);
-findLinksAndSetTargets( links, {
+  );
+  findLinksAndSetTargets(links, {
     shouldDebug: false,
     shouldFilter: false,
-});
+  });
+}
+
+const container = document.getElementById('s-cms-nav');
+
+if (!container) {
+  // Plain CMS page — no Portal nav injection
+  initLinks();
+} else if (container.dataset[NAV_READY_ATTR] === 'true') {
+  // Nav already populated before this script ran
+  initLinks();
+} else {
+  container.addEventListener(NAV_READY_EVENT, initLinks, { once: true });
+}

--- a/ptdatax_assets/snippets/js-global-ad-hoc.html
+++ b/ptdatax_assets/snippets/js-global-ad-hoc.html
@@ -1,5 +1,5 @@
 {% load sekizai_tags %}
-{% with local_commit="main" %}
+{% with local_commit="5b760ba" %}{# TACC/Core-CMS-Custom#538 #}
 
 {% addtoblock "js" %}
 {# One <script> to load script that 'import's many is faster than many <script>s. #}


### PR DESCRIPTION
## Overview

Wrap `findLinksAndSetTargets`, and defer until CMS nav signals it is ready.

_`open-certain-links-in-new-tab.js` was calling `findLinksAndSetTargets` immediately at load time. On Portal pages the CMS nav is injected asynchronously, so the target links don't exist yet._

[WP-1230]: https://tacc-main.atlassian.net/browse/WP-1230

## Related

- **supports client-side solution for [WP-1230]**
- **server-side alternative: https://github.com/TACC/Core-CMS/pull/1151**
- requires https://github.com/TACC/Core-Portal/pull/1304

## Changes

- **refactored** link query and `findLinksAndSetTargets` call into `initLinks` function

## Testing

1. **On CMS page**: Confirm `internal-docs` links **still** open in a new tab.
2. **On Portal**: Confirm `internal-docs` links **newly** open in a new tab.

## UI

https://github.com/user-attachments/assets/96879167-070d-4b63-84e0-bfe5a6295542

https://github.com/user-attachments/assets/36309943-33d7-4272-928c-d623ae2efa7f

---

Made with [Cursor](https://cursor.com)