### PR TITLE
feat(generic): data-aria-* attrs → aria-* attrs

### DIFF
--- a/generic_assets/js/promote-data-aria-attributes.js
+++ b/generic_assets/js/promote-data-aria-attributes.js
@@ -1,0 +1,33 @@
+/**
+ * Copy `data-aria-*` attributes to matching `aria-*` on the same nodes.
+ * For HTML saved through WYSIWYG editors that strip unprefixed ARIA on publish.
+ *
+ * @param {ParentNode | null | undefined} [root=document]
+ */
+export default function promoteDataAriaAttributes(root = document) {
+  if (!root) {
+    return;
+  }
+
+  const elements =
+    root instanceof Document
+      ? root.querySelectorAll('*')
+      : root instanceof Element
+        ? [ root, ...root.querySelectorAll('*') ]
+        : [];
+
+  for (const el of elements) {
+    if (!(el instanceof Element)) {
+      continue;
+    }
+    for (const attr of [ ...el.attributes ]) {
+      if (!attr.name.startsWith('data-aria-')) {
+        continue;
+      }
+      el.setAttribute(
+        'aria-' + attr.name.slice('data-aria-'.length),
+        attr.value
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Overview

ES module for Core CMS WYSIWYG HTML that copies `data-aria-*` to `aria-*` on a scope root before other scripts run.

## Related

- moves https://github.com/TACC/Core-Styles/pull/645
- supports testing https://github.com/TACC/tup-ui/pull/558

## Changes

- **added** `generic_assets/js/promote-data-aria-attributes.js`

## Testing

1. After merge, import from jsDelivr on this repo (pin commit hash).
2. Confirm sortable table / ARIA behavior still works per https://github.com/TACC/tup-ui/pull/558.

## UI

Skipped.